### PR TITLE
Enhance CI with dynamic versioning and macOS build support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,8 +32,9 @@ jobs:
         run: |
           VERSION=$(date +'%Y.%-m.%-d')
           if [ "${GITHUB_REF_NAME}" != "main" ]; then
-            # Sanitize branch name: replace all non-alphanumeric with hyphens for SemVer compliance
-            BRANCH_LABEL=$(echo ${GITHUB_REF_NAME} | sed 's/[^a-zA-Z0-9]/-/g' | tr '[:upper:]' '[:lower:]')
+            # Sanitize branch name: replace all non-alphanumeric with hyphens
+            # Squirrel for Windows limits the 'special version' part to 20 characters.
+            BRANCH_LABEL=$(echo ${GITHUB_REF_NAME} | sed 's/[^a-zA-Z0-9]/-/g' | tr '[:upper:]' '[:lower:]' | cut -c 1-20 | sed 's/-*$//')
             VERSION="${VERSION}-${BRANCH_LABEL}"
           fi
           echo "Setting version to: $VERSION"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: Build Windows App
 on:
   push:
     branches:
-      - main
+      - '**'
 
 jobs:
   build:
@@ -26,6 +26,18 @@ jobs:
 
       - name: Install Dependencies
         run: npm ci
+
+      - name: Set Version
+        shell: bash
+        run: |
+          VERSION=$(date +'%Y.%-m.%-d')
+          if [ "${GITHUB_REF_NAME}" != "main" ]; then
+            # Sanitize branch name: allow alpha and hyphens, others become underscores
+            BRANCH_LABEL=$(echo ${GITHUB_REF_NAME} | sed 's/[^a-zA-Z0-9-]/_/g' | tr '[:upper:]' '[:lower:]')
+            VERSION="${VERSION}-${BRANCH_LABEL}"
+          fi
+          echo "Setting version to: $VERSION"
+          npm version $VERSION --no-git-tag-version
 
       - name: Build Electron App
         run: npm run make

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         os:
           - windows-latest
-          # - macos-latest  # Need to set up secrets first
+          - macos-latest
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,8 +32,8 @@ jobs:
         run: |
           VERSION=$(date +'%Y.%-m.%-d')
           if [ "${GITHUB_REF_NAME}" != "main" ]; then
-            # Sanitize branch name: allow alpha and hyphens, others become underscores
-            BRANCH_LABEL=$(echo ${GITHUB_REF_NAME} | sed 's/[^a-zA-Z0-9-]/_/g' | tr '[:upper:]' '[:lower:]')
+            # Sanitize branch name: replace all non-alphanumeric with hyphens for SemVer compliance
+            BRANCH_LABEL=$(echo ${GITHUB_REF_NAME} | sed 's/[^a-zA-Z0-9]/-/g' | tr '[:upper:]' '[:lower:]')
             VERSION="${VERSION}-${BRANCH_LABEL}"
           fi
           echo "Setting version to: $VERSION"


### PR DESCRIPTION
This PR updates the CI workflow to implement a dynamic, date-based versioning scheme for the application and expands our build matrix to include macOS.

## Key Changes:

- **Dynamic Versioning**: Replaced the static version in `package.json` with a dynamic version calculated at build time.
  - **Format**: yyyy.m.d (e.g., `2026.4.6`).
  - **Pre-release Labels**: For builds from branches other than main, the branch name is appended as a suffix (e.g., `2026.4.6-feature-dynamic-vers`).
- **Compatibility & Sanitization**:
  - **SemVer Compliance**: Branch names are sanitized to replace all non-alphanumeric characters with hyphens to satisfy `npm version` and SemVer 2.0.0 requirements.
  - **Squirrel for Windows**: Truncated the branch suffix to 20 characters to stay within the limits imposed by Squirrel for Windows' "special version" part.
- **Multi-Platform CI**:
  - Enabled `macos-latest` in the GitHub Actions matrix.
  - Artifacts for both Windows and macOS will now be generated on every push to any branch.

## Verification:
- Pushed to `feature/dynamic-version` and verified that:
  1. The version was correctly set to `2026.4.6-feature-dynamic-vers`.
  2. Both Windows and macOS build jobs were triggered and successfully completed.