### PR TITLE
Branding

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.ico filter=lfs diff=lfs merge=lfs -text
+*.icns filter=lfs diff=lfs merge=lfs -text

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 *.ico filter=lfs diff=lfs merge=lfs -text
 *.icns filter=lfs diff=lfs merge=lfs -text
+*.png filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
+        with:
+          lfs: true
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="assets/logo-full.png" alt="Stitch Logo" width="600" />
+</p>
+
 # Stitch
 
 An Electron-based desktop application for DevOps workflows, built with React and

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
   <img src="assets/logo-full.png" alt="Stitch Logo" width="600" />
 </p>
 
-# Stitch
-
 An Electron-based desktop application for DevOps workflows, built with React and
 TypeScript using Electron Forge.
 

--- a/assets/icon.icns
+++ b/assets/icon.icns
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:408cbbdd8928aa95c195c5c964dee8213eb5716db4fae1c14c14ace7c13c7a5a
+size 1524570

--- a/assets/icon.ico
+++ b/assets/icon.ico
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8fe074ec3ec525e41d8110c1423bcf754b93e286fe4fd2339f22f17eef1d15f8
+size 152844

--- a/assets/logo-full.png
+++ b/assets/logo-full.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:110cea4062662c0b6a9862c5ef23c02f766612737f95f3771e590d228302ea9e
+size 1025445

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -18,10 +18,13 @@ import { rendererConfig } from './webpack.renderer.config';
 const config: ForgeConfig = {
   packagerConfig: {
     asar: true,
+    icon: './assets/icon'
   },
   rebuildConfig: {},
   makers: [
-    new MakerSquirrel({}),
+    new MakerSquirrel({
+      setupIcon: './assets/icon.ico',
+    }),
     new MakerZIP({}, ['darwin']),
     new MakerRpm({}),
     new MakerDeb({}),

--- a/src/renderer/images.d.ts
+++ b/src/renderer/images.d.ts
@@ -1,0 +1,5 @@
+declare module '*.png';
+declare module '*.jpg';
+declare module '*.jpeg';
+declare module '*.svg';
+declare module '*.gif';

--- a/src/renderer/pages/Menu.tsx
+++ b/src/renderer/pages/Menu.tsx
@@ -1,16 +1,26 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import logo from '../../../assets/logo-full.png';
 
 const Menu: React.FC = () => {
   return (
-    <div className="container mt-5">
-      <div className="d-flex justify-content-between align-items-center mb-4">
-        <div></div>
+    <div className="container mt-4 position-relative">
+      <div className="position-absolute top-0 end-0">
         <Link to="/settings" className="btn btn-outline-secondary">
           <i className="fas fa-cog me-2"></i>
           Settings
         </Link>
       </div>
+
+      <div className="text-center mb-5 mt-2">
+        <img 
+          src={logo} 
+          alt="Stitch Logo" 
+          className="img-fluid" 
+          style={{ maxHeight: '240px' }} 
+        />
+      </div>
+
       <div className="row justify-content-center">
         <div className="col-md-4 mb-4">
           <div className="card shadow-sm h-100">


### PR DESCRIPTION
Closes #22 

* Adds Git LFS support, configured for `ico`, `icns` and `png`
  * Adds Git LFS to the GitHub Action so builds continue to work
* Packaged icons based on the sizes Electron wants for Windows and Mac, and configured for use
* Packaged a bigger logo, with the icon and app name, and updated the main menu to display it
* Also updated the README with the logo