### PR TITLE
feat: add issues button to titlebar with platform-specific positioning

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain } from 'electron';
+import { app, BrowserWindow, ipcMain, shell } from 'electron';
 import { AzureDevOpsService } from './services/azureDevOpsService';
 import { CopilotService } from './services/copilotService';
 import { ConfluenceService } from './services/confluenceService';
@@ -51,6 +51,10 @@ ipcMain.handle('get-settings', async () => {
 
 ipcMain.handle('get-version', async () => {
   return app.getVersion();
+});
+
+ipcMain.handle('open-external', async (event, url: string) => {
+  return shell.openExternal(url);
 });
 
 function trimProperties(

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -40,4 +40,6 @@ contextBridge.exposeInMainWorld('electronAPI', {
   checkCopilotAuth: () => ipcRenderer.invoke('check-copilot-auth'),
   getVersion: () => ipcRenderer.invoke('get-version'),
   listCopilotModels: () => ipcRenderer.invoke('list-copilot-models'),
+  openExternal: (url: string) => ipcRenderer.invoke('open-external', url),
+  isWindows: process.platform === 'win32',
 });

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -20,13 +20,31 @@ const App: React.FC = () => {
     fetchVersion();
   }, []);
 
+  const handleOpenIssues = (e: React.MouseEvent) => {
+    e.preventDefault();
+    (window as any).electronAPI.openExternal(
+      'https://github.com/thealternator89/stitch/issues',
+    );
+  };
+
+  const isWindows = (window as any).electronAPI.isWindows;
+
   return (
     <Router>
-      <div className="titlebar shadow-sm">
+      <div className={`titlebar shadow-sm ${isWindows ? 'is-windows' : ''}`}>
         <span className="titlebar-content">
           <i className="fas fa-code-merge me-2 text-primary"></i>
           Stitch
         </span>
+        <div className="titlebar-actions no-drag">
+          <button
+            className="btn btn-outline-light btn-sm titlebar-btn"
+            onClick={handleOpenIssues}
+            title="Report an Issue"
+          >
+            <i className="fas fa-bug"></i>
+          </button>
+        </div>
       </div>
 
       <div className="main-content">

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -9,7 +9,10 @@ body {
 }
 
 /* Allow selection in inputs, textareas and generated content */
-input, textarea, .markdown-content, .selectable-text {
+input,
+textarea,
+.markdown-content,
+.selectable-text {
   user-select: text;
 }
 
@@ -31,11 +34,37 @@ input, textarea, .markdown-content, .selectable-text {
   font-weight: 600;
   user-select: none;
   flex-shrink: 0;
+  position: relative; /* For absolute positioning of actions */
 }
 
 /* For Windows/macOS title bar buttons if they're overlaid */
 .titlebar-content {
   pointer-events: none;
+}
+
+.titlebar-actions {
+  position: absolute;
+  right: 10px;
+  display: flex;
+  align-items: center;
+  height: 100%;
+}
+
+/* Compensate for Windows title bar overlay buttons (min/max/close) */
+.titlebar.is-windows .titlebar-actions {
+  right: 140px;
+}
+
+.titlebar-btn {
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.titlebar-btn:focus {
+  outline: none;
+  box-shadow: none;
 }
 
 .no-drag {
@@ -67,7 +96,9 @@ input, textarea, .markdown-content, .selectable-text {
   line-height: 1.6;
 }
 
-.markdown-content h1, .markdown-content h2, .markdown-content h3 {
+.markdown-content h1,
+.markdown-content h2,
+.markdown-content h3 {
   border-bottom: 1px solid #dee2e6;
   padding-bottom: 0.2rem;
   margin-top: 1.5rem;
@@ -86,7 +117,8 @@ input, textarea, .markdown-content, .selectable-text {
   margin: 1rem 0;
 }
 
-.markdown-content table th, .markdown-content table td {
+.markdown-content table th,
+.markdown-content table td {
   border: 1px solid #dee2e6;
   padding: 0.5rem;
 }


### PR DESCRIPTION
Resolves #27 

Adds a "Report an Issue" button to the right side of the titlebar (compensating for the window controls on Windows)

The button opens the default browser to the repo's GitHub issues page.