### PR TITLE
chore: tweak windows titlebar UX

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -171,7 +171,7 @@ const createWindow = (): void => {
     titleBarOverlay:
       process.platform === 'win32'
         ? {
-            color: '#212529',
+            color: '#133865',
             symbolColor: '#ffffff',
             height: 44,
           }

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -52,7 +52,7 @@ textarea,
 
 /* Compensate for Windows title bar overlay buttons (min/max/close) */
 .titlebar.is-windows .titlebar-actions {
-  right: 140px;
+  right: 150px;
 }
 
 .titlebar-btn {


### PR DESCRIPTION
Use the same background color for window buttons as the titlebar background
Add an extra 10px between the window buttons and the 'create issue' button