### PR TITLE
chore: group react packages in dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,9 @@ updates:
         patterns:
           - "eslint*"
           - "@typescript-eslint/*"
+      react-packages:
+        patterns:
+          - "react*"
     ignore:
       - dependency-name: "eslint"
         versions: [">= 10.0.0"]


### PR DESCRIPTION
Resolve an issue with react-dom and react having mismatched versions, causing the UI to fail to load