### PR TITLE
ci: optimize GitHub Actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,6 +50,7 @@ jobs:
           npm version $VERSION --no-git-tag-version
 
       - name: Build Electron App
+        if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.publish == true) }}
         run: npm run make
 
       - name: Publish Electron App
@@ -62,4 +63,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: build-artifacts-${{ matrix.os }}
-          path: out/make/**/*
+          path: |
+            out/make/**/*
+            !out/make/**/*.nupkg
+            !out/make/**/RELEASES


### PR DESCRIPTION
This PR tidies up a couple of minor issues with the Github Action;

1. On a publish, we were building twice. This reduces this to one build
2. On adhoc and branch builds we were pulling the exe, nupkg and RELEASES files into the zip. That's twice the size as necessary so we exclude the nupkg and RELEASES as these are only needed for publishing