### PR TITLE
Prompt customisation

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -55,17 +55,22 @@ ipcMain.handle('open-external', async (event, url: string) => {
   return shell.openExternal(url);
 });
 
-function trimProperties(
-  obj: Record<string, string | undefined>,
-): Record<string, string | undefined> {
-  const out: Record<string, string> = {};
-  for (const key in obj) {
-    if (Object.prototype.hasOwnProperty.call(obj, key)) {
-      out[key] = obj[key]?.toString().trim();
+/* eslint-disable @typescript-eslint/no-explicit-any */
+function trimProperties(obj: any): any {
+  if (obj === null || obj === undefined) return obj;
+  if (typeof obj === 'string') return obj.trim();
+  if (typeof obj === 'object') {
+    const out: any = Array.isArray(obj) ? [] : {};
+    for (const key in obj) {
+      if (Object.prototype.hasOwnProperty.call(obj, key)) {
+        out[key] = trimProperties(obj[key]);
+      }
     }
+    return out;
   }
-  return out;
+  return obj;
 }
+/* eslint-enable @typescript-eslint/no-explicit-any */
 
 ipcMain.handle('save-settings', async (event, settings: AppSettings) => {
   const s = await initStore();
@@ -76,7 +81,7 @@ ipcMain.handle('save-settings', async (event, settings: AppSettings) => {
   s.set('settings', sanitizedSettings);
 
   copilotService.setModel(sanitizedSettings.copilotModel || 'gpt-4.1');
-  copilotService.clearCache();
+  copilotService.clearCache(sanitizedSettings.copilotToken);
 
   // Apply theme immediately
   const theme = sanitizedSettings.theme ?? 'auto';
@@ -116,10 +121,13 @@ ipcMain.handle('search-tickets', async (event, query) => {
 ipcMain.handle(
   'generate-test-cases',
   async (event, ticketData, additionalContext, modelOverride) => {
+    const s = await initStore();
+    const settings = (s.get('settings') ?? {}) as AppSettings;
     return copilotService.generateTestCases(
       ticketData,
       additionalContext,
       modelOverride,
+      settings,
       (line: string) => {
         event.sender.send('test-case-line', line);
       },
@@ -160,10 +168,13 @@ ipcMain.handle('search-confluence-pages', async (event, query) => {
 ipcMain.handle(
   'generate-stories',
   async (event, pageData, additionalContext, modelOverride) => {
+    const s = await initStore();
+    const settings = (s.get('settings') ?? {}) as AppSettings;
     return copilotService.generateStories(
       pageData,
       additionalContext,
       modelOverride,
+      settings,
       (line: string) => {
         event.sender.send('story-line', line);
       },
@@ -172,11 +183,15 @@ ipcMain.handle(
 );
 
 ipcMain.handle('check-copilot-auth', async () => {
-  return copilotService.checkAuthStatus();
+  const s = await initStore();
+  const settings = (s.get('settings') ?? {}) as AppSettings;
+  return copilotService.checkAuthStatus(settings.copilotToken);
 });
 
 ipcMain.handle('list-copilot-models', async () => {
-  return copilotService.listModels();
+  const s = await initStore();
+  const settings = (s.get('settings') ?? {}) as AppSettings;
+  return copilotService.listModels(settings.copilotToken);
 });
 
 ipcMain.handle('add-comment', async (event, ticketId, text) => {
@@ -226,7 +241,7 @@ app.on('ready', async () => {
   nativeTheme.themeSource = theme === 'auto' ? 'system' : theme;
 
   copilotService.setModel(settings.copilotModel || 'gpt-4.1');
-  copilotService.initializeAsync().catch((err) => {
+  copilotService.initializeAsync(settings.copilotToken).catch((err) => {
     console.error('Failed to initialize copilotService on startup:', err);
   });
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -194,6 +194,12 @@ ipcMain.handle('list-copilot-models', async () => {
   return copilotService.listModels(settings.copilotToken);
 });
 
+ipcMain.handle('check-prompt-complexity', async (event, type, prompts) => {
+  const s = await initStore();
+  const settings = (s.get('settings') ?? {}) as AppSettings;
+  return copilotService.checkPromptComplexity(type, prompts, settings);
+});
+
 ipcMain.handle('add-comment', async (event, ticketId, text) => {
   const service = await getAzureService();
   return service.addComment(ticketId, text);

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -49,5 +49,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
   getVersion: () => ipcRenderer.invoke('get-version'),
   listCopilotModels: () => ipcRenderer.invoke('list-copilot-models'),
   openExternal: (url: string) => ipcRenderer.invoke('open-external', url),
+  checkPromptComplexity: (
+    type: 'story' | 'testcase',
+    prompts: Record<string, string>,
+  ) => ipcRenderer.invoke('check-prompt-complexity', type, prompts),
   isWindows: process.platform === 'win32',
 });

--- a/src/main/services/copilotService.ts
+++ b/src/main/services/copilotService.ts
@@ -1,6 +1,6 @@
 // Since we dynamically import the SDK, we need to use any - disable eslint rule
 /* eslint-disable @typescript-eslint/no-explicit-any */
-async function createCopilotClient() {
+async function createCopilotClient(copilotToken?: string) {
   // Eval to avoid webpack interfering with the import
   const { CopilotClient, approveAll } = await eval(
     'import("@github/copilot-sdk")',
@@ -17,6 +17,13 @@ async function createCopilotClient() {
   // with new Copilot CLI/SDK releases on Windows. If the standard platform-agnostic approach
   // starts working, the entire Windows workaround block below should be removed.
   const disableEnvVal = process.env.DISABLE_COPILOT_WINDOWS_WORKAROUND || '';
+  const env = copilotToken
+    ? {
+        ...process.env,
+        GITHUB_TOKEN: copilotToken,
+        COPILOT_TOKEN: copilotToken,
+      }
+    : undefined;
 
   if (process.platform === 'win32' && !['1', 'true'].includes(disableEnvVal)) {
     if (!process.env.NODE_PATH || !process.env.COPILOT_SCRIPT_PATH) {
@@ -29,15 +36,21 @@ async function createCopilotClient() {
         cliPath: process.env.NODE_PATH,
         cliArgs: [process.env.COPILOT_SCRIPT_PATH],
         useStdio: true,
+        env,
       }),
       approveAll,
     };
   }
 
-  return { client: new CopilotClient(), approveAll };
+  return { client: new CopilotClient({ env }), approveAll };
 }
 
-import { TicketData, DocPageData, CopilotModel } from '../../types';
+import {
+  TicketData,
+  DocPageData,
+  CopilotModel,
+  AppSettings,
+} from '../../types';
 
 export class CopilotService {
   private model = 'gpt-4.1';
@@ -49,9 +62,9 @@ export class CopilotService {
     }
   }
 
-  async initializeAsync(): Promise<void> {
+  async initializeAsync(copilotToken?: string): Promise<void> {
     try {
-      await this.fetchAndCacheModels();
+      await this.fetchAndCacheModels(copilotToken);
     } catch (error: any) {
       console.warn(
         'Could not pre-fetch Copilot models on startup:',
@@ -60,8 +73,10 @@ export class CopilotService {
     }
   }
 
-  private async fetchAndCacheModels(): Promise<CopilotModel[]> {
-    const { client } = await createCopilotClient();
+  private async fetchAndCacheModels(
+    copilotToken?: string,
+  ): Promise<CopilotModel[]> {
+    const { client } = await createCopilotClient(copilotToken);
     try {
       await client.start();
       const models = await client.listModels();
@@ -82,8 +97,8 @@ export class CopilotService {
     }
   }
 
-  async checkAuthStatus() {
-    const { client } = await createCopilotClient();
+  async checkAuthStatus(copilotToken?: string) {
+    const { client } = await createCopilotClient(copilotToken);
     try {
       await client.start();
       const authStatus = await client.getAuthStatus();
@@ -119,16 +134,16 @@ export class CopilotService {
     }
   }
 
-  async listModels(): Promise<CopilotModel[]> {
+  async listModels(copilotToken?: string): Promise<CopilotModel[]> {
     if (this.cachedModels.length > 0) {
       return this.cachedModels;
     }
-    return this.fetchAndCacheModels();
+    return this.fetchAndCacheModels(copilotToken);
   }
 
-  clearCache() {
+  clearCache(copilotToken?: string) {
     this.cachedModels = [];
-    this.initializeAsync().catch((err) => {
+    this.initializeAsync(copilotToken).catch((err) => {
       console.error(
         'Failed to re-initialize copilotService after settings update:',
         err,
@@ -225,9 +240,12 @@ export class CopilotService {
     ticketData: TicketData,
     additionalContext: string,
     modelOverride: string,
+    settings: AppSettings,
     onLine?: (line: string) => void,
   ) {
-    const { client, approveAll } = await createCopilotClient();
+    const { client, approveAll } = await createCopilotClient(
+      settings.copilotToken,
+    );
     let session: any = null;
     try {
       await client.start();
@@ -238,9 +256,24 @@ export class CopilotService {
         streaming: true,
       });
 
+      const testCaseWriter = settings.prompts?.testCaseWriter || {};
+      const generalPrompt = testCaseWriter.general || '';
+
+      const idPrompt = testCaseWriter.id || 'Test Case ID (e.g., "TC01")';
+      const descriptionPrompt =
+        testCaseWriter.description || 'Brief description of the test scenario';
+      const preConditionsPrompt =
+        testCaseWriter.preConditions ||
+        'Any preconditions required before running the test';
+      const stepsPrompt =
+        testCaseWriter.steps ||
+        'Bullet-pointed or numbered steps to execute the test';
+      const expectedResultPrompt =
+        testCaseWriter.expectedResult || 'The expected result';
+
       const prompt = `
         Generate a set of comprehensive test cases for the following user story/ticket.
-        
+        ${generalPrompt ? `\n        ${generalPrompt}\n` : ''}
         Ticket ID: ${ticketData.id}
         Title: ${ticketData.title}
         Description: ${ticketData.description}
@@ -252,11 +285,11 @@ export class CopilotService {
         Do NOT wrap the JSON objects inside a JSON array. Each line MUST be a standalone JSON object.
         
         Each JSON object must have exactly the following keys:
-        - "id": (string) Test Case ID (e.g., "TC01")
-        - "description": (string) Brief description of the test scenario
-        - "preConditions": (string) Any preconditions required before running the test
-        - "steps": (string) Bullet-pointed or numbered steps to execute the test
-        - "expectedResult": (string) The expected result
+        - "id": (string) ${idPrompt}
+        - "description": (string) ${descriptionPrompt}
+        - "preConditions": (string) ${preConditionsPrompt}
+        - "steps": (string) ${stepsPrompt}
+        - "expectedResult": (string) ${expectedResultPrompt}
         - "priority": (string) Priority of the test (e.g., "High", "Medium", "Low")
 
         DO NOT create any files, directly output the test cases in your response here.
@@ -293,9 +326,12 @@ export class CopilotService {
     pageData: DocPageData,
     additionalContext: string,
     modelOverride: string,
+    settings: AppSettings,
     onLine?: (line: string) => void,
   ): Promise<string> {
-    const { client, approveAll } = await createCopilotClient();
+    const { client, approveAll } = await createCopilotClient(
+      settings.copilotToken,
+    );
     let session: any = null;
     try {
       await client.start();
@@ -306,9 +342,22 @@ export class CopilotService {
         streaming: true,
       });
 
+      const storyWriter = settings.prompts?.storyWriter || {};
+      const generalPrompt = storyWriter.general || '';
+
+      const titlePrompt = storyWriter.title || 'The title of the story';
+      const descriptionPrompt =
+        storyWriter.description ||
+        'Description. This should contain a statement in the format "As a... I want to... So that..." followed by 2 blank lines and then a longer description of the changes required for story.';
+      const acceptanceCriteriaPrompt =
+        storyWriter.acceptanceCriteria || 'Formatted as a markdown list.';
+      const notesPrompt =
+        storyWriter.notes ||
+        'Any additional notes or assumptions (Optional, can be empty)';
+
       const prompt = `
         Generate a set of user stories based on the following functional requirements from a Confluence page.
-        
+        ${generalPrompt ? `\n        ${generalPrompt}\n` : ''}
         Page Title: ${pageData.title}
         Page Content: ${pageData.body}
         
@@ -318,11 +367,12 @@ export class CopilotService {
         Do NOT wrap the JSON objects inside a JSON array. Each line MUST be a standalone JSON object.
         
         Each JSON object must have exactly the following keys:
-        - "title": (string) The title of the story
-        - "description": (string) Description. This should contain a statement in the format "As a... I want to... So that..." followed by 2 blank lines and then a longer description of the changes required for story.
-        - "acceptanceCriteria": (string) Formatted as a markdown list. Use standard formatting without embedded newlines or with escaped newlines inside the JSON string as needed.
-        - "notes": (string) Any additional notes or assumptions (Optional, can be empty)
+        - "title": (string) ${titlePrompt}
+        - "description": (string) ${descriptionPrompt}
+        - "acceptanceCriteria": (string) ${acceptanceCriteriaPrompt}
+        - "notes": (string) ${notesPrompt}
 
+        For any fields containing markdown, use standard formatting without embedded newlines or with escaped newlines inside the JSON string as needed.
         DO NOT create any files, directly output the user stories in your response here.
         DO NOT include any other text in your response (no explanation, no intro, no outro, no markdown fences).
       `;

--- a/src/main/services/copilotService.ts
+++ b/src/main/services/copilotService.ts
@@ -256,45 +256,14 @@ export class CopilotService {
         streaming: true,
       });
 
-      const testCaseWriter = settings.prompts?.testCaseWriter || {};
-      const generalPrompt = testCaseWriter.general || '';
-
-      const idPrompt = testCaseWriter.id || 'Test Case ID (e.g., "TC01")';
-      const descriptionPrompt =
-        testCaseWriter.description || 'Brief description of the test scenario';
-      const preConditionsPrompt =
-        testCaseWriter.preConditions ||
-        'Any preconditions required before running the test';
-      const stepsPrompt =
-        testCaseWriter.steps ||
-        'Bullet-pointed or numbered steps to execute the test';
-      const expectedResultPrompt =
-        testCaseWriter.expectedResult || 'The expected result';
-
-      const prompt = `
-        Generate a set of comprehensive test cases for the following user story/ticket.
-        ${generalPrompt ? `\n        ${generalPrompt}\n` : ''}
-        Ticket ID: ${ticketData.id}
-        Title: ${ticketData.title}
-        Description: ${ticketData.description}
-        Acceptance Criteria: ${ticketData.acceptanceCriteria || 'N/A'}
-        
-        Additional Context: ${additionalContext || 'None provided'}
-        
-        Please format the output as JSON Lines (JSONL), where each line is a valid JSON object.
-        Do NOT wrap the JSON objects inside a JSON array. Each line MUST be a standalone JSON object.
-        
-        Each JSON object must have exactly the following keys:
-        - "id": (string) ${idPrompt}
-        - "description": (string) ${descriptionPrompt}
-        - "preConditions": (string) ${preConditionsPrompt}
-        - "steps": (string) ${stepsPrompt}
-        - "expectedResult": (string) ${expectedResultPrompt}
-        - "priority": (string) Priority of the test (e.g., "High", "Medium", "Low")
-
-        DO NOT create any files, directly output the test cases in your response here.
-        DO NOT include any other text in your response (no explanation, no intro, no outro, no markdown fences).
-      `;
+      const prompt = buildTestCasePrompt(
+        ticketData.id || '',
+        ticketData.title,
+        ticketData.description,
+        ticketData.acceptanceCriteria || '',
+        additionalContext,
+        settings,
+      );
 
       const responseContent = await this.sendAndCollectStream(
         session,
@@ -342,40 +311,12 @@ export class CopilotService {
         streaming: true,
       });
 
-      const storyWriter = settings.prompts?.storyWriter || {};
-      const generalPrompt = storyWriter.general || '';
-
-      const titlePrompt = storyWriter.title || 'The title of the story';
-      const descriptionPrompt =
-        storyWriter.description ||
-        'Description. This should contain a statement in the format "As a... I want to... So that..." followed by 2 blank lines and then a longer description of the changes required for story.';
-      const acceptanceCriteriaPrompt =
-        storyWriter.acceptanceCriteria || 'Formatted as a markdown list.';
-      const notesPrompt =
-        storyWriter.notes ||
-        'Any additional notes or assumptions (Optional, can be empty)';
-
-      const prompt = `
-        Generate a set of user stories based on the following functional requirements from a Confluence page.
-        ${generalPrompt ? `\n        ${generalPrompt}\n` : ''}
-        Page Title: ${pageData.title}
-        Page Content: ${pageData.body}
-        
-        Additional Context: ${additionalContext || 'None provided'}
-        
-        Please format the output as JSON Lines (JSONL), where each line is a valid JSON object.
-        Do NOT wrap the JSON objects inside a JSON array. Each line MUST be a standalone JSON object.
-        
-        Each JSON object must have exactly the following keys:
-        - "title": (string) ${titlePrompt}
-        - "description": (string) ${descriptionPrompt}
-        - "acceptanceCriteria": (string) ${acceptanceCriteriaPrompt}
-        - "notes": (string) ${notesPrompt}
-
-        For any fields containing markdown, use standard formatting without embedded newlines or with escaped newlines inside the JSON string as needed.
-        DO NOT create any files, directly output the user stories in your response here.
-        DO NOT include any other text in your response (no explanation, no intro, no outro, no markdown fences).
-      `;
+      const prompt = buildStoryPrompt(
+        pageData.title,
+        pageData.body,
+        additionalContext,
+        settings,
+      );
 
       const responseContent = await this.sendAndCollectStream(
         session,
@@ -403,7 +344,202 @@ export class CopilotService {
     }
   }
 
+  async checkPromptComplexity(
+    type: 'story' | 'testcase',
+    prompts: any,
+    settings: AppSettings,
+    modelOverride?: string,
+  ): Promise<string> {
+    const { client, approveAll } = await createCopilotClient(
+      settings.copilotToken,
+    );
+    let session: any = null;
+    try {
+      await client.start();
+      session = await client.createSession({
+        model: modelOverride || this.model,
+        availableTools: [],
+        onPermissionRequest: approveAll,
+        streaming: false,
+      });
+
+      let promptToCheck = '';
+      if (type === 'story') {
+        promptToCheck = buildStoryPrompt(
+          '[Page Title Placeholder]',
+          '[Page Content Placeholder]',
+          '[Additional Context Placeholder]',
+          { prompts: { storyWriter: prompts } },
+        );
+      } else {
+        promptToCheck = buildTestCasePrompt(
+          '[Ticket ID Placeholder]',
+          '[Title Placeholder]',
+          '[Description Placeholder]',
+          '[Acceptance Criteria Placeholder]',
+          '[Additional Context Placeholder]',
+          { prompts: { testCaseWriter: prompts } },
+        );
+      }
+
+      const metaPrompt = `
+You are an expert AI prompt engineer and validator.
+Review the following prompt template which is intended to guide an AI to generate JSON Lines (JSONL) output.
+Is there anything in the instructions or fields that is likely to confuse you (or any other LLM) or cause you to violate the requirement to produce valid JSONL?
+Specifically check if any of the custom descriptions might encourage code blocks, markdown fences, unescaped double quotes, or raw newlines inside JSON properties.
+
+Avoid being unnecessarily pessimistic. If the prompt is sufficiently clear DO NOT invent potential issues.
+
+Explain any issues detected clearly and suggest action-oriented improvements, or respond with a confirmation that the prompt template looks perfectly safe and compliant. Keep your response brief, clear, and formatted nicely as markdown.
+
+PROMPT TEMPLATE TO REVIEW:
+"""
+${promptToCheck.trim()}
+"""
+      `;
+
+      const responseContent = await this.sendAndCollectStream(
+        session,
+        metaPrompt,
+        undefined,
+        180000,
+      );
+      return responseContent;
+    } catch (error) {
+      console.error('Error checking prompt complexity:', error);
+      throw error;
+    } finally {
+      if (session) {
+        try {
+          await session.destroy();
+        } catch (e) {
+          console.error(
+            'Error destroying session in checkPromptComplexity:',
+            e,
+          );
+        }
+      }
+      try {
+        await client.stop();
+      } catch (e) {
+        console.error('Error stopping client in checkPromptComplexity:', e);
+      }
+    }
+  }
+
   async cleanup() {
     // Connections are now short-lived and cleaned up automatically after each session.
   }
+}
+
+export function buildStoryPrompt(
+  pageTitle: string,
+  pageContent: string,
+  additionalContext: string,
+  settings: AppSettings,
+): string {
+  const storyWriter = settings.prompts?.storyWriter || {};
+  const generalPrompt = storyWriter.general || '';
+
+  const titlePrompt = storyWriter.title || 'The title of the story';
+  const descriptionPrompt =
+    storyWriter.description ||
+    'Description. This should contain a statement in the format "As a... I want to... So that..." followed by 2 blank lines and then a longer description of the changes required for story.';
+  const acceptanceCriteriaPrompt =
+    storyWriter.acceptanceCriteria || 'Formatted as a markdown list.';
+  const notesPrompt =
+    storyWriter.notes ||
+    'Any additional notes or assumptions (Optional, can be empty)';
+
+  return `
+        Generate a set of user stories based on the following functional requirements from a Confluence page.
+        ${generalPrompt ? `\n        ${generalPrompt}\n` : ''}
+        Page Title: ${pageTitle}
+        Page Content: ${pageContent}
+        
+        Additional Context: ${additionalContext || 'None provided'}
+        
+        Please format the output as JSON Lines (JSONL), where each line is a valid JSON object.
+        Do NOT wrap the JSON objects inside a JSON array. Each line MUST be a standalone JSON object.
+
+        Do NOT use markdown code blocks, fences, or any formatting other than plain JSON objects. All newlines within string values must be represented as \`\\n\` (double backslash-n), not as actual newlines.
+        
+        Each JSON object must have exactly the following keys:
+        - "title": (string) ${titlePrompt}
+        - "description": (string) ${descriptionPrompt}
+        - "acceptanceCriteria": (string) ${acceptanceCriteriaPrompt}
+        - "notes": (string) ${notesPrompt}
+
+        For any fields containing markdown, these MUST be formatted and escaped for JSON.
+
+        For example:
+        {"title": "Title text", "description": "First line\\\\n\\\\nSecond line", "acceptanceCriteria": "* AC 1\\\\n* AC 2\\\\n* AC 3", "notes": "First line\\\\nSecond Line\\\\nThird Line"}
+        
+        All double quotes inside string values must be escaped as \\".
+        Do not use markdown formatting or syntax; only plain text is allowed.
+        Do not use actual newlines inside string values; use \\n instead.
+        Bullet points or numbers should be plain text only (e.g., "1. Step one\\n2. Step two").
+
+        DO NOT create any files, directly output the user stories in your response here.
+        DO NOT include any other text in your response (no explanation, no intro, no outro, no markdown fences).
+  `;
+}
+
+export function buildTestCasePrompt(
+  ticketId: string,
+  ticketTitle: string,
+  ticketDescription: string,
+  ticketAcceptanceCriteria: string,
+  additionalContext: string,
+  settings: AppSettings,
+): string {
+  const testCaseWriter = settings.prompts?.testCaseWriter || {};
+  const generalPrompt = testCaseWriter.general || '';
+
+  const idPrompt = testCaseWriter.id || 'Test Case ID (e.g., "TC01")';
+  const descriptionPrompt =
+    testCaseWriter.description || 'Brief description of the test scenario';
+  const preConditionsPrompt =
+    testCaseWriter.preConditions ||
+    'Any preconditions required before running the test';
+  const stepsPrompt =
+    testCaseWriter.steps ||
+    'Bullet-pointed or numbered steps to execute the test';
+  const expectedResultPrompt =
+    testCaseWriter.expectedResult || 'The expected result';
+
+  return `
+        Generate a set of comprehensive test cases for the following user story/ticket.
+        ${generalPrompt ? `\n        ${generalPrompt}\n` : ''}
+        Ticket ID: ${ticketId}
+        Title: ${ticketTitle}
+        Description: ${ticketDescription}
+        Acceptance Criteria: ${ticketAcceptanceCriteria || 'N/A'}
+        
+        Additional Context: ${additionalContext || 'None provided'}
+        
+        Please format the output as JSON Lines (JSONL), where each line is a valid JSON object.
+        Do NOT wrap the JSON objects inside a JSON array. Each line MUST be a standalone JSON object.
+
+        Do NOT use markdown code blocks, fences, or any formatting other than plain JSON objects. All newlines within string values must be represented as \`\\n\` (double backslash-n), not as actual newlines.
+        
+        Each JSON object must have exactly the following keys:
+        - "id": (string) ${idPrompt}
+        - "description": (string) ${descriptionPrompt}
+        - "preConditions": (string) ${preConditionsPrompt}
+        - "steps": (string) ${stepsPrompt}
+        - "expectedResult": (string) ${expectedResultPrompt}
+        - "priority": (string) Priority of the test (e.g., "High", "Medium", "Low")
+
+        For example:
+        {"id": "", "description": "It works", "preConditions": "* One\\\\n* Two\\\\n* Three", "steps": "1. Step 1\\\\n2. Step 2\\\\n3. Step 3", "expectedResult": "Nothing", "priority": "High"}
+
+        All double quotes inside string values must be escaped as \\".
+        Do not use markdown formatting or syntax; only plain text is allowed.
+        Do not use actual newlines inside string values; use \\n instead.
+        Bullet points or numbers should be plain text only (e.g., "1. Step one\\\\n2. Step two").
+
+        DO NOT create any files, directly output the test cases in your response here.
+        DO NOT include any other text in your response (no explanation, no intro, no outro, no markdown fences).
+  `;
 }

--- a/src/renderer/components/settings/AzureSettings.tsx
+++ b/src/renderer/components/settings/AzureSettings.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+
+interface AzureSettingsProps {
+  azureOrg: string;
+  setAzureOrg: (val: string) => void;
+  azureProject: string;
+  setAzureProject: (val: string) => void;
+  azurePat: string;
+  setAzurePat: (val: string) => void;
+}
+
+const AzureSettings: React.FC<AzureSettingsProps> = ({
+  azureOrg,
+  setAzureOrg,
+  azureProject,
+  setAzureProject,
+  azurePat,
+  setAzurePat,
+}) => {
+  return (
+    <div className="card shadow-sm border-0 bg-body-tertiary">
+      <div className="card-body p-4">
+        <h5 className="mb-4 border-bottom pb-2">
+          <i className="fab fa-microsoft me-2 text-primary"></i>Azure DevOps
+          Configuration
+        </h5>
+
+        <p className="text-muted small mb-4">
+          Configure connection details to fetch and sync work items, user
+          stories, and tasks directly with your Azure DevOps instance.
+        </p>
+
+        <div className="mb-3">
+          <label className="form-label fw-semibold">Organization URL</label>
+          <input
+            type="text"
+            className="form-control"
+            placeholder="https://dev.azure.com/your-org"
+            value={azureOrg}
+            onChange={(e) => setAzureOrg(e.target.value)}
+          />
+          <div className="form-text">
+            The base URL for your Azure DevOps organization (e.g.
+            `https://dev.azure.com/myorganization`).
+          </div>
+        </div>
+
+        <div className="mb-3">
+          <label className="form-label fw-semibold">Project Name</label>
+          <input
+            type="text"
+            className="form-control"
+            placeholder="YourProject"
+            value={azureProject}
+            onChange={(e) => setAzureProject(e.target.value)}
+          />
+          <div className="form-text">
+            The target project where work items reside.
+          </div>
+        </div>
+
+        <div className="mb-3">
+          <label className="form-label fw-semibold">
+            Personal Access Token (PAT)
+          </label>
+          <input
+            type="password"
+            className="form-control"
+            value={azurePat}
+            onChange={(e) => setAzurePat(e.target.value)}
+            placeholder="••••••••••••••••••••••••••••••••••••••••••••"
+          />
+          <div className="form-text">
+            Ensure your PAT has read and write access scope for work items.
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AzureSettings;

--- a/src/renderer/components/settings/ConfluenceSettings.tsx
+++ b/src/renderer/components/settings/ConfluenceSettings.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+
+interface ConfluenceSettingsProps {
+  confluenceUrl: string;
+  setConfluenceUrl: (val: string) => void;
+  confluenceUser: string;
+  setConfluenceUser: (val: string) => void;
+  confluenceToken: string;
+  setConfluenceToken: (val: string) => void;
+}
+
+const ConfluenceSettings: React.FC<ConfluenceSettingsProps> = ({
+  confluenceUrl,
+  setConfluenceUrl,
+  confluenceUser,
+  setConfluenceUser,
+  confluenceToken,
+  setConfluenceToken,
+}) => {
+  return (
+    <div className="card shadow-sm border-0 bg-body-tertiary">
+      <div className="card-body p-4">
+        <h5 className="mb-4 border-bottom pb-2">
+          <i className="fas fa-book me-2 text-primary"></i>Confluence
+          Configuration
+        </h5>
+
+        <p className="text-muted small mb-4">
+          Connect to Confluence to retrieve product requirements documents
+          (PRDs), specifications, and other documentation pages to generate user
+          stories.
+        </p>
+
+        <div className="mb-3">
+          <label className="form-label fw-semibold">Confluence URL</label>
+          <input
+            type="text"
+            className="form-control"
+            placeholder="https://your-domain.atlassian.net/wiki"
+            value={confluenceUrl}
+            onChange={(e) => setConfluenceUrl(e.target.value)}
+          />
+          <div className="form-text">
+            Base URL of your Atlassian Cloud or Server Confluence site.
+          </div>
+        </div>
+
+        <div className="mb-3">
+          <label className="form-label fw-semibold">
+            Email / User (Optional)
+          </label>
+          <input
+            type="text"
+            className="form-control"
+            placeholder="user@example.com"
+            value={confluenceUser}
+            onChange={(e) => setConfluenceUser(e.target.value)}
+          />
+          <div className="form-text">
+            Leave blank if using a Personal Access Token (Bearer Auth). Enter
+            email if using an Atlassian API Token (Basic Auth).
+          </div>
+        </div>
+
+        <div className="mb-3">
+          <label className="form-label fw-semibold">API Token / PAT</label>
+          <input
+            type="password"
+            className="form-control"
+            value={confluenceToken}
+            onChange={(e) => setConfluenceToken(e.target.value)}
+            placeholder="••••••••••••••••••••••••••••••••••••••••••••"
+          />
+          <div className="form-text">
+            Your personal API token or Personal Access Token (PAT).
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ConfluenceSettings;

--- a/src/renderer/components/settings/CopilotSettings.tsx
+++ b/src/renderer/components/settings/CopilotSettings.tsx
@@ -1,0 +1,146 @@
+import React from 'react';
+import ModelDropdown from '../ModelDropdown';
+import { CopilotAuth, CopilotModel } from '../../../types';
+
+interface CopilotSettingsProps {
+  copilotToken: string;
+  setCopilotToken: (val: string) => void;
+  models: CopilotModel[];
+  selectedModel: string;
+  setSelectedModel: (val: string) => void;
+  loadingModels: boolean;
+  authStatus: CopilotAuth | null;
+  checkingAuth: boolean;
+  handleCheckAuth: () => void;
+}
+
+const CopilotSettings: React.FC<CopilotSettingsProps> = ({
+  copilotToken,
+  setCopilotToken,
+  models,
+  selectedModel,
+  setSelectedModel,
+  loadingModels,
+  authStatus,
+  checkingAuth,
+  handleCheckAuth,
+}) => {
+  return (
+    <div className="card shadow-sm border-0 bg-body-tertiary">
+      <div className="card-body p-4">
+        <h5 className="mb-4 border-bottom pb-2">
+          <i className="fas fa-robot me-2 text-primary"></i>GitHub Copilot
+          Configuration
+        </h5>
+
+        <p className="text-muted small mb-4">
+          Configure integration with GitHub Copilot API to enable automated test
+          case and story writing.
+        </p>
+
+        <div className="mb-3">
+          <label className="form-label fw-semibold">Copilot API Token</label>
+          <input
+            type="password"
+            className="form-control"
+            value={copilotToken}
+            onChange={(e) => setCopilotToken(e.target.value)}
+            placeholder="••••••••••••••••••••••••••••••••••••••••••••"
+          />
+          <div className="form-text">
+            Your Copilot session or API token for authentication.
+          </div>
+        </div>
+
+        <div className="mb-4">
+          <label className="form-label fw-semibold">Default Model</label>
+          <ModelDropdown
+            models={models}
+            selectedModel={selectedModel}
+            onSelect={setSelectedModel}
+            loading={loadingModels}
+            className="w-50"
+            buttonVariant="outline-secondary"
+          />
+          <div className="form-text mt-1">
+            Choose the language model used by Copilot for text generation tasks.
+          </div>
+        </div>
+
+        <div className="mb-2 p-3 rounded border bg-body">
+          <div className="d-flex justify-content-between align-items-center mb-2">
+            <div>
+              <h6 className="mb-0 fw-semibold">Copilot CLI Status</h6>
+              <div className="text-muted small">
+                Verify local Copilot agent connectivity status.
+              </div>
+            </div>
+            <button
+              type="button"
+              className="btn btn-outline-info btn-sm d-flex align-items-center gap-2"
+              onClick={handleCheckAuth}
+              disabled={checkingAuth}
+            >
+              {checkingAuth ? (
+                <>
+                  <span
+                    className="spinner-border spinner-border-sm"
+                    role="status"
+                    aria-hidden="true"
+                  ></span>
+                  Checking...
+                </>
+              ) : (
+                <>
+                  <i className="fas fa-sync-alt"></i>Check Status
+                </>
+              )}
+            </button>
+          </div>
+
+          {authStatus && (
+            <div
+              className={`alert mt-3 mb-0 border-0 ${authStatus.error || !authStatus.authStatus?.isAuthenticated ? 'alert-danger bg-danger-subtle' : 'alert-success bg-success-subtle'}`}
+            >
+              {authStatus.error ? (
+                <div>
+                  <strong>Error:</strong> {authStatus.error}
+                </div>
+              ) : (
+                <div className="small">
+                  <div>
+                    <strong>Authenticated:</strong>{' '}
+                    {authStatus.authStatus?.isAuthenticated ? 'Yes' : 'No'}
+                  </div>
+                  {authStatus.authStatus?.isAuthenticated && (
+                    <>
+                      <div>
+                        <strong>User:</strong> {authStatus.authStatus?.login}
+                      </div>
+                      <div>
+                        <strong>Auth Type:</strong>{' '}
+                        {authStatus.authStatus?.authType}
+                      </div>
+                      <div>
+                        <strong>Message:</strong>{' '}
+                        {authStatus.authStatus?.statusMessage}
+                      </div>
+                      {authStatus.status && (
+                        <div className="mt-2 text-muted small border-top pt-2">
+                          CLI Version: {authStatus.status.version} (Protocol v
+                          {authStatus.status.protocolVersion})
+                        </div>
+                      )}
+                    </>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CopilotSettings;

--- a/src/renderer/components/settings/GeneralSettings.tsx
+++ b/src/renderer/components/settings/GeneralSettings.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+
+interface GeneralSettingsProps {
+  theme: 'auto' | 'light' | 'dark';
+  setTheme: (theme: 'auto' | 'light' | 'dark') => void;
+}
+
+const GeneralSettings: React.FC<GeneralSettingsProps> = ({
+  theme,
+  setTheme,
+}) => {
+  return (
+    <div className="card shadow-sm border-0 bg-body-tertiary">
+      <div className="card-body p-4">
+        <h5 className="mb-4 border-bottom pb-2">
+          <i className="fas fa-palette me-2 text-primary"></i>Appearance
+          Settings
+        </h5>
+
+        <div className="mb-4">
+          <label className="form-label d-block fw-semibold text-muted small uppercase tracking-wider mb-3">
+            Interface Theme
+          </label>
+          <p className="text-muted small mb-3">
+            Choose how Stitch appears. Selecting "Auto" will sync with your
+            macOS system theme settings.
+          </p>
+          <div className="btn-group" role="group" aria-label="Theme selection">
+            <button
+              type="button"
+              className={`btn px-4 py-2 d-flex align-items-center gap-2 ${theme === 'auto' ? 'btn-primary' : 'btn-outline-secondary'}`}
+              onClick={() => setTheme('auto')}
+            >
+              <i className="fas fa-circle-half-stroke"></i>
+              Auto
+            </button>
+            <button
+              type="button"
+              className={`btn px-4 py-2 d-flex align-items-center gap-2 ${theme === 'light' ? 'btn-primary' : 'btn-outline-secondary'}`}
+              onClick={() => setTheme('light')}
+            >
+              <i className="fas fa-sun"></i>
+              Light
+            </button>
+            <button
+              type="button"
+              className={`btn px-4 py-2 d-flex align-items-center gap-2 ${theme === 'dark' ? 'btn-primary' : 'btn-outline-secondary'}`}
+              onClick={() => setTheme('dark')}
+            >
+              <i className="fas fa-moon"></i>
+              Dark
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default GeneralSettings;

--- a/src/renderer/components/settings/PromptSettings.tsx
+++ b/src/renderer/components/settings/PromptSettings.tsx
@@ -1,4 +1,6 @@
 import React, { useState } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 
 interface PromptSettingsProps {
   storyGeneral: string;
@@ -53,6 +55,15 @@ const PromptSettings: React.FC<PromptSettingsProps> = ({
 }) => {
   const [subTab, setSubTab] = useState<'story' | 'testcase'>('story');
 
+  // Local state for checking prompt complexity
+  const [checkingStory, setCheckingStory] = useState(false);
+  const [storyResult, setStoryResult] = useState<string | null>(null);
+  const [storyError, setStoryError] = useState<string | null>(null);
+
+  const [checkingTestCase, setCheckingTestCase] = useState(false);
+  const [testCaseResult, setTestCaseResult] = useState<string | null>(null);
+  const [testCaseError, setTestCaseError] = useState<string | null>(null);
+
   const handleResetStoryDefaults = () => {
     setStoryGeneral('');
     setStoryTitle('');
@@ -70,6 +81,56 @@ const PromptSettings: React.FC<PromptSettingsProps> = ({
     setTestCaseExpectedResult('');
   };
 
+  const handleCheckStory = async () => {
+    setCheckingStory(true);
+    setStoryResult(null);
+    setStoryError(null);
+    try {
+      const response = await window.electronAPI.checkPromptComplexity('story', {
+        general: storyGeneral,
+        title: storyTitle,
+        description: storyDescription,
+        acceptanceCriteria: storyAcceptanceCriteria,
+        notes: storyNotes,
+      });
+      setStoryResult(response);
+    } catch (err) {
+      const errorMsg = err instanceof Error ? err.message : String(err);
+      setStoryError(
+        errorMsg || 'An error occurred while validating the prompt.',
+      );
+    } finally {
+      setCheckingStory(false);
+    }
+  };
+
+  const handleCheckTestCase = async () => {
+    setCheckingTestCase(true);
+    setTestCaseResult(null);
+    setTestCaseError(null);
+    try {
+      const response = await window.electronAPI.checkPromptComplexity(
+        'testcase',
+        {
+          general: testCaseGeneral,
+          id: testCaseId,
+          description: testCaseDescription,
+          preConditions: testCasePreConditions,
+          steps: testCaseSteps,
+          expectedResult: testCaseExpectedResult,
+        },
+      );
+      setTestCaseResult(response);
+    } catch (err) {
+      const errorMsg = err instanceof Error ? err.message : String(err);
+      setTestCaseError(
+        errorMsg || 'An error occurred while validating the prompt.',
+      );
+    } finally {
+      setCheckingTestCase(false);
+    }
+  };
+
   return (
     <div className="card shadow-sm border-0 bg-body-tertiary">
       <div className="card-header bg-transparent border-0 pt-4 px-4 pb-0">
@@ -78,23 +139,72 @@ const PromptSettings: React.FC<PromptSettingsProps> = ({
             <i className="fas fa-wand-magic-sparkles me-2 text-primary"></i>
             Prompt Customization
           </h5>
-          {subTab === 'story' ? (
-            <button
-              type="button"
-              className="btn btn-outline-secondary btn-sm"
-              onClick={handleResetStoryDefaults}
-            >
-              <i className="fas fa-undo me-2"></i>Reset Story Defaults
-            </button>
-          ) : (
-            <button
-              type="button"
-              className="btn btn-outline-secondary btn-sm"
-              onClick={handleResetTestCaseDefaults}
-            >
-              <i className="fas fa-undo me-2"></i>Reset Test Case Defaults
-            </button>
-          )}
+
+          <div className="d-flex gap-2">
+            {subTab === 'story' ? (
+              <>
+                <button
+                  type="button"
+                  className="btn btn-outline-info btn-sm d-flex align-items-center gap-2"
+                  onClick={handleCheckStory}
+                  disabled={checkingStory}
+                >
+                  {checkingStory ? (
+                    <>
+                      <span
+                        className="spinner-border spinner-border-sm"
+                        role="status"
+                        aria-hidden="true"
+                      ></span>
+                      Checking...
+                    </>
+                  ) : (
+                    <>
+                      <i className="fas fa-shield-halved"></i>Check Prompt
+                    </>
+                  )}
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-outline-secondary btn-sm"
+                  onClick={handleResetStoryDefaults}
+                >
+                  <i className="fas fa-undo me-2"></i>Reset Defaults
+                </button>
+              </>
+            ) : (
+              <>
+                <button
+                  type="button"
+                  className="btn btn-outline-info btn-sm d-flex align-items-center gap-2"
+                  onClick={handleCheckTestCase}
+                  disabled={checkingTestCase}
+                >
+                  {checkingTestCase ? (
+                    <>
+                      <span
+                        className="spinner-border spinner-border-sm"
+                        role="status"
+                        aria-hidden="true"
+                      ></span>
+                      Checking...
+                    </>
+                  ) : (
+                    <>
+                      <i className="fas fa-shield-halved"></i>Check Prompt
+                    </>
+                  )}
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-outline-secondary btn-sm"
+                  onClick={handleResetTestCaseDefaults}
+                >
+                  <i className="fas fa-undo me-2"></i>Reset Defaults
+                </button>
+              </>
+            )}
+          </div>
         </div>
 
         <ul className="nav nav-tabs border-bottom">
@@ -123,8 +233,8 @@ const PromptSettings: React.FC<PromptSettingsProps> = ({
         {subTab === 'story' && (
           <div key="story-writer-panel" className="settings-content p-0">
             <p className="text-muted small mb-4">
-              Customize the guidelines and instructions used when generating
-              user stories.
+              Customize the functional guidelines and instructions sent to
+              Copilot when drafting user stories.
             </p>
 
             <div className="mb-4">
@@ -132,7 +242,7 @@ const PromptSettings: React.FC<PromptSettingsProps> = ({
                 General Instructions
               </label>
               <textarea
-                className="form-control"
+                className="form-control text-start"
                 rows={3}
                 value={storyGeneral}
                 onChange={(e) => setStoryGeneral(e.target.value)}
@@ -205,6 +315,27 @@ const PromptSettings: React.FC<PromptSettingsProps> = ({
                 Instruct what extra warnings, assumptions, or notes to include.
               </div>
             </div>
+
+            {storyResult && (
+              <div className="card border-info bg-info-subtle mt-4">
+                <div className="card-header bg-transparent border-0 pt-3 pb-0 fw-semibold text-info-emphasis d-flex align-items-center gap-2">
+                  <i className="fas fa-magnifying-glass-chart"></i>Prompt
+                  Analysis Feedback
+                </div>
+                <div className="card-body markdown-content p-3">
+                  <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                    {storyResult}
+                  </ReactMarkdown>
+                </div>
+              </div>
+            )}
+
+            {storyError && (
+              <div className="alert alert-danger mt-4 d-flex align-items-start gap-2 border-0 bg-danger-subtle text-danger-emphasis">
+                <i className="fas fa-triangle-exclamation mt-1"></i>
+                <div>{storyError}</div>
+              </div>
+            )}
           </div>
         )}
 
@@ -325,6 +456,27 @@ const PromptSettings: React.FC<PromptSettingsProps> = ({
                 cannot be customized.
               </div>
             </div>
+
+            {testCaseResult && (
+              <div className="card border-info bg-info-subtle mt-4">
+                <div className="card-header bg-transparent border-0 pt-3 pb-0 fw-semibold text-info-emphasis d-flex align-items-center gap-2">
+                  <i className="fas fa-magnifying-glass-chart"></i>Prompt
+                  Analysis Feedback
+                </div>
+                <div className="card-body markdown-content p-3">
+                  <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                    {testCaseResult}
+                  </ReactMarkdown>
+                </div>
+              </div>
+            )}
+
+            {testCaseError && (
+              <div className="alert alert-danger mt-4 d-flex align-items-start gap-2 border-0 bg-danger-subtle text-danger-emphasis">
+                <i className="fas fa-triangle-exclamation mt-1"></i>
+                <div>{testCaseError}</div>
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/src/renderer/components/settings/PromptSettings.tsx
+++ b/src/renderer/components/settings/PromptSettings.tsx
@@ -1,64 +1,332 @@
-import React from 'react';
+import React, { useState } from 'react';
 
-const PromptSettings: React.FC = () => {
+interface PromptSettingsProps {
+  storyGeneral: string;
+  setStoryGeneral: (val: string) => void;
+  storyTitle: string;
+  setStoryTitle: (val: string) => void;
+  storyDescription: string;
+  setStoryDescription: (val: string) => void;
+  storyAcceptanceCriteria: string;
+  setStoryAcceptanceCriteria: (val: string) => void;
+  storyNotes: string;
+  setStoryNotes: (val: string) => void;
+
+  testCaseGeneral: string;
+  setTestCaseGeneral: (val: string) => void;
+  testCaseId: string;
+  setTestCaseId: (val: string) => void;
+  testCaseDescription: string;
+  setTestCaseDescription: (val: string) => void;
+  testCasePreConditions: string;
+  setTestCasePreConditions: (val: string) => void;
+  testCaseSteps: string;
+  setTestCaseSteps: (val: string) => void;
+  testCaseExpectedResult: string;
+  setTestCaseExpectedResult: (val: string) => void;
+}
+
+const PromptSettings: React.FC<PromptSettingsProps> = ({
+  storyGeneral,
+  setStoryGeneral,
+  storyTitle,
+  setStoryTitle,
+  storyDescription,
+  setStoryDescription,
+  storyAcceptanceCriteria,
+  setStoryAcceptanceCriteria,
+  storyNotes,
+  setStoryNotes,
+
+  testCaseGeneral,
+  setTestCaseGeneral,
+  testCaseId,
+  setTestCaseId,
+  testCaseDescription,
+  setTestCaseDescription,
+  testCasePreConditions,
+  setTestCasePreConditions,
+  testCaseSteps,
+  setTestCaseSteps,
+  testCaseExpectedResult,
+  setTestCaseExpectedResult,
+}) => {
+  const [subTab, setSubTab] = useState<'story' | 'testcase'>('story');
+
+  const handleResetStoryDefaults = () => {
+    setStoryGeneral('');
+    setStoryTitle('');
+    setStoryDescription('');
+    setStoryAcceptanceCriteria('');
+    setStoryNotes('');
+  };
+
+  const handleResetTestCaseDefaults = () => {
+    setTestCaseGeneral('');
+    setTestCaseId('');
+    setTestCaseDescription('');
+    setTestCasePreConditions('');
+    setTestCaseSteps('');
+    setTestCaseExpectedResult('');
+  };
+
   return (
     <div className="card shadow-sm border-0 bg-body-tertiary">
-      <div className="card-body p-4">
-        <h5 className="mb-4 border-bottom pb-2">
-          <i className="fas fa-wand-magic-sparkles me-2 text-primary"></i>Prompt
-          Customization
-        </h5>
+      <div className="card-header bg-transparent border-0 pt-4 px-4 pb-0">
+        <div className="d-flex justify-content-between align-items-center mb-3">
+          <h5 className="mb-0 fw-semibold">
+            <i className="fas fa-wand-magic-sparkles me-2 text-primary"></i>
+            Prompt Customization
+          </h5>
+          {subTab === 'story' ? (
+            <button
+              type="button"
+              className="btn btn-outline-secondary btn-sm"
+              onClick={handleResetStoryDefaults}
+            >
+              <i className="fas fa-undo me-2"></i>Reset Story Defaults
+            </button>
+          ) : (
+            <button
+              type="button"
+              className="btn btn-outline-secondary btn-sm"
+              onClick={handleResetTestCaseDefaults}
+            >
+              <i className="fas fa-undo me-2"></i>Reset Test Case Defaults
+            </button>
+          )}
+        </div>
 
-        <p className="text-muted small mb-4">
-          Customize the AI prompts, templates, and instruction guidelines used
-          to generate your user stories and test cases.
-        </p>
+        <ul className="nav nav-tabs border-bottom">
+          <li className="nav-item">
+            <button
+              type="button"
+              className={`nav-link px-4 py-2 border-0 ${subTab === 'story' ? 'active border-bottom border-primary fw-semibold text-primary' : 'text-muted bg-transparent'}`}
+              onClick={() => setSubTab('story')}
+            >
+              <i className="fas fa-file-signature me-2"></i>Story Writer
+            </button>
+          </li>
+          <li className="nav-item">
+            <button
+              type="button"
+              className={`nav-link px-4 py-2 border-0 ${subTab === 'testcase' ? 'active border-bottom border-primary fw-semibold text-primary' : 'text-muted bg-transparent'}`}
+              onClick={() => setSubTab('testcase')}
+            >
+              <i className="fas fa-vial me-2"></i>Test Case Writer
+            </button>
+          </li>
+        </ul>
+      </div>
 
-        <div className="alert alert-info border-0 bg-info-subtle d-flex align-items-start gap-3 mb-4">
-          <i className="fas fa-info-circle mt-1 fs-5 text-info"></i>
-          <div>
-            <h6 className="alert-heading fw-semibold mb-1">
-              Coming Soon (Next Step)
-            </h6>
-            <p className="mb-0 small text-muted">
-              You will be able to customize system instructions and templates
-              here to adapt generation outputs to your specific coding style,
-              team rules, and formats.
+      <div className="card-body p-4 pt-3">
+        {subTab === 'story' && (
+          <div key="story-writer-panel" className="settings-content p-0">
+            <p className="text-muted small mb-4">
+              Customize the guidelines and instructions used when generating
+              user stories.
             </p>
-          </div>
-        </div>
 
-        <div className="mb-4 opacity-75">
-          <label className="form-label fw-semibold text-muted">
-            Story Writer System Instructions
-          </label>
-          <textarea
-            className="form-control"
-            rows={4}
-            disabled
-            defaultValue="You are an expert product manager. Generate comprehensive user stories and acceptance criteria based on the provided requirements documentation..."
-          />
-          <div className="form-text">
-            Define the persona and global instructions for generating user
-            stories.
-          </div>
-        </div>
+            <div className="mb-4">
+              <label className="form-label fw-semibold">
+                General Instructions
+              </label>
+              <textarea
+                className="form-control"
+                rows={3}
+                value={storyGeneral}
+                onChange={(e) => setStoryGeneral(e.target.value)}
+                placeholder="Optional general instructions inserted between the default header context and story details (e.g., 'Target a React & TypeScript architecture. Focus on clear boundary cases.')"
+              />
+              <div className="form-text">
+                This prompt is inserted right after the main goal description to
+                influence overall behavior.
+              </div>
+            </div>
 
-        <div className="mb-4 opacity-75">
-          <label className="form-label fw-semibold text-muted">
-            Test Case Writer System Instructions
-          </label>
-          <textarea
-            className="form-control"
-            rows={4}
-            disabled
-            defaultValue="You are a senior QA engineer. Generate detailed step-by-step test cases, including edge cases and negative validation scenarios, based on the provided story description..."
-          />
-          <div className="form-text">
-            Define the persona and global instructions for generating test
-            cases.
+            <h6 className="mb-3 border-bottom pb-2 fw-semibold text-primary mt-4">
+              Field Customization
+            </h6>
+
+            <div className="mb-3">
+              <label className="form-label fw-semibold">Title</label>
+              <textarea
+                className="form-control"
+                rows={2}
+                value={storyTitle}
+                onChange={(e) => setStoryTitle(e.target.value)}
+                placeholder="The title of the story"
+              />
+              <div className="form-text">
+                Instruct how to generate the story title.
+              </div>
+            </div>
+
+            <div className="mb-3">
+              <label className="form-label fw-semibold">Description</label>
+              <textarea
+                className="form-control"
+                rows={3}
+                value={storyDescription}
+                onChange={(e) => setStoryDescription(e.target.value)}
+                placeholder='Description. This should contain a statement in the format "As a... I want to... So that..." followed by 2 blank lines and then a longer description of the changes required for story.'
+              />
+              <div className="form-text">
+                Define format constraints or detail levels for descriptions.
+              </div>
+            </div>
+
+            <div className="mb-3">
+              <label className="form-label fw-semibold">
+                Acceptance Criteria
+              </label>
+              <textarea
+                className="form-control"
+                rows={3}
+                value={storyAcceptanceCriteria}
+                onChange={(e) => setStoryAcceptanceCriteria(e.target.value)}
+                placeholder="Formatted as a markdown list."
+              />
+              <div className="form-text">
+                Specify formatting rules for the acceptance criteria checklist.
+              </div>
+            </div>
+
+            <div className="mb-3">
+              <label className="form-label fw-semibold">Notes</label>
+              <textarea
+                className="form-control"
+                rows={2}
+                value={storyNotes}
+                onChange={(e) => setStoryNotes(e.target.value)}
+                placeholder="Any additional notes or assumptions (Optional, can be empty)"
+              />
+              <div className="form-text">
+                Instruct what extra warnings, assumptions, or notes to include.
+              </div>
+            </div>
           </div>
-        </div>
+        )}
+
+        {subTab === 'testcase' && (
+          <div key="testcase-writer-panel" className="settings-content p-0">
+            <p className="text-muted small mb-4">
+              Customize the guidelines and instructions used when generating
+              test cases.
+            </p>
+
+            <div className="mb-4">
+              <label className="form-label fw-semibold">
+                General Instructions
+              </label>
+              <textarea
+                className="form-control"
+                rows={3}
+                value={testCaseGeneral}
+                onChange={(e) => setTestCaseGeneral(e.target.value)}
+                placeholder="Optional general instructions inserted between the default header context and ticket details (e.g., 'Emphasize accessibility testing (ARIA attributes) and responsiveness.')"
+              />
+              <div className="form-text">
+                This prompt is inserted right after the main goal description to
+                influence overall behavior.
+              </div>
+            </div>
+
+            <h6 className="mb-3 border-bottom pb-2 fw-semibold text-primary mt-4">
+              Field Customization
+            </h6>
+
+            <div className="mb-3">
+              <label className="form-label fw-semibold">Test Case ID</label>
+              <textarea
+                className="form-control"
+                rows={2}
+                value={testCaseId}
+                onChange={(e) => setTestCaseId(e.target.value)}
+                placeholder='Test Case ID (e.g., "TC01")'
+              />
+              <div className="form-text">
+                Define ID naming conventions or serial formats.
+              </div>
+            </div>
+
+            <div className="mb-3">
+              <label className="form-label fw-semibold">Description</label>
+              <textarea
+                className="form-control"
+                rows={2}
+                value={testCaseDescription}
+                onChange={(e) => setTestCaseDescription(e.target.value)}
+                placeholder="Brief description of the test scenario"
+              />
+              <div className="form-text">
+                Define scenario structure requirements.
+              </div>
+            </div>
+
+            <div className="mb-3">
+              <label className="form-label fw-semibold">Preconditions</label>
+              <textarea
+                className="form-control"
+                rows={2}
+                value={testCasePreConditions}
+                onChange={(e) => setTestCasePreConditions(e.target.value)}
+                placeholder="Any preconditions required before running the test"
+              />
+              <div className="form-text">
+                Instruct how to detail environment states or prerequisites.
+              </div>
+            </div>
+
+            <div className="mb-3">
+              <label className="form-label fw-semibold">Steps</label>
+              <textarea
+                className="form-control"
+                rows={3}
+                value={testCaseSteps}
+                onChange={(e) => setTestCaseSteps(e.target.value)}
+                placeholder="Bullet-pointed or numbered steps to execute the test"
+              />
+              <div className="form-text">
+                Customize the format of steps (e.g. Gherkin Given/When/Then,
+                numbered list).
+              </div>
+            </div>
+
+            <div className="mb-3">
+              <label className="form-label fw-semibold">Expected Result</label>
+              <textarea
+                className="form-control"
+                rows={2}
+                value={testCaseExpectedResult}
+                onChange={(e) => setTestCaseExpectedResult(e.target.value)}
+                placeholder="The expected result"
+              />
+              <div className="form-text">
+                Specify detail requirements for validation expectations.
+              </div>
+            </div>
+
+            <div className="mb-3">
+              <div className="d-flex align-items-center justify-content-between mb-2">
+                <label className="form-label fw-semibold mb-0">Priority</label>
+                <span className="badge bg-warning-subtle text-warning border border-warning-subtle small px-2 py-1">
+                  <i className="fas fa-lock me-1"></i>System Required
+                </span>
+              </div>
+              <textarea
+                className="form-control bg-body-secondary text-muted"
+                rows={2}
+                readOnly
+                value='Priority of the test (e.g., "High", "Medium", "Low")'
+              />
+              <div className="form-text">
+                This field is fixed to match downstream categorization logic and
+                cannot be customized.
+              </div>
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/renderer/components/settings/PromptSettings.tsx
+++ b/src/renderer/components/settings/PromptSettings.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+
+const PromptSettings: React.FC = () => {
+  return (
+    <div className="card shadow-sm border-0 bg-body-tertiary">
+      <div className="card-body p-4">
+        <h5 className="mb-4 border-bottom pb-2">
+          <i className="fas fa-wand-magic-sparkles me-2 text-primary"></i>Prompt
+          Customization
+        </h5>
+
+        <p className="text-muted small mb-4">
+          Customize the AI prompts, templates, and instruction guidelines used
+          to generate your user stories and test cases.
+        </p>
+
+        <div className="alert alert-info border-0 bg-info-subtle d-flex align-items-start gap-3 mb-4">
+          <i className="fas fa-info-circle mt-1 fs-5 text-info"></i>
+          <div>
+            <h6 className="alert-heading fw-semibold mb-1">
+              Coming Soon (Next Step)
+            </h6>
+            <p className="mb-0 small text-muted">
+              You will be able to customize system instructions and templates
+              here to adapt generation outputs to your specific coding style,
+              team rules, and formats.
+            </p>
+          </div>
+        </div>
+
+        <div className="mb-4 opacity-75">
+          <label className="form-label fw-semibold text-muted">
+            Story Writer System Instructions
+          </label>
+          <textarea
+            className="form-control"
+            rows={4}
+            disabled
+            defaultValue="You are an expert product manager. Generate comprehensive user stories and acceptance criteria based on the provided requirements documentation..."
+          />
+          <div className="form-text">
+            Define the persona and global instructions for generating user
+            stories.
+          </div>
+        </div>
+
+        <div className="mb-4 opacity-75">
+          <label className="form-label fw-semibold text-muted">
+            Test Case Writer System Instructions
+          </label>
+          <textarea
+            className="form-control"
+            rows={4}
+            disabled
+            defaultValue="You are a senior QA engineer. Generate detailed step-by-step test cases, including edge cases and negative validation scenarios, based on the provided story description..."
+          />
+          <div className="form-text">
+            Define the persona and global instructions for generating test
+            cases.
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PromptSettings;

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -36,6 +36,10 @@ export interface IElectronAPI {
   getVersion: () => Promise<string>;
   listCopilotModels: () => Promise<CopilotModel[]>;
   openExternal: (url: string) => Promise<void>;
+  checkPromptComplexity: (
+    type: 'story' | 'testcase',
+    prompts: Record<string, string>,
+  ) => Promise<string>;
   isWindows: boolean;
 }
 

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -156,3 +156,77 @@ textarea,
 [data-bs-theme='dark'] .markdown-content table th {
   background-color: #161b22;
 }
+
+/* Settings Page Sidebar Layout */
+.settings-container {
+  display: flex;
+  min-height: calc(100vh - 120px);
+}
+
+.settings-sidebar {
+  width: 240px;
+  flex-shrink: 0;
+  border-right: 1px solid var(--bs-border-color);
+  padding: 0.5rem 1rem 0.5rem 0;
+}
+
+.settings-content {
+  flex-grow: 1;
+  padding: 0.5rem 0 0.5rem 1.5rem;
+  animation: settings-fade-in 0.25s ease-out forwards;
+}
+
+.settings-nav-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border: none;
+  background: transparent;
+  color: var(--bs-body-color);
+  border-radius: 0.375rem;
+  text-align: left;
+  font-size: 0.9rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  margin-bottom: 0.25rem;
+}
+
+.settings-nav-item:hover {
+  background-color: var(--bs-secondary-bg);
+  color: var(--bs-primary-text-emphasis);
+  padding-left: 1.25rem;
+}
+
+.settings-nav-item.active {
+  background-color: var(--bs-primary-bg-subtle);
+  color: var(--bs-primary-text-emphasis);
+  font-weight: 600;
+  border-left: 4px solid var(--bs-primary);
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.settings-nav-item i {
+  font-size: 1rem;
+  width: 20px;
+  text-align: center;
+  transition: transform 0.2s ease;
+}
+
+.settings-nav-item:hover i {
+  transform: scale(1.1);
+}
+
+@keyframes settings-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/src/renderer/pages/Settings.tsx
+++ b/src/renderer/pages/Settings.tsx
@@ -28,6 +28,21 @@ const Settings: React.FC = () => {
     'general' | 'azure' | 'confluence' | 'copilot' | 'prompts'
   >('general');
 
+  // Story Writer Custom Prompts
+  const [storyGeneral, setStoryGeneral] = useState('');
+  const [storyTitle, setStoryTitle] = useState('');
+  const [storyDescription, setStoryDescription] = useState('');
+  const [storyAcceptanceCriteria, setStoryAcceptanceCriteria] = useState('');
+  const [storyNotes, setStoryNotes] = useState('');
+
+  // Test Case Writer Custom Prompts
+  const [testCaseGeneral, setTestCaseGeneral] = useState('');
+  const [testCaseId, setTestCaseId] = useState('');
+  const [testCaseDescription, setTestCaseDescription] = useState('');
+  const [testCasePreConditions, setTestCasePreConditions] = useState('');
+  const [testCaseSteps, setTestCaseSteps] = useState('');
+  const [testCaseExpectedResult, setTestCaseExpectedResult] = useState('');
+
   useEffect(() => {
     const loadSettings = async () => {
       try {
@@ -41,6 +56,24 @@ const Settings: React.FC = () => {
           setConfluenceUser(settings.confluenceUser || '');
           setConfluenceToken(settings.confluenceToken || '');
           setTheme(settings.theme || 'auto');
+
+          // Load custom prompts
+          const prompts = settings.prompts || {};
+          const story = prompts.storyWriter || {};
+          const tc = prompts.testCaseWriter || {};
+
+          setStoryGeneral(story.general || '');
+          setStoryTitle(story.title || '');
+          setStoryDescription(story.description || '');
+          setStoryAcceptanceCriteria(story.acceptanceCriteria || '');
+          setStoryNotes(story.notes || '');
+
+          setTestCaseGeneral(tc.general || '');
+          setTestCaseId(tc.id || '');
+          setTestCaseDescription(tc.description || '');
+          setTestCasePreConditions(tc.preConditions || '');
+          setTestCaseSteps(tc.steps || '');
+          setTestCaseExpectedResult(tc.expectedResult || '');
         }
       } catch (error) {
         console.error('Failed to load settings:', error);
@@ -62,6 +95,23 @@ const Settings: React.FC = () => {
         confluenceUser: confluenceUser,
         confluenceToken: confluenceToken,
         theme: theme,
+        prompts: {
+          storyWriter: {
+            general: storyGeneral,
+            title: storyTitle,
+            description: storyDescription,
+            acceptanceCriteria: storyAcceptanceCriteria,
+            notes: storyNotes,
+          },
+          testCaseWriter: {
+            general: testCaseGeneral,
+            id: testCaseId,
+            description: testCaseDescription,
+            preConditions: testCasePreConditions,
+            steps: testCaseSteps,
+            expectedResult: testCaseExpectedResult,
+          },
+        },
       });
       setStatusMessage('Settings saved successfully!');
       window.scrollTo({ top: 0, behavior: 'smooth' });
@@ -134,7 +184,32 @@ const Settings: React.FC = () => {
           />
         );
       case 'prompts':
-        return <PromptSettings />;
+        return (
+          <PromptSettings
+            storyGeneral={storyGeneral}
+            setStoryGeneral={setStoryGeneral}
+            storyTitle={storyTitle}
+            setStoryTitle={setStoryTitle}
+            storyDescription={storyDescription}
+            setStoryDescription={setStoryDescription}
+            storyAcceptanceCriteria={storyAcceptanceCriteria}
+            setStoryAcceptanceCriteria={setStoryAcceptanceCriteria}
+            storyNotes={storyNotes}
+            setStoryNotes={setStoryNotes}
+            testCaseGeneral={testCaseGeneral}
+            setTestCaseGeneral={setTestCaseGeneral}
+            testCaseId={testCaseId}
+            setTestCaseId={setTestCaseId}
+            testCaseDescription={testCaseDescription}
+            setTestCaseDescription={setTestCaseDescription}
+            testCasePreConditions={testCasePreConditions}
+            setTestCasePreConditions={setTestCasePreConditions}
+            testCaseSteps={testCaseSteps}
+            setTestCaseSteps={setTestCaseSteps}
+            testCaseExpectedResult={testCaseExpectedResult}
+            setTestCaseExpectedResult={setTestCaseExpectedResult}
+          />
+        );
       default:
         return null;
     }

--- a/src/renderer/pages/Settings.tsx
+++ b/src/renderer/pages/Settings.tsx
@@ -1,8 +1,13 @@
 import React, { useState, useEffect } from 'react';
 import { useCopilotModels } from '../hooks/useCopilotModels';
-import ModelDropdown from '../components/ModelDropdown';
 import PageLayout from '../components/PageLayout';
 import { CopilotAuth } from '../../types';
+
+import GeneralSettings from '../components/settings/GeneralSettings';
+import AzureSettings from '../components/settings/AzureSettings';
+import ConfluenceSettings from '../components/settings/ConfluenceSettings';
+import CopilotSettings from '../components/settings/CopilotSettings';
+import PromptSettings from '../components/settings/PromptSettings';
 
 const Settings: React.FC = () => {
   const [azureOrg, setAzureOrg] = useState('');
@@ -18,6 +23,10 @@ const Settings: React.FC = () => {
   const [checkingAuth, setCheckingAuth] = useState(false);
   const { models, selectedModel, setSelectedModel, loadingModels } =
     useCopilotModels();
+
+  const [activeTab, setActiveTab] = useState<
+    'general' | 'azure' | 'confluence' | 'copilot' | 'prompts'
+  >('general');
 
   useEffect(() => {
     const loadSettings = async () => {
@@ -84,8 +93,55 @@ const Settings: React.FC = () => {
     </button>
   );
 
+  const renderActiveTab = () => {
+    switch (activeTab) {
+      case 'general':
+        return <GeneralSettings theme={theme} setTheme={setTheme} />;
+      case 'azure':
+        return (
+          <AzureSettings
+            azureOrg={azureOrg}
+            setAzureOrg={setAzureOrg}
+            azureProject={azureProject}
+            setAzureProject={setAzureProject}
+            azurePat={azurePat}
+            setAzurePat={setAzurePat}
+          />
+        );
+      case 'confluence':
+        return (
+          <ConfluenceSettings
+            confluenceUrl={confluenceUrl}
+            setConfluenceUrl={setConfluenceUrl}
+            confluenceUser={confluenceUser}
+            setConfluenceUser={setConfluenceUser}
+            confluenceToken={confluenceToken}
+            setConfluenceToken={setConfluenceToken}
+          />
+        );
+      case 'copilot':
+        return (
+          <CopilotSettings
+            copilotToken={copilotToken}
+            setCopilotToken={setCopilotToken}
+            models={models}
+            selectedModel={selectedModel}
+            setSelectedModel={setSelectedModel}
+            loadingModels={loadingModels}
+            authStatus={authStatus}
+            checkingAuth={checkingAuth}
+            handleCheckAuth={handleCheckAuth}
+          />
+        );
+      case 'prompts':
+        return <PromptSettings />;
+      default:
+        return null;
+    }
+  };
+
   return (
-    <PageLayout title="Settings" actions={actions} maxWidth="848px">
+    <PageLayout title="Settings" actions={actions} maxWidth="960px">
       {statusMessage && (
         <div
           className={`alert ${statusMessage.includes('Error') ? 'alert-danger' : 'alert-success'} mb-4`}
@@ -95,210 +151,52 @@ const Settings: React.FC = () => {
       )}
 
       <form id="settings-form" onSubmit={handleSave}>
-        <div className="card shadow-sm mb-4">
-          <div className="card-body p-4">
-            <h5 className="mb-3 border-bottom pb-2">Appearance</h5>
-            <div className="mb-4">
-              <label className="form-label d-block">Theme</label>
-              <div
-                className="btn-group"
-                role="group"
-                aria-label="Theme selection"
-              >
-                <button
-                  type="button"
-                  className={`btn ${theme === 'auto' ? 'btn-secondary' : 'btn-outline-secondary'}`}
-                  onClick={() => setTheme('auto')}
-                >
-                  <i className="fas fa-circle-half-stroke me-2"></i>
-                  Auto
-                </button>
-                <button
-                  type="button"
-                  className={`btn ${theme === 'light' ? 'btn-secondary' : 'btn-outline-secondary'}`}
-                  onClick={() => setTheme('light')}
-                >
-                  <i className="fas fa-sun me-2"></i>
-                  Light
-                </button>
-                <button
-                  type="button"
-                  className={`btn ${theme === 'dark' ? 'btn-secondary' : 'btn-outline-secondary'}`}
-                  onClick={() => setTheme('dark')}
-                >
-                  <i className="fas fa-moon me-2"></i>
-                  Dark
-                </button>
-              </div>
-            </div>
+        <div className="settings-container">
+          <div className="settings-sidebar">
+            <button
+              type="button"
+              className={`settings-nav-item ${activeTab === 'general' ? 'active' : ''}`}
+              onClick={() => setActiveTab('general')}
+            >
+              <i className="fas fa-palette"></i>
+              General
+            </button>
+            <button
+              type="button"
+              className={`settings-nav-item ${activeTab === 'azure' ? 'active' : ''}`}
+              onClick={() => setActiveTab('azure')}
+            >
+              <i className="fab fa-microsoft"></i>
+              Azure DevOps
+            </button>
+            <button
+              type="button"
+              className={`settings-nav-item ${activeTab === 'confluence' ? 'active' : ''}`}
+              onClick={() => setActiveTab('confluence')}
+            >
+              <i className="fas fa-book"></i>
+              Confluence
+            </button>
+            <button
+              type="button"
+              className={`settings-nav-item ${activeTab === 'copilot' ? 'active' : ''}`}
+              onClick={() => setActiveTab('copilot')}
+            >
+              <i className="fas fa-robot"></i>
+              GitHub Copilot
+            </button>
+            <button
+              type="button"
+              className={`settings-nav-item ${activeTab === 'prompts' ? 'active' : ''}`}
+              onClick={() => setActiveTab('prompts')}
+            >
+              <i className="fas fa-wand-magic-sparkles"></i>
+              Prompts
+            </button>
+          </div>
 
-            <h5 className="mb-3 border-bottom pb-2 mt-4">
-              Azure DevOps Configuration
-            </h5>
-            <div className="mb-3">
-              <label className="form-label">Organization URL</label>
-              <input
-                type="text"
-                className="form-control"
-                placeholder="https://dev.azure.com/your-org"
-                value={azureOrg}
-                onChange={(e) => setAzureOrg(e.target.value)}
-              />
-            </div>
-            <div className="mb-3">
-              <label className="form-label">Project Name</label>
-              <input
-                type="text"
-                className="form-control"
-                placeholder="YourProject"
-                value={azureProject}
-                onChange={(e) => setAzureProject(e.target.value)}
-              />
-            </div>
-            <div className="mb-4">
-              <label className="form-label">Personal Access Token (PAT)</label>
-              <input
-                type="password"
-                className="form-control"
-                value={azurePat}
-                onChange={(e) => setAzurePat(e.target.value)}
-              />
-            </div>
-
-            <h5 className="mb-3 border-bottom pb-2 mt-4">
-              Confluence Configuration
-            </h5>
-            <div className="mb-3">
-              <label className="form-label">Confluence URL</label>
-              <input
-                type="text"
-                className="form-control"
-                placeholder="https://your-domain.atlassian.net/wiki"
-                value={confluenceUrl}
-                onChange={(e) => setConfluenceUrl(e.target.value)}
-              />
-            </div>
-            <div className="mb-3">
-              <label className="form-label">Email / User (Optional)</label>
-              <input
-                type="text"
-                className="form-control"
-                placeholder="user@example.com"
-                value={confluenceUser}
-                onChange={(e) => setConfluenceUser(e.target.value)}
-              />
-              <div className="form-text">
-                Leave blank if using a Personal Access Token (Bearer Auth).
-                Enter email if using an Atlassian API Token (Basic Auth).
-              </div>
-            </div>
-            <div className="mb-4">
-              <label className="form-label">API Token</label>
-              <input
-                type="password"
-                className="form-control"
-                value={confluenceToken}
-                onChange={(e) => setConfluenceToken(e.target.value)}
-              />
-              <div className="form-text">
-                Your API token or Personal Access Token (PAT).
-              </div>
-            </div>
-
-            <h5 className="mb-3 border-bottom pb-2 mt-4">
-              GitHub Copilot Configuration
-            </h5>
-            <div className="mb-3">
-              <label className="form-label">Copilot API Token</label>
-              <input
-                type="password"
-                className="form-control"
-                value={copilotToken}
-                onChange={(e) => setCopilotToken(e.target.value)}
-              />
-              <div className="form-text">
-                Your Copilot session or API token for authentication.
-              </div>
-            </div>
-            <div className="mb-4">
-              <label className="form-label">Default Model</label>
-              <ModelDropdown
-                models={models}
-                selectedModel={selectedModel}
-                onSelect={setSelectedModel}
-                loading={loadingModels}
-                className="w-25"
-                buttonVariant="outline-secondary"
-              />
-            </div>
-
-            <div className="mb-4 p-3 rounded border">
-              <div className="d-flex justify-content-between align-items-center mb-2">
-                <h6 className="mb-0">Copilot CLI Status</h6>
-                <button
-                  type="button"
-                  className="btn btn-outline-info btn-sm"
-                  onClick={handleCheckAuth}
-                  disabled={checkingAuth}
-                >
-                  {checkingAuth ? (
-                    <>
-                      <span
-                        className="spinner-border spinner-border-sm me-2"
-                        role="status"
-                        aria-hidden="true"
-                      ></span>
-                      Checking...
-                    </>
-                  ) : (
-                    <>
-                      <i className="fas fa-sync-alt me-2"></i>Check Status
-                    </>
-                  )}
-                </button>
-              </div>
-
-              {authStatus && (
-                <div
-                  className={`alert mt-2 mb-0 ${authStatus.error || !authStatus.authStatus?.isAuthenticated ? 'alert-danger' : 'alert-success'}`}
-                >
-                  {authStatus.error ? (
-                    <div>
-                      <strong>Error:</strong> {authStatus.error}
-                    </div>
-                  ) : (
-                    <>
-                      <div>
-                        <strong>Authenticated:</strong>{' '}
-                        {authStatus.authStatus?.isAuthenticated ? 'Yes' : 'No'}
-                      </div>
-                      {authStatus.authStatus?.isAuthenticated && (
-                        <>
-                          <div>
-                            <strong>User:</strong>{' '}
-                            {authStatus.authStatus?.login}
-                          </div>
-                          <div>
-                            <strong>Auth Type:</strong>{' '}
-                            {authStatus.authStatus?.authType}
-                          </div>
-                          <div>
-                            <strong>Message:</strong>{' '}
-                            {authStatus.authStatus?.statusMessage}
-                          </div>
-                          {authStatus.status && (
-                            <div className="mt-2 text-muted small">
-                              CLI Version: {authStatus.status.version} v
-                              {authStatus.status.protocolVersion}
-                            </div>
-                          )}
-                        </>
-                      )}
-                    </>
-                  )}
-                </div>
-              )}
-            </div>
+          <div key={activeTab} className="settings-content">
+            {renderActiveTab()}
           </div>
         </div>
       </form>

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,23 @@ export type AppSettings = {
   confluenceUser?: string;
   confluenceToken?: string;
   theme?: 'auto' | 'light' | 'dark';
+  prompts?: {
+    storyWriter?: {
+      general?: string;
+      title?: string;
+      description?: string;
+      acceptanceCriteria?: string;
+      notes?: string;
+    };
+    testCaseWriter?: {
+      general?: string;
+      id?: string;
+      description?: string;
+      preConditions?: string;
+      steps?: string;
+      expectedResult?: string;
+    };
+  };
 };
 
 export interface TicketData {


### PR DESCRIPTION
Adds a new configuration option of custom prompts for Story Writer and Test Case Writer.

Users can provide an overall prompt for what they want as context for every prompt, along with customising how they want each part of the output to be configured.

The settings page has a button to check the prompt for contradictory statements - since the output must be JSONL it's possible the user could write something in the custom sections which contradict that and confuse the LLM. We ask if the prompt looks confusing and what should be changed. This is an optional feature which doesn't prevent the prompt customisation being saved.

To make this usable without cluttering the settings, this PR also restructures the settings page, adding a left-side menu to simplify configuration.

Resolves #2 