### PR TITLE
tweak: render changelog button only for CalVer version format

### DIFF
--- a/src/renderer/components/UpdateToast.tsx
+++ b/src/renderer/components/UpdateToast.tsx
@@ -22,8 +22,10 @@ const UpdateToast: React.FC<UpdateToastProps> = ({
         <h6 className="update-toast-title">Stitch Updated!</h6>
       </div>
       <p className="update-toast-body">
-        The app has successfully updated to version <strong>v{version}</strong>.
-        Check out the latest changes and improvements in the release notes.
+        The app has successfully updated to version <strong>v{version}</strong>.{' '}
+        {isCalVer
+          ? 'Check out the latest changes and improvements in the release notes.'
+          : "You're running an unreleased build. Check out the git history for changes."}
       </p>
       <div className="update-toast-actions">
         <button

--- a/src/renderer/components/UpdateToast.tsx
+++ b/src/renderer/components/UpdateToast.tsx
@@ -11,6 +11,8 @@ const UpdateToast: React.FC<UpdateToastProps> = ({
   onClose,
   onChangelog,
 }) => {
+  const isCalVer = /^\d{4}\.\d{1,2}\.\d{1,2}$/.test(version);
+
   return (
     <div className="update-toast" role="alert" aria-live="assertive">
       <div className="update-toast-header">
@@ -31,13 +33,15 @@ const UpdateToast: React.FC<UpdateToastProps> = ({
         >
           Close
         </button>
-        <button
-          type="button"
-          className="update-toast-btn-changelog"
-          onClick={onChangelog}
-        >
-          Changelog
-        </button>
+        {isCalVer && (
+          <button
+            type="button"
+            className="update-toast-btn-changelog"
+            onClick={onChangelog}
+          >
+            Changelog
+          </button>
+        )}
       </div>
     </div>
   );

--- a/src/renderer/components/__tests__/UpdateToast.test.tsx
+++ b/src/renderer/components/__tests__/UpdateToast.test.tsx
@@ -17,6 +17,11 @@ describe('UpdateToast Component', () => {
 
     expect(screen.getByText('Stitch Updated!')).toBeInTheDocument();
     expect(screen.getByText('v2026.6.3')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Check out the latest changes and improvements in the release notes/,
+      ),
+    ).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /close/i })).toBeInTheDocument();
     expect(
       screen.getByRole('button', { name: /changelog/i }),
@@ -59,6 +64,11 @@ describe('UpdateToast Component', () => {
     expect(
       screen.queryByRole('button', { name: /changelog/i }),
     ).not.toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /You're running an unreleased build. Check out the git history for changes/,
+      ),
+    ).toBeInTheDocument();
 
     rerender(
       <UpdateToast
@@ -71,5 +81,10 @@ describe('UpdateToast Component', () => {
     expect(
       screen.queryByRole('button', { name: /changelog/i }),
     ).not.toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /You're running an unreleased build. Check out the git history for changes/,
+      ),
+    ).toBeInTheDocument();
   });
 });

--- a/src/renderer/components/__tests__/UpdateToast.test.tsx
+++ b/src/renderer/components/__tests__/UpdateToast.test.tsx
@@ -50,4 +50,26 @@ describe('UpdateToast Component', () => {
     fireEvent.click(screen.getByRole('button', { name: /changelog/i }));
     expect(onChangelogSpy).toHaveBeenCalledOnce();
   });
+
+  it('does not render Changelog button if the version is not strictly CalVer format', () => {
+    const { rerender } = render(
+      <UpdateToast version="1.0.1" onClose={vi.fn()} onChangelog={vi.fn()} />,
+    );
+
+    expect(
+      screen.queryByRole('button', { name: /changelog/i }),
+    ).not.toBeInTheDocument();
+
+    rerender(
+      <UpdateToast
+        version="2026.6.7-some-branch"
+        onClose={vi.fn()}
+        onChangelog={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.queryByRole('button', { name: /changelog/i }),
+    ).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
This PR fixes a minor issue where the toast displayed after updating to unreleased versions of the app display a button which will lead to a 404 page.

The toast will still display on first launch, however it now has 2 possible states;

**Official Release** - If the version is strictly CalVer (e.g. `2026.6.7`):

Will display the text:

> The app has successfully updated to version **v2026.6.7**. Check out the latest changes and improvements in the release notes.

The toast will have "Close" and "Changelog" buttons.

**Prerelease or Dev Build** - If the version isn't strictly CalVer (`1.0.0` or `2026.6.7-feature-fix-update-t`):

Will display the text:

> The app has successfully updated to version **v2026.6.7-feature-fix-update-t**. You're running an unreleased build. Check out the git history for changes.

The toast will only have a "Close" button.