### PR TITLE
feat: implement self-managed GitHub Copilot CLI installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,10 @@ TypeScript using Electron Forge.
 
 ### Prerequisites
 
-- [Node.js](https://nodejs.org/) (LTS recommended)
+- [Node.js](https://nodejs.org/) (v22 or above recommended)
 - **GitHub Copilot CLI**: You must be authenticated via the Copilot CLI on your
   machine (launch `copilot`, enter `/login` and follow the prompts).
-  - **Note for Windows Users**: You must set the `NODE_PATH` (path to Node.js
-    executable) and `COPILOT_SCRIPT_PATH` (path to the Copilot JS script)
-    environment variables for the Copilot client to initialize correctly.
+  - **Note**: Stitch requires Node.js v22+ to run the Copilot CLI. On launch, Stitch will check if the `@github/copilot` CLI is installed locally in the application's user data directory. If it is missing or outdated, an interactive setup wizard will install it automatically using your system's Node and NPM.
 - **Azure DevOps PAT**: A Personal Access Token with "Work Items: Read & Write"
   permissions.
 - **Confluence API Token**: An Atlassian API Token generated from your profile

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -63,6 +63,10 @@ locally on the machine.
 - **Authentication:** Relies on the machine's local GitHub CLI authentication
   (`gh auth login`). The application checks the active connection and auth
   status via the SDK.
+- **Self-Managed Copilot CLI Installer:**
+  - To prevent cross-platform execution issues in packaged environments (e.g., on Windows where system Node spawned as a child process cannot access files inside Electron's read-only `app.asar` package), Stitch manages `@github/copilot` (Copilot CLI) locally in a dedicated directory inside the application's user data path (`<userData>/copilot-cli`).
+  - On launch, Stitch verifies that Node.js v22+ is installed, checks for the existence of `@github/copilot` in the managed directory, and matches the installed version against the required version range declared by `@github/copilot-sdk`.
+  - If the CLI dependency is missing or outdated, an automated setup wizard displays in the UI to perform the installation seamlessly in the background via NPM.
 - **Model Selection:** Supports listing available models (e.g., GPT-4o, Claude
   3.5 Sonnet) and allowing users to choose a model for each generation session.
 - **Generation & Multi-turn Sessions:**
@@ -115,6 +119,8 @@ support modern ESM-only libraries like `electron-store` and
 - `generate-stories`: Interfaces with Copilot to produce structured JSON
   stories. Streams output line-by-line via `story-line` IPC events and resolves once concluded. Supports `modelOverride`.
 - `check-copilot-auth`: Checks Copilot CLI authentication and connection status.
+- `check-environment`: Validates the environment by checking that Node.js is present (v22+) and checking the local `@github/copilot` installation version.
+- `install-copilot-cli`: Performs the automated local installation of `@github/copilot` in the application data directory.
 - `list-copilot-models`: Retrieves available GitHub Copilot models.
 - `add-comment`: Pushes text as a comment onto an Azure DevOps work item.
 - `create-ticket`: Creates a new work item (PBI or Task) in Azure DevOps linked to a parent.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -221,6 +221,10 @@ ipcMain.handle('check-environment', async () => {
   return copilotService.checkEnvironment();
 });
 
+ipcMain.handle('install-copilot-cli', async () => {
+  return copilotService.installCopilotCli();
+});
+
 ipcMain.handle('list-copilot-models', async () => {
   const s = await initStore();
   const settings = (s.get('settings') ?? {}) as AppSettings;

--- a/src/main/infrastructure/copilot/__tests__/copilotDetector.test.ts
+++ b/src/main/infrastructure/copilot/__tests__/copilotDetector.test.ts
@@ -4,33 +4,62 @@ import {
   checkEnvironment,
   getNodePath,
   getCopilotScriptPath,
+  checkCopilotCli,
+  installCopilotCli,
+  getManagedCopilotDir,
+  getRequiredCopilotVersion,
 } from '../copilotDetector';
 import fs from 'fs';
 import path from 'path';
+
+// Mock electron
+vi.mock('electron', () => {
+  return {
+    app: {
+      getPath: (name: string) => {
+        if (name === 'userData') {
+          return '/mock/userData';
+        }
+        return '/mock/path';
+      },
+    },
+  };
+});
 
 let mockExec: any = null;
 let mockExecFile: any = null;
 
 vi.mock('child_process', () => {
   return {
-    exec: (cmd: string, cb: any) => {
+    exec: (cmd: string, options: any, cb?: any) => {
+      let callback = cb;
+      if (typeof options === 'function') {
+        callback = options;
+      }
       if (mockExec) {
-        mockExec(cmd, cb);
+        mockExec(cmd, callback);
       } else {
-        cb(null, { stdout: '' });
+        callback(null, { stdout: '' });
       }
     },
-    execFile: (file: string, args: string[], cb: any) => {
+    execFile: (file: string, args: any, options: any, cb?: any) => {
+      let callback = cb;
+      if (typeof options === 'function') {
+        callback = options;
+      }
       if (mockExecFile) {
-        mockExecFile(file, args, cb);
+        mockExecFile(file, args, callback);
       } else {
-        cb(null, { stdout: '' });
+        callback(null, { stdout: '' });
       }
     },
   };
 });
 
 const originalExistsSync = fs.existsSync;
+const originalReadFileSync = fs.readFileSync;
+const originalWriteFileSync = fs.writeFileSync;
+const originalMkdirSync = fs.mkdirSync;
 const originalEval = global.eval;
 
 describe('copilotDetector', () => {
@@ -43,11 +72,140 @@ describe('copilotDetector', () => {
     delete process.env.NODE_PATH;
     delete process.env.COPILOT_SCRIPT_PATH;
     delete process.env.DISABLE_COPILOT_WINDOWS_WORKAROUND;
+
+    // Mock write operations to avoid making directories or files
+    vi.spyOn(fs, 'mkdirSync').mockImplementation(() => undefined as any);
+    vi.spyOn(fs, 'writeFileSync').mockImplementation(() => undefined as any);
   });
 
   afterEach(() => {
     fs.existsSync = originalExistsSync;
+    fs.readFileSync = originalReadFileSync;
+    fs.writeFileSync = originalWriteFileSync;
+    fs.mkdirSync = originalMkdirSync;
     global.eval = originalEval;
+  });
+
+  describe('getManagedCopilotDir', () => {
+    it('should return the path inside userData directory', () => {
+      const dir = getManagedCopilotDir();
+      expect(dir).toBe(path.join('/mock/userData', 'copilot-cli'));
+    });
+  });
+
+  describe('getRequiredCopilotVersion', () => {
+    it('should resolve version from @github/copilot-sdk package.json', () => {
+      global.eval = vi.fn().mockImplementation((val) => {
+        if (val === "require.resolve('@github/copilot-sdk')") {
+          return '/mock/node_modules/@github/copilot-sdk/dist/cjs/index.js';
+        }
+        return undefined;
+      });
+
+      vi.spyOn(fs, 'existsSync').mockImplementation((p) => {
+        return (
+          p ===
+          path.normalize('/mock/node_modules/@github/copilot-sdk/package.json')
+        );
+      });
+
+      vi.spyOn(fs, 'readFileSync').mockImplementation((p: any) => {
+        if (
+          p ===
+          path.normalize('/mock/node_modules/@github/copilot-sdk/package.json')
+        ) {
+          return JSON.stringify({
+            dependencies: {
+              '@github/copilot': '^1.0.65',
+            },
+          });
+        }
+        return '';
+      });
+
+      const version = getRequiredCopilotVersion();
+      expect(version).toBe('1.0.65');
+    });
+
+    it('should fallback if file cannot be read or resolved', () => {
+      global.eval = vi.fn().mockImplementation(() => {
+        throw new Error('module not found');
+      });
+      const version = getRequiredCopilotVersion();
+      expect(version).toBe('1.0.61');
+    });
+  });
+
+  describe('checkCopilotCli', () => {
+    it('should return COPILOT_CLI_MISSING if package.json does not exist', async () => {
+      vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+      const res = await checkCopilotCli();
+      expect(res.success).toBe(false);
+      expect(res.errorType).toBe('COPILOT_CLI_MISSING');
+    });
+
+    it('should return COPILOT_CLI_OUTDATED if installed version is older than required', async () => {
+      global.eval = vi.fn().mockImplementation((val) => {
+        if (val === "require.resolve('@github/copilot-sdk')") {
+          return '/mock/node_modules/@github/copilot-sdk/dist/cjs/index.js';
+        }
+        return undefined;
+      });
+
+      vi.spyOn(fs, 'existsSync').mockImplementation((p: any) => {
+        // SDK package.json exists, copilot package.json exists
+        return (
+          p.includes('copilot-sdk/package.json') ||
+          p.includes('copilot/package.json')
+        );
+      });
+
+      vi.spyOn(fs, 'readFileSync').mockImplementation((p: any) => {
+        if (p.includes('copilot-sdk/package.json')) {
+          return JSON.stringify({
+            dependencies: { '@github/copilot': '^1.0.61' },
+          });
+        }
+        if (p.includes('copilot/package.json')) {
+          return JSON.stringify({ version: '1.0.60' });
+        }
+        return '';
+      });
+
+      const res = await checkCopilotCli();
+      expect(res.success).toBe(false);
+      expect(res.errorType).toBe('COPILOT_CLI_OUTDATED');
+      expect(res.installedVersion).toBe('1.0.60');
+      expect(res.requiredVersion).toBe('1.0.61');
+    });
+
+    it('should return success true if installed version matches required and index.js exists', async () => {
+      global.eval = vi.fn().mockImplementation((val) => {
+        if (val === "require.resolve('@github/copilot-sdk')") {
+          return '/mock/node_modules/@github/copilot-sdk/dist/cjs/index.js';
+        }
+        return undefined;
+      });
+
+      vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+
+      vi.spyOn(fs, 'readFileSync').mockImplementation((p: any) => {
+        if (p.includes('copilot-sdk/package.json')) {
+          return JSON.stringify({
+            dependencies: { '@github/copilot': '^1.0.61' },
+          });
+        }
+        if (p.includes('copilot/package.json')) {
+          return JSON.stringify({ version: '1.0.61' });
+        }
+        return '';
+      });
+
+      const res = await checkCopilotCli();
+      expect(res.success).toBe(true);
+      expect(res.errorType).toBeNull();
+      expect(res.installedVersion).toBe('1.0.61');
+    });
   });
 
   describe('checkEnvironment', () => {
@@ -65,7 +223,9 @@ describe('copilotDetector', () => {
       mockExecFile = (file: string, args: string[], cb: any) =>
         cb(null, { stdout: 'v18.5.0\n' });
 
-      vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+      vi.spyOn(fs, 'existsSync').mockImplementation((p) => {
+        return p === '/usr/bin/node';
+      });
 
       const result = await checkEnvironment();
       expect(result.success).toBe(false);
@@ -74,84 +234,67 @@ describe('copilotDetector', () => {
       expect(result.nodePath).toBe('/usr/bin/node');
     });
 
-    it('should return success if candidate node version is 22 or above', async () => {
+    it('should fail with COPILOT_CLI_MISSING if Node succeeds but Copilot CLI is missing', async () => {
       mockExec = (cmd: string, cb: any) =>
         cb(null, { stdout: '/usr/bin/node\n' });
       mockExecFile = (file: string, args: string[], cb: any) =>
         cb(null, { stdout: 'v22.2.0\n' });
 
+      vi.spyOn(fs, 'existsSync').mockImplementation((p) => {
+        // Return true only for node binary, false for copilot files
+        return p === '/usr/bin/node';
+      });
+
+      const result = await checkEnvironment();
+      expect(result.success).toBe(false);
+      expect(result.errorType).toBe('COPILOT_CLI_MISSING');
+      expect(result.nodeVersion).toBe('v22.2.0');
+    });
+
+    it('should return success if both Node and Copilot CLI are valid', async () => {
+      mockExec = (cmd: string, cb: any) =>
+        cb(null, { stdout: '/usr/bin/node\n' });
+      mockExecFile = (file: string, args: string[], cb: any) =>
+        cb(null, { stdout: 'v22.2.0\n' });
+
+      global.eval = vi.fn().mockImplementation((val) => {
+        if (val === "require.resolve('@github/copilot-sdk')") {
+          return '/mock/node_modules/@github/copilot-sdk/dist/cjs/index.js';
+        }
+        return undefined;
+      });
+
       vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+
+      vi.spyOn(fs, 'readFileSync').mockImplementation((p: any) => {
+        if (p.includes('copilot-sdk/package.json')) {
+          return JSON.stringify({
+            dependencies: { '@github/copilot': '^1.0.61' },
+          });
+        }
+        if (p.includes('copilot/package.json')) {
+          return JSON.stringify({ version: '1.0.61' });
+        }
+        return '';
+      });
 
       const result = await checkEnvironment();
       expect(result.success).toBe(true);
       expect(result.nodeVersion).toBe('v22.2.0');
       expect(result.nodePath).toBe('/usr/bin/node');
     });
-
-    it('should prioritize the first valid node candidate even if others are invalid/older', async () => {
-      mockExec = (cmd: string, cb: any) =>
-        cb(null, {
-          stdout: '/invalid/node\n/usr/bin/node22\n/usr/bin/node18\n',
-        });
-      mockExecFile = (file: string, args: string[], cb: any) => {
-        if (file === '/usr/bin/node22') {
-          cb(null, { stdout: 'v22.1.0\n' });
-        } else if (file === '/usr/bin/node18') {
-          cb(null, { stdout: 'v18.0.0\n' });
-        } else {
-          cb(new Error('not executable'));
-        }
-      };
-
-      vi.spyOn(fs, 'existsSync').mockImplementation((p) => {
-        return p === '/usr/bin/node22' || p === '/usr/bin/node18';
-      });
-
-      const result = await checkEnvironment();
-      expect(result.success).toBe(true);
-      expect(result.nodePath).toBe('/usr/bin/node22');
-      expect(result.nodeVersion).toBe('v22.1.0');
-    });
-
-    it('should respect NODE_PATH if specified and valid', async () => {
-      process.env.NODE_PATH = '/custom/node';
-      mockExecFile = (file: string, args: string[], cb: any) =>
-        cb(null, { stdout: 'v23.0.0\n' });
-
-      vi.spyOn(fs, 'existsSync').mockImplementation(
-        (p) => p === '/custom/node',
-      );
-
-      const result = await checkEnvironment();
-      expect(result.success).toBe(true);
-      expect(result.nodePath).toBe('/custom/node');
-      expect(result.nodeVersion).toBe('v23.0.0');
-    });
-
-    it('should return NODE_VERSION_TOO_LOW if NODE_PATH is specified but version is too low', async () => {
-      process.env.NODE_PATH = '/custom/node';
-      mockExecFile = (file: string, args: string[], cb: any) =>
-        cb(null, { stdout: 'v16.0.0\n' });
-
-      vi.spyOn(fs, 'existsSync').mockImplementation(
-        (p) => p === '/custom/node',
-      );
-
-      const result = await checkEnvironment();
-      expect(result.success).toBe(false);
-      expect(result.errorType).toBe('NODE_VERSION_TOO_LOW');
-      expect(result.nodePath).toBe('/custom/node');
-      expect(result.nodeVersion).toBe('v16.0.0');
-    });
   });
 
   describe('getNodePath', () => {
-    it('should return path on success', async () => {
+    it('should return path on success even if Copilot CLI is missing', async () => {
       mockExec = (cmd: string, cb: any) =>
         cb(null, { stdout: '/usr/bin/node\n' });
       mockExecFile = (file: string, args: string[], cb: any) =>
         cb(null, { stdout: 'v22.0.0\n' });
-      vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+
+      vi.spyOn(fs, 'existsSync').mockImplementation((p) => {
+        return p === '/usr/bin/node'; // Node exists, Copilot CLI does not
+      });
 
       const path = await getNodePath();
       expect(path).toBe('/usr/bin/node');
@@ -170,36 +313,75 @@ describe('copilotDetector', () => {
       const scriptPath = getCopilotScriptPath();
       expect(scriptPath).toBe('/custom/copilot/index.js');
     });
-    it('should resolve script path relative to @github/copilot-sdk peer package', () => {
-      const mockSdkPath = path.normalize(
-        '/mock/node_modules/@github/copilot-sdk/dist/index.js',
+
+    it('should return the path in the managed directory if it exists', () => {
+      const expectedPath = path.join(
+        '/mock/userData',
+        'copilot-cli',
+        'node_modules',
+        '@github',
+        'copilot',
+        'index.js',
       );
-      const expectedCopilotPath = path.normalize(
-        '/mock/node_modules/@github/copilot/index.js',
-      );
+
+      vi.spyOn(fs, 'existsSync').mockImplementation((p) => {
+        return p === expectedPath;
+      });
+
+      const scriptPath = getCopilotScriptPath();
+      expect(scriptPath).toBe(expectedPath);
+    });
+  });
+
+  describe('installCopilotCli', () => {
+    it('should run npm install and return success', async () => {
+      // Mock Node detection succeeding
+      mockExec = (cmd: string, cb: any) =>
+        cb(null, { stdout: '/usr/bin/node\n' });
+      mockExecFile = (file: string, args: string[], cb: any) => {
+        if (file === '/usr/bin/node') {
+          cb(null, { stdout: 'v22.0.0\n' });
+        } else {
+          // npm install command
+          cb(null, { stdout: 'installed' });
+        }
+      };
 
       global.eval = vi.fn().mockImplementation((val) => {
         if (val === "require.resolve('@github/copilot-sdk')") {
-          return mockSdkPath;
+          return '/mock/node_modules/@github/copilot-sdk/dist/cjs/index.js';
         }
-        return originalEval(val);
+        return undefined;
       });
 
-      vi.spyOn(fs, 'existsSync').mockImplementation((p) => {
-        // Should traverse up to node_modules/ and check node_modules/@github/copilot/index.js
-        return p === expectedCopilotPath;
+      vi.spyOn(fs, 'existsSync').mockImplementation((p: any) => {
+        const normalized = path.normalize(p);
+        return (
+          normalized ===
+            path.normalize(
+              '/mock/node_modules/@github/copilot-sdk/package.json',
+            ) ||
+          normalized === path.normalize('/usr/bin/node') ||
+          normalized.includes('copilot/package.json') ||
+          normalized.includes('copilot/index.js') ||
+          normalized.includes('copilot-cli')
+        );
       });
 
-      const scriptPath = getCopilotScriptPath();
-      expect(scriptPath).toBe(expectedCopilotPath);
-    });
-    it('should return null if path cannot be resolved', () => {
-      global.eval = vi.fn().mockImplementation(() => {
-        throw new Error('module not found');
+      vi.spyOn(fs, 'readFileSync').mockImplementation((p: any) => {
+        if (p.includes('copilot-sdk/package.json')) {
+          return JSON.stringify({
+            dependencies: { '@github/copilot': '^1.0.61' },
+          });
+        }
+        if (p.includes('copilot/package.json')) {
+          return JSON.stringify({ version: '1.0.61' });
+        }
+        return '';
       });
 
-      const scriptPath = getCopilotScriptPath();
-      expect(scriptPath).toBeNull();
+      const res = await installCopilotCli();
+      expect(res.success).toBe(true);
     });
   });
 });

--- a/src/main/infrastructure/copilot/__tests__/copilotDetector.test.ts
+++ b/src/main/infrastructure/copilot/__tests__/copilotDetector.test.ts
@@ -153,20 +153,21 @@ describe('copilotDetector', () => {
       });
 
       vi.spyOn(fs, 'existsSync').mockImplementation((p: any) => {
-        // SDK package.json exists, copilot package.json exists
+        const np = p.replace(/\\/g, '/');
         return (
-          p.includes('copilot-sdk/package.json') ||
-          p.includes('copilot/package.json')
+          np.includes('copilot-sdk/package.json') ||
+          np.includes('copilot/package.json')
         );
       });
 
       vi.spyOn(fs, 'readFileSync').mockImplementation((p: any) => {
-        if (p.includes('copilot-sdk/package.json')) {
+        const np = p.replace(/\\/g, '/');
+        if (np.includes('copilot-sdk/package.json')) {
           return JSON.stringify({
             dependencies: { '@github/copilot': '^1.0.61' },
           });
         }
-        if (p.includes('copilot/package.json')) {
+        if (np.includes('copilot/package.json')) {
           return JSON.stringify({ version: '1.0.60' });
         }
         return '';
@@ -190,12 +191,13 @@ describe('copilotDetector', () => {
       vi.spyOn(fs, 'existsSync').mockReturnValue(true);
 
       vi.spyOn(fs, 'readFileSync').mockImplementation((p: any) => {
-        if (p.includes('copilot-sdk/package.json')) {
+        const np = p.replace(/\\/g, '/');
+        if (np.includes('copilot-sdk/package.json')) {
           return JSON.stringify({
             dependencies: { '@github/copilot': '^1.0.61' },
           });
         }
-        if (p.includes('copilot/package.json')) {
+        if (np.includes('copilot/package.json')) {
           return JSON.stringify({ version: '1.0.61' });
         }
         return '';
@@ -267,12 +269,13 @@ describe('copilotDetector', () => {
       vi.spyOn(fs, 'existsSync').mockReturnValue(true);
 
       vi.spyOn(fs, 'readFileSync').mockImplementation((p: any) => {
-        if (p.includes('copilot-sdk/package.json')) {
+        const np = p.replace(/\\/g, '/');
+        if (np.includes('copilot-sdk/package.json')) {
           return JSON.stringify({
             dependencies: { '@github/copilot': '^1.0.61' },
           });
         }
-        if (p.includes('copilot/package.json')) {
+        if (np.includes('copilot/package.json')) {
           return JSON.stringify({ version: '1.0.61' });
         }
         return '';
@@ -355,6 +358,7 @@ describe('copilotDetector', () => {
       });
 
       vi.spyOn(fs, 'existsSync').mockImplementation((p: any) => {
+        const np = p.replace(/\\/g, '/');
         const normalized = path.normalize(p);
         return (
           normalized ===
@@ -362,19 +366,20 @@ describe('copilotDetector', () => {
               '/mock/node_modules/@github/copilot-sdk/package.json',
             ) ||
           normalized === path.normalize('/usr/bin/node') ||
-          normalized.includes('copilot/package.json') ||
-          normalized.includes('copilot/index.js') ||
-          normalized.includes('copilot-cli')
+          np.includes('copilot/package.json') ||
+          np.includes('copilot/index.js') ||
+          np.includes('copilot-cli')
         );
       });
 
       vi.spyOn(fs, 'readFileSync').mockImplementation((p: any) => {
-        if (p.includes('copilot-sdk/package.json')) {
+        const np = p.replace(/\\/g, '/');
+        if (np.includes('copilot-sdk/package.json')) {
           return JSON.stringify({
             dependencies: { '@github/copilot': '^1.0.61' },
           });
         }
-        if (p.includes('copilot/package.json')) {
+        if (np.includes('copilot/package.json')) {
           return JSON.stringify({ version: '1.0.61' });
         }
         return '';

--- a/src/main/infrastructure/copilot/__tests__/copilotDetector.test.ts
+++ b/src/main/infrastructure/copilot/__tests__/copilotDetector.test.ts
@@ -317,7 +317,7 @@ describe('copilotDetector', () => {
       expect(scriptPath).toBe('/custom/copilot/index.js');
     });
 
-    it('should return the path in the managed directory if it exists', () => {
+    it('should return the path in the managed directory if it and package.json exists', () => {
       const expectedPath = path.join(
         '/mock/userData',
         'copilot-cli',
@@ -327,8 +327,11 @@ describe('copilotDetector', () => {
         'npm-loader.js',
       );
 
-      vi.spyOn(fs, 'existsSync').mockImplementation((p) => {
-        return p === expectedPath || p === path.dirname(expectedPath);
+      // pretend every file exists
+      vi.spyOn(fs, 'existsSync').mockImplementation(() => true);
+
+      vi.spyOn(fs, 'readFileSync').mockImplementation(() => {
+        return JSON.stringify({ version: '1.0.61', bin: 'npm-loader.js' });
       });
 
       const scriptPath = getCopilotScriptPath();

--- a/src/main/infrastructure/copilot/__tests__/copilotDetector.test.ts
+++ b/src/main/infrastructure/copilot/__tests__/copilotDetector.test.ts
@@ -68,11 +68,6 @@ describe('copilotDetector', () => {
     mockExec = null;
     mockExecFile = null;
 
-    // Default NODE_PATH and COPILOT_SCRIPT_PATH to undefined for standard test cases
-    delete process.env.NODE_PATH;
-    delete process.env.COPILOT_SCRIPT_PATH;
-    delete process.env.DISABLE_COPILOT_WINDOWS_WORKAROUND;
-
     // Mock write operations to avoid making directories or files
     vi.spyOn(fs, 'mkdirSync').mockImplementation(() => undefined as any);
     vi.spyOn(fs, 'writeFileSync').mockImplementation(() => undefined as any);
@@ -311,12 +306,6 @@ describe('copilotDetector', () => {
   });
 
   describe('getCopilotScriptPath', () => {
-    it('should respect COPILOT_SCRIPT_PATH if defined', () => {
-      process.env.COPILOT_SCRIPT_PATH = '/custom/copilot/index.js';
-      const scriptPath = getCopilotScriptPath();
-      expect(scriptPath).toBe('/custom/copilot/index.js');
-    });
-
     it('should return the path in the managed directory if it and package.json exists', () => {
       const expectedPath = path.join(
         '/mock/userData',

--- a/src/main/infrastructure/copilot/__tests__/copilotDetector.test.ts
+++ b/src/main/infrastructure/copilot/__tests__/copilotDetector.test.ts
@@ -324,11 +324,11 @@ describe('copilotDetector', () => {
         'node_modules',
         '@github',
         'copilot',
-        'index.js',
+        'npm-loader.js',
       );
 
       vi.spyOn(fs, 'existsSync').mockImplementation((p) => {
-        return p === expectedPath;
+        return p === expectedPath || p === path.dirname(expectedPath);
       });
 
       const scriptPath = getCopilotScriptPath();
@@ -368,6 +368,7 @@ describe('copilotDetector', () => {
           normalized === path.normalize('/usr/bin/node') ||
           np.includes('copilot/package.json') ||
           np.includes('copilot/index.js') ||
+          np.includes('copilot/npm-loader.js') ||
           np.includes('copilot-cli')
         );
       });

--- a/src/main/infrastructure/copilot/__tests__/copilotService.test.ts
+++ b/src/main/infrastructure/copilot/__tests__/copilotService.test.ts
@@ -3,6 +3,20 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { CopilotService } from '../copilotService';
 import fs from 'fs';
 
+// Mock electron
+vi.mock('electron', () => {
+  return {
+    app: {
+      getPath: (name: string) => {
+        if (name === 'userData') {
+          return '/mock/userData';
+        }
+        return '/mock/path';
+      },
+    },
+  };
+});
+
 // Mock child_process to avoid running real shell commands
 vi.mock('child_process', () => {
   return {
@@ -38,6 +52,7 @@ const mockApproveAll = vi.fn();
 
 const originalEval = global.eval;
 const originalExistsSync = fs.existsSync;
+const originalReadFileSync = fs.readFileSync;
 
 describe('CopilotService', () => {
   let service: CopilotService;
@@ -64,11 +79,31 @@ describe('CopilotService', () => {
       }
     });
 
-    vi.spyOn(fs, 'existsSync').mockImplementation((p) => {
-      if (p === '/mock/node' || p === '/mock/copilot/index.js') {
+    vi.spyOn(fs, 'existsSync').mockImplementation((p: any) => {
+      const normalized = p.toString().replace(/\\/g, '/');
+      if (
+        normalized === '/mock/node' ||
+        normalized ===
+          '/mock/userData/copilot-cli/node_modules/@github/copilot' ||
+        normalized ===
+          '/mock/userData/copilot-cli/node_modules/@github/copilot/package.json' ||
+        normalized ===
+          '/mock/userData/copilot-cli/node_modules/@github/copilot/npm-loader.js'
+      ) {
         return true;
       }
       return originalExistsSync(p);
+    });
+
+    vi.spyOn(fs, 'readFileSync').mockImplementation((p: any, options?: any) => {
+      const normalized = p.toString().replace(/\\/g, '/');
+      if (
+        normalized ===
+        '/mock/userData/copilot-cli/node_modules/@github/copilot/package.json'
+      ) {
+        return JSON.stringify({ version: '1.0.61', bin: 'npm-loader.js' });
+      }
+      return originalReadFileSync(p, options);
     });
 
     service = new CopilotService();
@@ -90,6 +125,8 @@ describe('CopilotService', () => {
 
   afterEach(() => {
     global.eval = originalEval;
+    fs.readFileSync = originalReadFileSync;
+    fs.existsSync = originalExistsSync;
     vi.useRealTimers();
   });
 
@@ -391,6 +428,16 @@ describe('CopilotService', () => {
         availableTools: [],
         streaming: true,
       }),
+    );
+  });
+
+  it('should throw an error if Node.js path or Copilot script path cannot be resolved', async () => {
+    // Mock files not existing so paths cannot be resolved
+    vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+    await expect(
+      service.createClientAndSession('test-token', 'test-model', {}),
+    ).rejects.toThrow(
+      'Copilot CLI client cannot be started: Node.js executable or Copilot CLI script path could not be resolved',
     );
   });
 });

--- a/src/main/infrastructure/copilot/copilotDetector.ts
+++ b/src/main/infrastructure/copilot/copilotDetector.ts
@@ -49,6 +49,31 @@ export function getRequiredCopilotVersion(): string {
   return '1.0.61'; // Fallback
 }
 
+function getCopilotPackageInfo(copilotPkgDir: string): {
+  version: string;
+  binScript: string;
+} | null {
+  try {
+    const pkgJsonPath = path.join(copilotPkgDir, 'package.json');
+    if (fs.existsSync(pkgJsonPath)) {
+      const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
+      let binScript = 'npm-loader.js';
+      if (pkg.bin && typeof pkg.bin === 'object' && pkg.bin.copilot) {
+        binScript = pkg.bin.copilot;
+      } else if (typeof pkg.bin === 'string') {
+        binScript = pkg.bin;
+      }
+      return {
+        version: pkg.version,
+        binScript,
+      };
+    }
+  } catch (err) {
+    console.warn('Failed to parse Copilot CLI package.json:', err);
+  }
+  return null;
+}
+
 function isVersionOlder(toCheck: string, baseline: string): boolean {
   const partsToCheck = toCheck.split('.').map(Number);
   const partsBaseline = baseline.split('.').map(Number);
@@ -73,13 +98,13 @@ export async function checkCopilotCli(): Promise<{
   message?: string;
 }> {
   const managedDir = getManagedCopilotDir();
-  const pkgJsonPath = path.join(
+  const copilotDir = path.join(
     managedDir,
     'node_modules',
     '@github',
     'copilot',
-    'package.json',
   );
+  const pkgJsonPath = path.join(copilotDir, 'package.json');
   const requiredVersion = getRequiredCopilotVersion();
 
   if (!fs.existsSync(pkgJsonPath)) {
@@ -92,26 +117,27 @@ export async function checkCopilotCli(): Promise<{
   }
 
   try {
-    const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
-    const installedVersion = pkg.version;
-
-    if (isVersionOlder(installedVersion, requiredVersion)) {
+    const pkgInfo = getCopilotPackageInfo(copilotDir);
+    if (!pkgInfo) {
       return {
         success: false,
-        errorType: 'COPILOT_CLI_OUTDATED',
-        installedVersion,
+        errorType: 'COPILOT_CLI_MISSING',
         requiredVersion,
-        message: `GitHub Copilot CLI is outdated. Installed: ${installedVersion}, Required: ${requiredVersion}`,
+        message: 'Failed to read version from local Copilot CLI installation.',
       };
     }
 
-    const scriptPath = path.join(
-      managedDir,
-      'node_modules',
-      '@github',
-      'copilot',
-      'index.js',
-    );
+    if (isVersionOlder(pkgInfo.version, requiredVersion)) {
+      return {
+        success: false,
+        errorType: 'COPILOT_CLI_OUTDATED',
+        installedVersion: pkgInfo.version,
+        requiredVersion,
+        message: `GitHub Copilot CLI is outdated. Installed: ${pkgInfo.version}, Required: ${requiredVersion}`,
+      };
+    }
+
+    const scriptPath = path.join(copilotDir, pkgInfo.binScript);
     if (!fs.existsSync(scriptPath)) {
       return {
         success: false,
@@ -124,7 +150,7 @@ export async function checkCopilotCli(): Promise<{
     return {
       success: true,
       errorType: null,
-      installedVersion,
+      installedVersion: pkgInfo.version,
       requiredVersion,
     };
   } catch (err: unknown) {
@@ -317,15 +343,18 @@ export function getCopilotScriptPath(): string | null {
 
   // Check the managed directory first
   const managedDir = getManagedCopilotDir();
-  const candidate = path.join(
+  const copilotDir = path.join(
     managedDir,
     'node_modules',
     '@github',
     'copilot',
-    'index.js',
   );
-  if (fs.existsSync(candidate)) {
-    return candidate;
+  if (fs.existsSync(copilotDir)) {
+    const pkgInfo = getCopilotPackageInfo(copilotDir);
+    const candidate = path.join(copilotDir, pkgInfo.binScript);
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
   }
 
   // Fallback to peer package resolution if running in dev/test environment
@@ -333,14 +362,13 @@ export function getCopilotScriptPath(): string | null {
     const sdkEntryPoint = eval("require.resolve('@github/copilot-sdk')");
     let dir = path.dirname(sdkEntryPoint);
     for (let i = 0; i < 5; i++) {
-      const fallbackCandidate = path.join(
-        dir,
-        '@github',
-        'copilot',
-        'index.js',
-      );
-      if (fs.existsSync(fallbackCandidate)) {
-        return fallbackCandidate;
+      const fallbackDir = path.join(dir, '@github', 'copilot');
+      if (fs.existsSync(fallbackDir)) {
+        const pkgInfo = getCopilotPackageInfo(fallbackDir);
+        const fallbackCandidate = path.join(fallbackDir, pkgInfo.binScript);
+        if (fs.existsSync(fallbackCandidate)) {
+          return fallbackCandidate;
+        }
       }
       const parent = path.dirname(dir);
       if (parent === dir) break;
@@ -424,9 +452,13 @@ export async function installCopilotCli(): Promise<{
     );
 
     if (path.isAbsolute(npmCmd)) {
-      await execFilePromise(npmCmd, args, {
+      const finalCmd =
+        isWin && npmCmd.includes(' ') && !npmCmd.startsWith('"')
+          ? `"${npmCmd}"`
+          : npmCmd;
+      await execFilePromise(finalCmd, args, {
         cwd: managedDir,
-        shell: process.platform === 'win32',
+        shell: isWin,
       });
     } else {
       // Fallback: run via shell if npmCmd is just 'npm'

--- a/src/main/infrastructure/copilot/copilotDetector.ts
+++ b/src/main/infrastructure/copilot/copilotDetector.ts
@@ -49,14 +49,18 @@ export function getRequiredCopilotVersion(): string {
   return '1.0.61'; // Fallback
 }
 
-function isVersionOlder(v1: string, v2: string): boolean {
-  const parts1 = v1.split('.').map(Number);
-  const parts2 = v2.split('.').map(Number);
-  for (let i = 0; i < Math.max(parts1.length, parts2.length); i++) {
-    const p1 = parts1[i] || 0;
-    const p2 = parts2[i] || 0;
-    if (p1 < p2) return true;
-    if (p1 > p2) return false;
+function isVersionOlder(toCheck: string, baseline: string): boolean {
+  const partsToCheck = toCheck.split('.').map(Number);
+  const partsBaseline = baseline.split('.').map(Number);
+  for (
+    let i = 0;
+    i < Math.max(partsToCheck.length, partsBaseline.length);
+    i++
+  ) {
+    const pToCheck = partsToCheck[i] || 0;
+    const pBaseline = partsBaseline[i] || 0;
+    if (pToCheck < pBaseline) return true;
+    if (pToCheck > pBaseline) return false;
   }
   return false;
 }

--- a/src/main/infrastructure/copilot/copilotDetector.ts
+++ b/src/main/infrastructure/copilot/copilotDetector.ts
@@ -2,6 +2,7 @@ import { exec, execFile } from 'child_process';
 import { promisify } from 'util';
 import fs from 'fs';
 import path from 'path';
+import { app } from 'electron';
 import { EnvironmentCheckResult } from '../../../types';
 
 const execPromise = promisify(exec);
@@ -13,7 +14,132 @@ const DISABLE_WINDOWS_WORKAROUND = ['1', 'true'].includes(
   process.env.DISABLE_COPILOT_WINDOWS_WORKAROUND || '',
 );
 
-export async function checkEnvironment(): Promise<EnvironmentCheckResult> {
+export function getManagedCopilotDir(): string {
+  try {
+    return path.join(app.getPath('userData'), 'copilot-cli');
+  } catch (err) {
+    // Fallback for tests or when app is not ready/mocked
+    return path.join(process.cwd(), '.copilot-cli-test');
+  }
+}
+
+export function getRequiredCopilotVersion(): string {
+  try {
+    const sdkEntryPoint = eval("require.resolve('@github/copilot-sdk')");
+    let dir = path.dirname(sdkEntryPoint);
+    for (let i = 0; i < 5; i++) {
+      const candidate = path.join(dir, 'package.json');
+      if (fs.existsSync(candidate)) {
+        const pkg = JSON.parse(fs.readFileSync(candidate, 'utf8'));
+        const version = pkg.dependencies?.['@github/copilot'];
+        if (version) {
+          return version.replace(/^[\^~]/, '');
+        }
+      }
+      const parent = path.dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+  } catch (e) {
+    console.warn(
+      'Failed to resolve required @github/copilot version dynamically:',
+      e,
+    );
+  }
+  return '1.0.61'; // Fallback
+}
+
+function isVersionOlder(v1: string, v2: string): boolean {
+  const parts1 = v1.split('.').map(Number);
+  const parts2 = v2.split('.').map(Number);
+  for (let i = 0; i < Math.max(parts1.length, parts2.length); i++) {
+    const p1 = parts1[i] || 0;
+    const p2 = parts2[i] || 0;
+    if (p1 < p2) return true;
+    if (p1 > p2) return false;
+  }
+  return false;
+}
+
+export async function checkCopilotCli(): Promise<{
+  success: boolean;
+  errorType: 'COPILOT_CLI_MISSING' | 'COPILOT_CLI_OUTDATED' | null;
+  installedVersion?: string;
+  requiredVersion?: string;
+  message?: string;
+}> {
+  const managedDir = getManagedCopilotDir();
+  const pkgJsonPath = path.join(
+    managedDir,
+    'node_modules',
+    '@github',
+    'copilot',
+    'package.json',
+  );
+  const requiredVersion = getRequiredCopilotVersion();
+
+  if (!fs.existsSync(pkgJsonPath)) {
+    return {
+      success: false,
+      errorType: 'COPILOT_CLI_MISSING',
+      requiredVersion,
+      message: 'GitHub Copilot CLI is not installed locally.',
+    };
+  }
+
+  try {
+    const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
+    const installedVersion = pkg.version;
+
+    if (isVersionOlder(installedVersion, requiredVersion)) {
+      return {
+        success: false,
+        errorType: 'COPILOT_CLI_OUTDATED',
+        installedVersion,
+        requiredVersion,
+        message: `GitHub Copilot CLI is outdated. Installed: ${installedVersion}, Required: ${requiredVersion}`,
+      };
+    }
+
+    const scriptPath = path.join(
+      managedDir,
+      'node_modules',
+      '@github',
+      'copilot',
+      'index.js',
+    );
+    if (!fs.existsSync(scriptPath)) {
+      return {
+        success: false,
+        errorType: 'COPILOT_CLI_MISSING',
+        requiredVersion,
+        message: 'GitHub Copilot CLI entry point is missing.',
+      };
+    }
+
+    return {
+      success: true,
+      errorType: null,
+      installedVersion,
+      requiredVersion,
+    };
+  } catch (err: any) {
+    return {
+      success: false,
+      errorType: 'COPILOT_CLI_MISSING',
+      requiredVersion,
+      message: `Failed to read local Copilot CLI installation: ${err.message}`,
+    };
+  }
+}
+
+async function checkNodeEnvironment(): Promise<{
+  success: boolean;
+  nodePath: string | null;
+  nodeVersion: string | null;
+  errorType: 'NODE_NOT_FOUND' | 'NODE_VERSION_TOO_LOW' | null;
+  message: string | null;
+}> {
   // Respect user-specified NODE_PATH first
   if (!DISABLE_WINDOWS_WORKAROUND && process.env.NODE_PATH) {
     const nodePath = process.env.NODE_PATH;
@@ -29,7 +155,6 @@ export async function checkEnvironment(): Promise<EnvironmentCheckResult> {
               success: true,
               nodePath,
               nodeVersion: versionStr,
-              minRequiredVersion: MIN_NODE_VERSION,
               errorType: null,
               message: null,
             };
@@ -38,7 +163,6 @@ export async function checkEnvironment(): Promise<EnvironmentCheckResult> {
               success: false,
               nodePath,
               nodeVersion: versionStr,
-              minRequiredVersion: MIN_NODE_VERSION,
               errorType: 'NODE_VERSION_TOO_LOW',
               message: `The resolved Node.js version is ${versionStr}. Version ${MIN_NODE_VERSION} or above is required to run the Copilot CLI.`,
             };
@@ -70,7 +194,6 @@ export async function checkEnvironment(): Promise<EnvironmentCheckResult> {
       success: false,
       nodePath: null,
       nodeVersion: null,
-      minRequiredVersion: MIN_NODE_VERSION,
       errorType: 'NODE_NOT_FOUND',
       message: `Node.js was not found on your system PATH. Node.js version ${MIN_NODE_VERSION} or above is required.`,
     };
@@ -98,7 +221,6 @@ export async function checkEnvironment(): Promise<EnvironmentCheckResult> {
               success: true,
               nodePath: candidate,
               nodeVersion: versionStr,
-              minRequiredVersion: MIN_NODE_VERSION,
               errorType: null,
               message: null,
             };
@@ -126,7 +248,6 @@ export async function checkEnvironment(): Promise<EnvironmentCheckResult> {
       success: false,
       nodePath: highestVersionFound.path,
       nodeVersion: highestVersionFound.version,
-      minRequiredVersion: MIN_NODE_VERSION,
       errorType: 'NODE_VERSION_TOO_LOW',
       message: `The resolved Node.js version is ${highestVersionFound.version}. Version ${MIN_NODE_VERSION} or above is required to run the Copilot CLI.`,
     };
@@ -136,14 +257,50 @@ export async function checkEnvironment(): Promise<EnvironmentCheckResult> {
     success: false,
     nodePath: null,
     nodeVersion: null,
-    minRequiredVersion: MIN_NODE_VERSION,
     errorType: 'NODE_NOT_FOUND',
     message: `Node.js was not found on your system PATH. Node.js version ${MIN_NODE_VERSION} or above is required.`,
   };
 }
 
+export async function checkEnvironment(): Promise<EnvironmentCheckResult> {
+  const nodeResult = await checkNodeEnvironment();
+  if (!nodeResult.success) {
+    return {
+      success: false,
+      nodePath: nodeResult.nodePath,
+      nodeVersion: nodeResult.nodeVersion,
+      minRequiredVersion: MIN_NODE_VERSION,
+      errorType: nodeResult.errorType,
+      message: nodeResult.message,
+    };
+  }
+
+  const copilotResult = await checkCopilotCli();
+  if (!copilotResult.success) {
+    return {
+      success: false,
+      nodePath: nodeResult.nodePath,
+      nodeVersion: nodeResult.nodeVersion,
+      minRequiredVersion: MIN_NODE_VERSION,
+      errorType: copilotResult.errorType,
+      message: copilotResult.message,
+      requiredCopilotVersion: copilotResult.requiredVersion,
+      installedCopilotVersion: copilotResult.installedVersion,
+    };
+  }
+
+  return {
+    success: true,
+    nodePath: nodeResult.nodePath,
+    nodeVersion: nodeResult.nodeVersion,
+    minRequiredVersion: MIN_NODE_VERSION,
+    errorType: null,
+    message: null,
+  };
+}
+
 export async function getNodePath(): Promise<string | null> {
-  const result = await checkEnvironment();
+  const result = await checkNodeEnvironment();
   return result.success ? result.nodePath : null;
 }
 
@@ -153,17 +310,32 @@ export function getCopilotScriptPath(): string | null {
     return process.env.COPILOT_SCRIPT_PATH;
   }
 
-  try {
-    // Locate the peer `@github/copilot` package directory relative to `@github/copilot-sdk`
-    // Webpack wraps require.resolve, but eval('require.resolve') runs standard Node resolution at runtime.
-    const sdkEntryPoint = eval("require.resolve('@github/copilot-sdk')");
+  // Check the managed directory first
+  const managedDir = getManagedCopilotDir();
+  const candidate = path.join(
+    managedDir,
+    'node_modules',
+    '@github',
+    'copilot',
+    'index.js',
+  );
+  if (fs.existsSync(candidate)) {
+    return candidate;
+  }
 
-    // Traverse up to find the peer `@github/copilot/index.js`
+  // Fallback to peer package resolution if running in dev/test environment
+  try {
+    const sdkEntryPoint = eval("require.resolve('@github/copilot-sdk')");
     let dir = path.dirname(sdkEntryPoint);
     for (let i = 0; i < 5; i++) {
-      const candidate = path.join(dir, '@github', 'copilot', 'index.js');
-      if (fs.existsSync(candidate)) {
-        return candidate;
+      const fallbackCandidate = path.join(
+        dir,
+        '@github',
+        'copilot',
+        'index.js',
+      );
+      if (fs.existsSync(fallbackCandidate)) {
+        return fallbackCandidate;
       }
       const parent = path.dirname(dir);
       if (parent === dir) break;
@@ -176,4 +348,100 @@ export function getCopilotScriptPath(): string | null {
     );
   }
   return null;
+}
+
+export async function installCopilotCli(): Promise<{
+  success: boolean;
+  error?: string;
+}> {
+  try {
+    const nodePath = await getNodePath();
+    if (!nodePath) {
+      return { success: false, error: 'Node.js executable not found' };
+    }
+
+    const managedDir = getManagedCopilotDir();
+
+    // Ensure the managed directory exists
+    if (!fs.existsSync(managedDir)) {
+      fs.mkdirSync(managedDir, { recursive: true });
+    }
+
+    // Write package.json if it doesn't exist
+    const pkgJsonPath = path.join(managedDir, 'package.json');
+    if (!fs.existsSync(pkgJsonPath)) {
+      fs.writeFileSync(
+        pkgJsonPath,
+        JSON.stringify(
+          {
+            name: 'stitch-copilot-cli',
+            version: '1.0.0',
+            private: true,
+          },
+          null,
+          2,
+        ),
+      );
+    }
+
+    // Locate npm relative to nodePath or fallback to system path
+    let npmCmd = 'npm';
+    const nodeDir = path.dirname(nodePath);
+    const isWin = process.platform === 'win32';
+
+    if (isWin) {
+      const candidates = [
+        path.join(nodeDir, 'npm.cmd'),
+        path.join(nodeDir, 'npm.bat'),
+        path.join(nodeDir, 'npm.exe'),
+      ];
+      for (const candidate of candidates) {
+        if (fs.existsSync(candidate)) {
+          npmCmd = candidate;
+          break;
+        }
+      }
+    } else {
+      const candidate = path.join(nodeDir, 'npm');
+      if (fs.existsSync(candidate)) {
+        npmCmd = candidate;
+      }
+    }
+
+    const requiredVersion = getRequiredCopilotVersion();
+    const pkgToInstall = `@github/copilot@${requiredVersion}`;
+
+    // Execute installation
+    const args = ['install', '--no-audit', '--no-fund', pkgToInstall];
+
+    console.log(
+      `Running install command: ${npmCmd} ${args.join(' ')} in ${managedDir}`,
+    );
+
+    if (path.isAbsolute(npmCmd)) {
+      await execFilePromise(npmCmd, args, { cwd: managedDir });
+    } else {
+      // Fallback: run via shell if npmCmd is just 'npm'
+      await execPromise(`npm install --no-audit --no-fund ${pkgToInstall}`, {
+        cwd: managedDir,
+      });
+    }
+
+    // Verify it works by checking checkCopilotCli()
+    const verifyResult = await checkCopilotCli();
+    if (!verifyResult.success) {
+      return {
+        success: false,
+        error: verifyResult.message || 'Installation verification failed.',
+      };
+    }
+
+    return { success: true };
+  } catch (err: any) {
+    console.error('Error installing Copilot CLI:', err);
+    return {
+      success: false,
+      error: err.message || 'An unknown error occurred during installation.',
+    };
+  }
 }

--- a/src/main/infrastructure/copilot/copilotDetector.ts
+++ b/src/main/infrastructure/copilot/copilotDetector.ts
@@ -351,9 +351,11 @@ export function getCopilotScriptPath(): string | null {
   );
   if (fs.existsSync(copilotDir)) {
     const pkgInfo = getCopilotPackageInfo(copilotDir);
-    const candidate = path.join(copilotDir, pkgInfo.binScript);
-    if (fs.existsSync(candidate)) {
-      return candidate;
+    if (pkgInfo) {
+      const candidate = path.join(copilotDir, pkgInfo.binScript);
+      if (fs.existsSync(candidate)) {
+        return candidate;
+      }
     }
   }
 

--- a/src/main/infrastructure/copilot/copilotDetector.ts
+++ b/src/main/infrastructure/copilot/copilotDetector.ts
@@ -10,10 +10,6 @@ const execFilePromise = promisify(execFile);
 
 const MIN_NODE_VERSION = 22;
 
-const DISABLE_WINDOWS_WORKAROUND = ['1', 'true'].includes(
-  process.env.DISABLE_COPILOT_WINDOWS_WORKAROUND || '',
-);
-
 export function getManagedCopilotDir(): string {
   try {
     return path.join(app.getPath('userData'), 'copilot-cli');
@@ -171,40 +167,6 @@ async function checkNodeEnvironment(): Promise<{
   errorType: 'NODE_NOT_FOUND' | 'NODE_VERSION_TOO_LOW' | null;
   message: string | null;
 }> {
-  // Respect user-specified NODE_PATH first
-  if (!DISABLE_WINDOWS_WORKAROUND && process.env.NODE_PATH) {
-    const nodePath = process.env.NODE_PATH;
-    if (fs.existsSync(nodePath)) {
-      try {
-        const { stdout } = await execFilePromise(nodePath, ['--version']);
-        const versionStr = stdout.trim();
-        const match = versionStr.match(/^v?(\d+)\./);
-        if (match) {
-          const majorVersion = parseInt(match[1], 10);
-          if (majorVersion >= MIN_NODE_VERSION) {
-            return {
-              success: true,
-              nodePath,
-              nodeVersion: versionStr,
-              errorType: null,
-              message: null,
-            };
-          } else {
-            return {
-              success: false,
-              nodePath,
-              nodeVersion: versionStr,
-              errorType: 'NODE_VERSION_TOO_LOW',
-              message: `The resolved Node.js version is ${versionStr}. Version ${MIN_NODE_VERSION} or above is required to run the Copilot CLI.`,
-            };
-          }
-        }
-      } catch (error: unknown) {
-        console.warn(`Failed to verify NODE_PATH version:`, error);
-      }
-    }
-  }
-
   const cmd = process.platform === 'win32' ? 'where node' : 'which -a node';
   let stdout = '';
   try {
@@ -336,11 +298,6 @@ export async function getNodePath(): Promise<string | null> {
 }
 
 export function getCopilotScriptPath(): string | null {
-  // Respect user-specified COPILOT_SCRIPT_PATH first (unless the workaround test bypass is active)
-  if (!DISABLE_WINDOWS_WORKAROUND && process.env.COPILOT_SCRIPT_PATH) {
-    return process.env.COPILOT_SCRIPT_PATH;
-  }
-
   // Check the managed directory first
   const managedDir = getManagedCopilotDir();
   const copilotDir = path.join(

--- a/src/main/infrastructure/copilot/copilotDetector.ts
+++ b/src/main/infrastructure/copilot/copilotDetector.ts
@@ -17,7 +17,7 @@ const DISABLE_WINDOWS_WORKAROUND = ['1', 'true'].includes(
 export function getManagedCopilotDir(): string {
   try {
     return path.join(app.getPath('userData'), 'copilot-cli');
-  } catch (err) {
+  } catch {
     // Fallback for tests or when app is not ready/mocked
     return path.join(process.cwd(), '.copilot-cli-test');
   }
@@ -123,12 +123,13 @@ export async function checkCopilotCli(): Promise<{
       installedVersion,
       requiredVersion,
     };
-  } catch (err: any) {
+  } catch (err: unknown) {
+    const errMsg = err instanceof Error ? err.message : String(err);
     return {
       success: false,
       errorType: 'COPILOT_CLI_MISSING',
       requiredVersion,
-      message: `Failed to read local Copilot CLI installation: ${err.message}`,
+      message: `Failed to read local Copilot CLI installation: ${errMsg}`,
     };
   }
 }
@@ -437,11 +438,12 @@ export async function installCopilotCli(): Promise<{
     }
 
     return { success: true };
-  } catch (err: any) {
+  } catch (err: unknown) {
     console.error('Error installing Copilot CLI:', err);
+    const errMsg = err instanceof Error ? err.message : String(err);
     return {
       success: false,
-      error: err.message || 'An unknown error occurred during installation.',
+      error: errMsg || 'An unknown error occurred during installation.',
     };
   }
 }

--- a/src/main/infrastructure/copilot/copilotDetector.ts
+++ b/src/main/infrastructure/copilot/copilotDetector.ts
@@ -424,7 +424,10 @@ export async function installCopilotCli(): Promise<{
     );
 
     if (path.isAbsolute(npmCmd)) {
-      await execFilePromise(npmCmd, args, { cwd: managedDir });
+      await execFilePromise(npmCmd, args, {
+        cwd: managedDir,
+        shell: process.platform === 'win32',
+      });
     } else {
       // Fallback: run via shell if npmCmd is just 'npm'
       await execPromise(`npm install --no-audit --no-fund ${pkgToInstall}`, {

--- a/src/main/infrastructure/copilot/copilotService.ts
+++ b/src/main/infrastructure/copilot/copilotService.ts
@@ -28,25 +28,23 @@ async function createCopilotClient(copilotToken?: string) {
   const nodePath = await getNodePath();
   const copilotScriptPath = getCopilotScriptPath();
 
-  // If we found both the system node and the copilot script path, spawn the Copilot CLI
-  // using the system node. This avoids Electron's process.argv parsing issues
-  // (e.g. Commander.js bug) and packaging limitations.
-  if (nodePath && copilotScriptPath) {
-    return {
-      client: new CopilotClient({
-        connection: {
-          kind: 'stdio',
-          path: nodePath,
-          args: [copilotScriptPath],
-        },
-        env,
-      }),
-      approveAll,
-    };
+  if (!nodePath || !copilotScriptPath) {
+    throw new Error(
+      `Copilot CLI client cannot be started: Node.js executable or Copilot CLI script path could not be resolved. Node.js path: ${nodePath}, Copilot script path: ${copilotScriptPath}`,
+    );
   }
 
-  // Fallback to the default platform-agnostic approach using process.execPath (Electron)
-  return { client: new CopilotClient({ env }), approveAll };
+  return {
+    client: new CopilotClient({
+      connection: {
+        kind: 'stdio',
+        path: nodePath,
+        args: [copilotScriptPath],
+      },
+      env,
+    }),
+    approveAll,
+  };
 }
 
 function parseResilientJSONL(

--- a/src/main/infrastructure/copilot/copilotService.ts
+++ b/src/main/infrastructure/copilot/copilotService.ts
@@ -3,6 +3,7 @@ import {
   checkEnvironment,
   getNodePath,
   getCopilotScriptPath,
+  installCopilotCli,
 } from './copilotDetector';
 
 // Since we dynamically import the SDK, we need to use any - disable eslint rule
@@ -114,6 +115,10 @@ export class CopilotService {
 
   async checkEnvironment(): Promise<EnvironmentCheckResult> {
     return checkEnvironment();
+  }
+
+  async installCopilotCli(): Promise<{ success: boolean; error?: string }> {
+    return installCopilotCli();
   }
 
   setModel(model: string) {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -47,6 +47,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('create-ticket', type, parentTicketId, data),
   checkCopilotAuth: () => ipcRenderer.invoke('check-copilot-auth'),
   checkEnvironment: () => ipcRenderer.invoke('check-environment'),
+  installCopilotCli: () => ipcRenderer.invoke('install-copilot-cli'),
   getVersionStatus: () => ipcRenderer.invoke('get-version-status'),
   listCopilotModels: () => ipcRenderer.invoke('list-copilot-models'),
   openExternal: (url: string) => ipcRenderer.invoke('open-external', url),

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -49,10 +49,11 @@ const App: React.FC = () => {
         setInstallStatus('error');
         setInstallError(res.error || 'Unknown error occurred.');
       }
-    } catch (err: any) {
+    } catch (err: unknown) {
       setInstallStatus('error');
+      const errMsg = err instanceof Error ? err.message : String(err);
       setInstallError(
-        err.message || 'An error occurred during installer execution.',
+        errMsg || 'An error occurred during installer execution.',
       );
     }
   };

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -17,6 +17,45 @@ const App: React.FC = () => {
   const [updateStatus, setUpdateStatus] = useState<UpdateStatus | null>(null);
   const [envCheckResult, setEnvCheckResult] =
     useState<EnvironmentCheckResult | null>(null);
+  const [installStatus, setInstallStatus] = useState<
+    'idle' | 'installing' | 'success' | 'error'
+  >('idle');
+  const [installError, setInstallError] = useState<string | null>(null);
+
+  const handleInstallCopilot = async () => {
+    setInstallStatus('installing');
+    setInstallError(null);
+    try {
+      const res = await window.electronAPI.installCopilotCli();
+      if (res.success) {
+        setInstallStatus('success');
+        setTimeout(async () => {
+          try {
+            const result = await window.electronAPI.checkEnvironment();
+            if (result.success) {
+              setEnvCheckResult(null);
+            } else {
+              setEnvCheckResult(result);
+            }
+          } catch (err) {
+            console.error(
+              'Failed to run environment check after install:',
+              err,
+            );
+          }
+          setInstallStatus('idle');
+        }, 1500);
+      } else {
+        setInstallStatus('error');
+        setInstallError(res.error || 'Unknown error occurred.');
+      }
+    } catch (err: any) {
+      setInstallStatus('error');
+      setInstallError(
+        err.message || 'An error occurred during installer execution.',
+      );
+    }
+  };
 
   useEffect(() => {
     const runEnvCheck = async () => {
@@ -127,34 +166,126 @@ const App: React.FC = () => {
 
         {envCheckResult && (
           <div className="env-error-overlay">
-            <div className="env-error-modal">
-              <div className="env-error-icon">
-                <i className="fas fa-exclamation-triangle"></i>
+            {envCheckResult.errorType === 'NODE_NOT_FOUND' ||
+            envCheckResult.errorType === 'NODE_VERSION_TOO_LOW' ? (
+              <div className="env-error-modal">
+                <div className="env-error-icon">
+                  <i className="fas fa-exclamation-triangle"></i>
+                </div>
+                <h4 className="env-error-title">Node.js Upgrade Required</h4>
+                <p className="env-error-message text-center">
+                  {envCheckResult.message}
+                </p>
+                <div className="env-error-details">
+                  Stitch requires Node.js v{envCheckResult.minRequiredVersion}{' '}
+                  or above to communicate with the GitHub Copilot CLI safely and
+                  reliably. Please install the latest LTS version of Node.js and
+                  restart the application.
+                </div>
+                <div className="env-error-actions">
+                  <button
+                    className="btn btn-indigo btn-lg"
+                    onClick={async () => {
+                      await window.electronAPI.openExternal(
+                        'https://nodejs.org/',
+                      );
+                    }}
+                  >
+                    <i className="fas fa-download me-2"></i>
+                    Download Node.js
+                  </button>
+                </div>
               </div>
-              <h4 className="env-error-title">Node.js Upgrade Required</h4>
-              <p className="env-error-message text-center">
-                {envCheckResult.message}
-              </p>
-              <div className="env-error-details">
-                Stitch requires Node.js v{envCheckResult.minRequiredVersion} or
-                above to communicate with the GitHub Copilot CLI safely and
-                reliably. Please install the latest LTS version of Node.js and
-                restart the application.
+            ) : (
+              <div className="env-error-modal">
+                {installStatus === 'idle' && (
+                  <>
+                    <div className="env-error-icon info">
+                      <i className="fas fa-cloud-download-alt"></i>
+                    </div>
+                    <h4 className="env-error-title">
+                      {envCheckResult.errorType === 'COPILOT_CLI_OUTDATED'
+                        ? 'Update Required'
+                        : 'Setup Required'}
+                    </h4>
+                    <p className="env-error-message text-center">
+                      {envCheckResult.errorType === 'COPILOT_CLI_OUTDATED'
+                        ? 'Stitch needs to update its internal copy of GitHub Copilot CLI.'
+                        : 'Stitch needs to install an internal copy of GitHub Copilot CLI.'}
+                    </p>
+                    <div className="env-error-details">
+                      This process is automated. We will set up this dependency
+                      securely within the application data directory.
+                    </div>
+                    <div className="env-error-actions">
+                      <button
+                        className="btn btn-indigo btn-lg"
+                        onClick={handleInstallCopilot}
+                      >
+                        <i className="fas fa-tools me-2"></i>
+                        {envCheckResult.errorType === 'COPILOT_CLI_OUTDATED'
+                          ? 'Update CLI'
+                          : 'Install CLI'}
+                      </button>
+                    </div>
+                  </>
+                )}
+                {installStatus === 'installing' && (
+                  <>
+                    <div className="env-error-icon info">
+                      <i className="fas fa-circle-notch fa-spin"></i>
+                    </div>
+                    <h4 className="env-error-title">Installing Dependency</h4>
+                    <p className="env-error-message text-center">
+                      Downloading and setting up the internal GitHub Copilot
+                      CLI...
+                    </p>
+                    <div className="env-error-details">
+                      This may take a moment. Please keep the application
+                      running.
+                    </div>
+                  </>
+                )}
+                {installStatus === 'success' && (
+                  <>
+                    <div className="env-error-icon success">
+                      <i className="fas fa-check-circle"></i>
+                    </div>
+                    <h4 className="env-error-title">Installation Complete</h4>
+                    <p className="env-error-message text-center">
+                      GitHub Copilot CLI was successfully installed.
+                    </p>
+                    <div className="env-error-details">
+                      Verifying setup and loading Stitch dashboard...
+                    </div>
+                  </>
+                )}
+                {installStatus === 'error' && (
+                  <>
+                    <div className="env-error-icon">
+                      <i className="fas fa-exclamation-triangle"></i>
+                    </div>
+                    <h4 className="env-error-title">Installation Failed</h4>
+                    <p className="env-error-message text-center text-danger">
+                      {installError || 'An unexpected error occurred.'}
+                    </p>
+                    <div className="env-error-details">
+                      Please make sure you have an active internet connection
+                      and that Node.js is configured correctly.
+                    </div>
+                    <div className="env-error-actions">
+                      <button
+                        className="btn btn-indigo btn-lg"
+                        onClick={handleInstallCopilot}
+                      >
+                        <i className="fas fa-redo me-2"></i>
+                        Retry Installation
+                      </button>
+                    </div>
+                  </>
+                )}
               </div>
-              <div className="env-error-actions">
-                <button
-                  className="btn btn-indigo btn-lg"
-                  onClick={async () => {
-                    await window.electronAPI.openExternal(
-                      'https://nodejs.org/',
-                    );
-                  }}
-                >
-                  <i className="fas fa-download me-2"></i>
-                  Download Node.js
-                </button>
-              </div>
-            </div>
+            )}
           </div>
         )}
       </Router>

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -36,6 +36,7 @@ export interface IElectronAPI {
 
   checkCopilotAuth: () => Promise<CopilotAuth>;
   checkEnvironment: () => Promise<EnvironmentCheckResult>;
+  installCopilotCli: () => Promise<{ success: boolean; error?: string }>;
   getVersionStatus: () => Promise<UpdateStatus>;
   listCopilotModels: () => Promise<CopilotModel[]>;
   openExternal: (url: string) => Promise<void>;

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -440,6 +440,20 @@ textarea,
   animation: pulse 2s infinite;
 }
 
+.env-error-icon.info {
+  background: rgba(13, 110, 253, 0.1);
+  color: #0d6efd;
+  box-shadow: 0 0 20px rgba(13, 110, 253, 0.15);
+  animation: none;
+}
+
+.env-error-icon.success {
+  background: rgba(25, 135, 84, 0.1);
+  color: #198754;
+  box-shadow: 0 0 20px rgba(25, 135, 84, 0.15);
+  animation: none;
+}
+
 .env-error-title {
   font-weight: 700;
   font-size: 22px;

--- a/src/types.ts
+++ b/src/types.ts
@@ -81,6 +81,13 @@ export interface EnvironmentCheckResult {
   nodePath: string | null;
   nodeVersion: string | null;
   minRequiredVersion: number;
-  errorType: 'NODE_NOT_FOUND' | 'NODE_VERSION_TOO_LOW' | null;
+  errorType:
+    | 'NODE_NOT_FOUND'
+    | 'NODE_VERSION_TOO_LOW'
+    | 'COPILOT_CLI_MISSING'
+    | 'COPILOT_CLI_OUTDATED'
+    | null;
   message: string | null;
+  requiredCopilotVersion?: string;
+  installedCopilotVersion?: string;
 }


### PR DESCRIPTION
Resolves #101 

Instead of requiring the user to manually configure `NODE_PATH` and `COPILOT_SCRIPT_PATH` environment variables, and deal with those becoming outdated, we change the app to self-manage in a 2-step process.

1. Firstly, we check `which` (*nix) or `where` (windows) for Node, and iterate over all the matches, finding one which meets our minimum requirements. If no matches are found, we display a modal requesting the user install Node first before continuing. They need to relaunch the app once NodeJS is installed to ensure the PATH is updated.
2. Secondly, we check if a local instance of the GitHub Copilot CLI is present in the app's data directory. If not (or it is outdated) we prompt the user to install/update it before continuing. Once complete they can continue to use the app.