### PR TITLE
feat: Allow story elaborator to read linked documents

### DIFF
--- a/src/main/features/story-elaborator/__tests__/storyElaboratorService.test.ts
+++ b/src/main/features/story-elaborator/__tests__/storyElaboratorService.test.ts
@@ -85,7 +85,10 @@ describe('StoryElaborator feature', () => {
         sendAndCollectStream: vi.fn().mockResolvedValue('Mocked response'),
         getModel: vi.fn().mockReturnValue('auto'),
       };
-      service = new StoryElaboratorService(mockCopilotService);
+      service = new StoryElaboratorService(
+        mockCopilotService,
+        async () => null,
+      );
     });
 
     it('should start story elaboration and store session in active map', async () => {
@@ -132,6 +135,186 @@ describe('StoryElaborator feature', () => {
       await service.stopStoryElaboration('US-1');
       expect(mockSession.disconnect).toHaveBeenCalled();
       expect(mockClient.stop).toHaveBeenCalled();
+    });
+  });
+
+  describe('StoryElaboratorService with Documentation Retrieval', () => {
+    let mockCopilotService: any;
+    let mockDocProvider: any;
+    let service: StoryElaboratorService;
+    const mockClient = { stop: vi.fn() };
+    const mockSession = { disconnect: vi.fn() };
+
+    beforeEach(() => {
+      mockDocProvider = {
+        isDocPageUrl: vi.fn((url) => url.includes('confluence.com')),
+        extractPageId: vi.fn((url) => {
+          const match = url.match(/pages\/(\d+)/);
+          return match ? match[1] : null;
+        }),
+        fetchPage: vi.fn((id) =>
+          Promise.resolve({
+            id,
+            title: `Doc ${id}`,
+            body: `Content of Doc ${id}`,
+          }),
+        ),
+      };
+
+      mockCopilotService = {
+        createClientAndSession: vi
+          .fn()
+          .mockResolvedValue({ client: mockClient, session: mockSession }),
+        sendAndCollectStream: vi.fn(),
+      };
+
+      service = new StoryElaboratorService(
+        mockCopilotService,
+        async () => mockDocProvider,
+      );
+    });
+
+    it('should find Confluence links in description/acceptance criteria, fetch metadata, and pass to prompt', async () => {
+      const ticket: TicketData = {
+        id: 'US-100',
+        title: 'Need info from doc',
+        description: 'See https://confluence.com/pages/11111 for details.',
+        acceptanceCriteria: 'Must adhere to https://confluence.com/pages/22222',
+      };
+
+      mockCopilotService.sendAndCollectStream.mockResolvedValueOnce(
+        JSON.stringify({ type: 'status', text: 'Elaborating...' }),
+      );
+
+      await service.startStoryElaboration(
+        ticket,
+        null,
+        '',
+        'gpt-4',
+        defaultSettings,
+      );
+
+      // Verify page metadata was fetched
+      expect(mockDocProvider.fetchPage).toHaveBeenCalledWith('11111');
+      expect(mockDocProvider.fetchPage).toHaveBeenCalledWith('22222');
+
+      // Verify the prompt passed to copilot contained the known docs list
+      expect(mockCopilotService.sendAndCollectStream).toHaveBeenCalledWith(
+        mockSession,
+        expect.stringContaining('- "Doc 11111" (ID: 11111)'),
+        undefined,
+        expect.any(Function),
+      );
+    });
+
+    it('should recursively fetch and feed back documents requested via request_doc', async () => {
+      const ticket: TicketData = {
+        id: 'US-200',
+        title: 'Story 200',
+        description: 'No links here',
+      };
+
+      // 1. Initial turn: Agent requests doc 123
+      mockCopilotService.sendAndCollectStream.mockResolvedValueOnce(
+        JSON.stringify({ type: 'request_doc', documentId: '123' }),
+      );
+
+      // 2. Second turn: Agent gets doc content, then responds with a clarifying question
+      mockCopilotService.sendAndCollectStream.mockResolvedValueOnce(
+        JSON.stringify({ type: 'question', text: 'Which DB field?' }),
+      );
+
+      const onLineSpy = vi.fn();
+
+      const result = await service.startStoryElaboration(
+        ticket,
+        null,
+        '',
+        'gpt-4',
+        defaultSettings,
+        onLineSpy,
+      );
+
+      // Verify final response is the question
+      expect(result).toContain('Which DB field?');
+
+      // Verify Confluence fetch occurred
+      expect(mockDocProvider.fetchPage).toHaveBeenCalledWith('123');
+
+      // Verify the document content was sent back to copilot
+      expect(mockCopilotService.sendAndCollectStream).toHaveBeenNthCalledWith(
+        2,
+        mockSession,
+        expect.stringContaining('Content of Doc 123'),
+        onLineSpy,
+        expect.any(Function),
+      );
+
+      // Verify the status updates were streamed back to the renderer
+      expect(onLineSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          '"type":"status","text":"Agent requesting document ID: 123..."',
+        ),
+      );
+      expect(onLineSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          '"type":"status","text":"Agent viewed document: Doc 123"',
+        ),
+      );
+    });
+
+    it('should refuse to fetch a document that has already been provided to prevent loops', async () => {
+      const ticket: TicketData = {
+        id: 'US-300',
+        title: 'Story 300',
+        description: 'No links',
+      };
+
+      // 1. Initial turn: Agent requests doc 999
+      mockCopilotService.sendAndCollectStream.mockResolvedValueOnce(
+        JSON.stringify({ type: 'request_doc', documentId: '999' }),
+      );
+
+      // 2. Second turn: Agent receives doc 999, then requests it AGAIN (duplicate)
+      mockCopilotService.sendAndCollectStream.mockResolvedValueOnce(
+        JSON.stringify({ type: 'request_doc', documentId: '999' }),
+      );
+
+      // 3. Third turn: Agent receives error about duplicate request, then asks a question
+      mockCopilotService.sendAndCollectStream.mockResolvedValueOnce(
+        JSON.stringify({ type: 'question', text: 'Understood' }),
+      );
+
+      const onLineSpy = vi.fn();
+
+      await service.startStoryElaboration(
+        ticket,
+        null,
+        '',
+        'gpt-4',
+        defaultSettings,
+        onLineSpy,
+      );
+
+      // Verify doc 999 was only fetched ONCE from confluence
+      expect(mockDocProvider.fetchPage).toHaveBeenCalledTimes(1);
+
+      // Verify that the duplicate warning was fed back to copilot
+      expect(mockCopilotService.sendAndCollectStream).toHaveBeenLastCalledWith(
+        mockSession,
+        expect.stringContaining(
+          'already been provided to you. Do not request it again',
+        ),
+        onLineSpy,
+        expect.any(Function),
+      );
+
+      // Verify status update for duplicate warning was streamed to user
+      expect(onLineSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          '"type":"status","text":"Agent requested duplicate document ID: 999 (declined)"',
+        ),
+      );
     });
   });
 });

--- a/src/main/features/story-elaborator/__tests__/storyElaboratorService.test.ts
+++ b/src/main/features/story-elaborator/__tests__/storyElaboratorService.test.ts
@@ -253,11 +253,6 @@ describe('StoryElaborator feature', () => {
       // Verify the status updates were streamed back to the renderer
       expect(onLineSpy).toHaveBeenCalledWith(
         expect.stringContaining(
-          '"type":"status","text":"Agent requesting document ID: 123..."',
-        ),
-      );
-      expect(onLineSpy).toHaveBeenCalledWith(
-        expect.stringContaining(
           '"type":"status","text":"Agent viewed document: Doc 123"',
         ),
       );

--- a/src/main/features/story-elaborator/storyElaboratorPrompts.ts
+++ b/src/main/features/story-elaborator/storyElaboratorPrompts.ts
@@ -5,6 +5,7 @@ export function buildStoryElaboratorPrompt(
   additionalContext: string,
   settings: AppSettings,
   hasRepo: boolean,
+  knownDocs?: { id: string; title: string }[],
 ): string {
   const customGeneral = settings.prompts?.storyElaborator?.general || '';
 
@@ -22,6 +23,17 @@ Do NOT attempt to run any filesystem or command tools, as no repository context 
 `;
   }
 
+  let docsInstructions = '';
+  if (knownDocs && knownDocs.length > 0) {
+    const docsList = knownDocs
+      .map((d) => `- "${d.title}" (ID: ${d.id})`)
+      .join('\n');
+    docsInstructions = `
+You have identified the following documentation links in this ticket. You can request the content of any of these documents using the "request_doc" command.
+${docsList}
+`;
+  }
+
   return `
 You are a Story Elaborator. Your task is to elaborate the following user story / ticket into a detailed implementation plan.
 ${customGeneral ? `\n${customGeneral}\n` : ''}
@@ -33,6 +45,7 @@ Acceptance Criteria: ${ticketData.acceptanceCriteria || 'N/A'}
 Additional Context: ${additionalContext || 'None provided'}
 
 ${repoInstructions}
+${docsInstructions}
 
 Once you have enough information, generate the final plan in markdown format and output it in a "plan" message.
 If you have access to the repository you are forbidden from modifying, creating, or deleting any files. You must only read.
@@ -52,12 +65,16 @@ You must choose one of the following JSON formats for each line you output:
 3. The Final Plan (when all questions are answered and the plan is ready. In this case, output a single JSON object:
    \`{"type": "plan", "text": "# Detailed Implementation Plan\\n\\n### Proposed Changes..."}\`
 
+4. Request Documentation (if you want to fetch and read the content of a known Confluence page):
+   \`{"type": "request_doc", "documentId": "12345"}\` or \`{"type": "request_doc", "id": "12345"}\`
+   *IMPORTANT*: When you request documentation, you must not output any other JSON lines in that turn. You must end your turn immediately so the host application can retrieve the document and provide it to you.
+
 Follow this process:
-1. Analyze the ticket and, if a repository is available, inspect the files using your tools to understand the codebase.
-2. If you are still analyzing or reading files, call your filesystem/grep tools to continue. Each turn where you do not call a tool must ask the user a clarifying question or present the final plan. Do not stop without either calling a tool or asking a question/plan.
-3. Ask clarifying questions one by one, stopping after each question to wait for the user's response.
-4. Once all details are resolved, draft the detailed implementation plan.
-6. Finally, return the "plan" message in JSONL format.
+1. Analyze the ticket, and if a repository is available, inspect the files using your tools.
+2. If you want to request any of the known documents, output the "request_doc" message in JSONL and end your turn. The host application will fetch it and provide the document content in the next turn.
+3. If you are still analyzing or reading files, call your filesystem/grep tools to continue. Each turn where you do not call a tool must ask the user a clarifying question, request a document, or present the final plan. Do not stop without either calling a tool or asking a question/requesting a document/plan.
+4. Ask clarifying questions one by one, stopping after each question to wait for the user's response.
+5. Once all details are resolved, draft the detailed implementation plan and return the "plan" message in JSONL format.
 
 You are forbidden from ending the interaction without returning the "plan" message in JSONL format.
 

--- a/src/main/features/story-elaborator/storyElaboratorService.ts
+++ b/src/main/features/story-elaborator/storyElaboratorService.ts
@@ -1,12 +1,19 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { TicketData, AppSettings } from '../../../types';
 import { CopilotService } from '../../infrastructure/copilot/copilotService';
+import { DocumentationProvider } from '../../infrastructure/providers/DocumentationProvider';
 import { buildStoryElaboratorPrompt } from './storyElaboratorPrompts';
 
 export class StoryElaboratorService {
-  private activeElaborations = new Map<string, { client: any; session: any }>();
+  private activeElaborations = new Map<
+    string,
+    { client: any; session: any; providedDocIds: Set<string> }
+  >();
 
-  constructor(private copilotService: CopilotService) {}
+  constructor(
+    private copilotService: CopilotService,
+    private getDocProvider: () => Promise<DocumentationProvider | null>,
+  ) {}
 
   async startStoryElaboration(
     ticketData: TicketData,
@@ -27,35 +34,56 @@ export class StoryElaboratorService {
           repoPath ? { workingDirectory: repoPath } : { availableTools: [] },
         );
 
+      const providedDocIds = new Set<string>();
       // Store in map so we can continue or stop later
-      this.activeElaborations.set(ticketData.id || '', { client, session });
+      this.activeElaborations.set(ticketData.id || '', {
+        client,
+        session,
+        providedDocIds,
+      });
+
+      // Find links and fetch titles for knownDocs
+      const knownDocs: { id: string; title: string }[] = [];
+      const docProvider = await this.getDocProvider();
+      if (docProvider) {
+        const urls = [
+          ...this.extractUrls(ticketData.description || ''),
+          ...this.extractUrls(ticketData.acceptanceCriteria || ''),
+        ];
+        const pageIds = Array.from(
+          new Set(
+            urls
+              .filter((url) => docProvider.isDocPageUrl(url))
+              .map((url) => docProvider.extractPageId(url))
+              .filter((id): id is string => id !== null),
+          ),
+        );
+
+        for (const pageId of pageIds) {
+          try {
+            const page = await docProvider.fetchPage(pageId);
+            knownDocs.push({ id: page.id, title: page.title });
+          } catch (e) {
+            console.error(
+              `Failed to fetch metadata for Confluence page ${pageId}:`,
+              e,
+            );
+            knownDocs.push({ id: pageId, title: `Document ID: ${pageId}` });
+          }
+        }
+      }
 
       const prompt = buildStoryElaboratorPrompt(
         ticketData,
         additionalContext,
         settings,
         !!repoPath,
+        knownDocs,
       );
 
-      return await this.copilotService.sendAndCollectStream(
-        session,
-        prompt,
-        onLine,
-        (type, tool, success, error, args) => {
-          if (onLine) {
-            onLine(
-              JSON.stringify({
-                type: 'tool',
-                status: type,
-                name: tool,
-                success,
-                error,
-                arguments: args,
-              }),
-            );
-          }
-        },
-      );
+      console.log(prompt);
+
+      return await this.runElaborationTurn(ticketData.id || '', prompt, onLine);
     } catch (error) {
       console.error('Error starting story elaboration:', error);
       // Clean up if it failed
@@ -69,41 +97,181 @@ export class StoryElaboratorService {
     answer: string,
     onLine?: (line: string) => void,
   ): Promise<string> {
+    return await this.runElaborationTurn(ticketId, answer, onLine);
+  }
+
+  private async runElaborationTurn(
+    ticketId: string,
+    inputContent: string,
+    onLine?: (line: string) => void,
+  ): Promise<string> {
     const data = this.activeElaborations.get(ticketId);
     if (!data) {
       throw new Error(
         `No active story elaboration session found for ticket ID: ${ticketId}`,
       );
     }
+    const { session, providedDocIds } = data;
 
-    const { session } = data;
-    try {
-      return await this.copilotService.sendAndCollectStream(
-        session,
-        answer,
-        onLine,
-        (type, tool, success, error, args) => {
+    const onToolCallback = (
+      type: 'start' | 'end',
+      tool: string,
+      success?: boolean,
+      error?: string,
+      args?: any,
+    ) => {
+      if (onLine) {
+        onLine(
+          JSON.stringify({
+            type: 'tool',
+            status: type,
+            name: tool,
+            success,
+            error,
+            arguments: args,
+          }),
+        );
+      }
+    };
+
+    let response = await this.copilotService.sendAndCollectStream(
+      session,
+      inputContent,
+      onLine,
+      onToolCallback,
+    );
+
+    let requestedDocId = this.extractDocRequest(response);
+    while (requestedDocId) {
+      const docProvider = await this.getDocProvider();
+      if (!docProvider) {
+        const errorMsg =
+          'Documentation provider not configured. Cannot retrieve document.';
+        if (onLine) {
+          onLine(JSON.stringify({ type: 'status', text: errorMsg }));
+        }
+        response = await this.copilotService.sendAndCollectStream(
+          session,
+          `Error: ${errorMsg}`,
+          onLine,
+          onToolCallback,
+        );
+      } else if (providedDocIds.has(requestedDocId)) {
+        const warningMsg = `Document with ID ${requestedDocId} has already been provided to you. Do not request it again. Use the information already in your context.`;
+        if (onLine) {
+          onLine(
+            JSON.stringify({
+              type: 'status',
+              text: `Agent requested duplicate document ID: ${requestedDocId} (declined)`,
+            }),
+          );
+        }
+        response = await this.copilotService.sendAndCollectStream(
+          session,
+          `Error: ${warningMsg}`,
+          onLine,
+          onToolCallback,
+        );
+      } else {
+        try {
           if (onLine) {
             onLine(
               JSON.stringify({
-                type: 'tool',
-                status: type,
-                name: tool,
-                success,
-                error,
-                arguments: args,
+                type: 'status',
+                text: `Agent requesting document ID: ${requestedDocId}...`,
               }),
             );
           }
-        },
-      );
-    } catch (error) {
-      console.error(
-        `Error sending answer to story elaboration session for ticket ${ticketId}:`,
-        error,
-      );
-      throw error;
+          const page = await docProvider.fetchPage(requestedDocId);
+          providedDocIds.add(requestedDocId);
+
+          if (onLine) {
+            onLine(
+              JSON.stringify({
+                type: 'status',
+                text: `Agent viewed document: ${page.title}`,
+              }),
+            );
+          }
+
+          const docPrompt = `
+Here is the requested document content:
+Title: ${page.title}
+ID: ${page.id}
+Content:
+${page.body}
+`;
+          response = await this.copilotService.sendAndCollectStream(
+            session,
+            docPrompt,
+            onLine,
+            onToolCallback,
+          );
+        } catch (e: any) {
+          const errorMsg = `Failed to fetch document: ${e.message || e}`;
+          if (onLine) {
+            onLine(JSON.stringify({ type: 'status', text: errorMsg }));
+          }
+          response = await this.copilotService.sendAndCollectStream(
+            session,
+            `Error: ${errorMsg}`,
+            onLine,
+            onToolCallback,
+          );
+        }
+      }
+
+      requestedDocId = this.extractDocRequest(response);
     }
+
+    return response;
+  }
+
+  private extractUrls(text: string): string[] {
+    const urls: string[] = [];
+    const hrefRegex = /href=["'](https?:\/\/[^"']+)["']/gi;
+    let match;
+    while ((match = hrefRegex.exec(text)) !== null) {
+      urls.push(match[1]);
+    }
+    const rawRegex = /(https?:\/\/[^\s"<>]+)/gi;
+    while ((match = rawRegex.exec(text)) !== null) {
+      const url = match[1].replace(/[.,;:!?)]+$/, '');
+      if (!urls.includes(url)) {
+        urls.push(url);
+      }
+    }
+    return urls;
+  }
+
+  private extractDocRequest(text: string): string | null {
+    const lines = text.split('\n');
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        const obj = JSON.parse(trimmed);
+        if (obj && obj.type === 'request_doc') {
+          return obj.documentId || obj.id || null;
+        }
+      } catch {
+        // Ignore
+      }
+    }
+
+    const regex =
+      /"type"\s*:\s*"request_doc"\s*,\s*"(documentId|id)"\s*:\s*"([^"]+)"/i;
+    const match = regex.exec(text);
+    if (match) {
+      return match[2];
+    }
+    const regexAlt =
+      /"(documentId|id)"\s*:\s*"([^"]+)"\s*,\s*"type"\s*:\s*"request_doc"/i;
+    const matchAlt = regexAlt.exec(text);
+    if (matchAlt) {
+      return matchAlt[2];
+    }
+    return null;
   }
 
   async stopStoryElaboration(ticketId: string): Promise<void> {

--- a/src/main/features/story-elaborator/storyElaboratorService.ts
+++ b/src/main/features/story-elaborator/storyElaboratorService.ts
@@ -174,14 +174,6 @@ export class StoryElaboratorService {
         );
       } else {
         try {
-          if (onLine) {
-            onLine(
-              JSON.stringify({
-                type: 'status',
-                text: `Agent requesting document ID: ${requestedDocId}...`,
-              }),
-            );
-          }
           const page = await docProvider.fetchPage(requestedDocId);
           providedDocIds.add(requestedDocId);
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -47,7 +47,16 @@ let confluenceService: DocumentationProvider | null = null;
 const copilotService = new CopilotService();
 const storyWriterService = new StoryWriterService(copilotService);
 const testCaseWriterService = new TestCaseWriterService(copilotService);
-const storyElaboratorService = new StoryElaboratorService(copilotService);
+const storyElaboratorService = new StoryElaboratorService(
+  copilotService,
+  async () => {
+    try {
+      return await getConfluenceService();
+    } catch {
+      return null;
+    }
+  },
+);
 const promptComplexityService = new PromptComplexityService(copilotService);
 
 // Handle creating/removing shortcuts on Windows when installing/uninstalling.

--- a/src/main/infrastructure/confluence/__tests__/confluenceService.test.ts
+++ b/src/main/infrastructure/confluence/__tests__/confluenceService.test.ts
@@ -278,4 +278,107 @@ describe('ConfluenceService', () => {
       ]);
     });
   });
+
+  describe('isDocPageUrl and extractPageId', () => {
+    const service = new ConfluenceService(
+      'myorg.atlassian.net',
+      'user',
+      'token',
+    );
+
+    describe('isDocPageUrl', () => {
+      it('should return true for valid confluence URLs matching base URL and containing a numeric page ID', () => {
+        expect(
+          service.isDocPageUrl(
+            'https://myorg.atlassian.net/wiki/spaces/SPACE/pages/12345',
+          ),
+        ).toBe(true);
+        expect(
+          service.isDocPageUrl(
+            'https://myorg.atlassian.net/wiki/spaces/SPACE/pages/12345/Title',
+          ),
+        ).toBe(true);
+        expect(
+          service.isDocPageUrl(
+            'https://myorg.atlassian.net/wiki/pages/viewpage.action?pageId=12345',
+          ),
+        ).toBe(true);
+        expect(
+          service.isDocPageUrl(
+            'http://myorg.atlassian.net/wiki/pages/viewpage.action?pageId=12345',
+          ),
+        ).toBe(true);
+      });
+
+      it('should return false for different hostnames or invalid patterns', () => {
+        expect(
+          service.isDocPageUrl(
+            'https://otherorg.atlassian.net/wiki/spaces/SPACE/pages/12345',
+          ),
+        ).toBe(false);
+        expect(
+          service.isDocPageUrl(
+            'https://myorg.atlassian.net/wiki/spaces/SPACE/pages/abc',
+          ),
+        ).toBe(false);
+        expect(
+          service.isDocPageUrl(
+            'https://myorg.atlassian.net/wiki/spaces/SPACE/',
+          ),
+        ).toBe(false);
+        expect(service.isDocPageUrl('https://google.com')).toBe(false);
+        expect(service.isDocPageUrl('')).toBe(false);
+      });
+    });
+
+    describe('extractPageId', () => {
+      it('should extract numeric page ID from path patterns', () => {
+        expect(
+          service.extractPageId(
+            'https://myorg.atlassian.net/wiki/spaces/SPACE/pages/12345',
+          ),
+        ).toBe('12345');
+        expect(
+          service.extractPageId(
+            'https://myorg.atlassian.net/wiki/spaces/SPACE/pages/12345/Page+Title',
+          ),
+        ).toBe('12345');
+      });
+
+      it('should extract numeric page ID from query param patterns', () => {
+        expect(
+          service.extractPageId(
+            'https://myorg.atlassian.net/wiki/pages/viewpage.action?pageId=67890',
+          ),
+        ).toBe('67890');
+        expect(
+          service.extractPageId(
+            'https://myorg.atlassian.net/wiki/pages/viewpage.action?foo=bar&pageId=67890',
+          ),
+        ).toBe('67890');
+      });
+
+      it('should return null if no numeric page ID can be found', () => {
+        expect(
+          service.extractPageId(
+            'https://myorg.atlassian.net/wiki/spaces/SPACE/pages/',
+          ),
+        ).toBe(null);
+        expect(
+          service.extractPageId(
+            'https://myorg.atlassian.net/wiki/spaces/SPACE/pages/abc',
+          ),
+        ).toBe(null);
+        expect(
+          service.extractPageId(
+            'https://myorg.atlassian.net/wiki/pages/viewpage.action?pageId=abc',
+          ),
+        ).toBe(null);
+        expect(service.extractPageId('https://myorg.atlassian.net/')).toBe(
+          null,
+        );
+        expect(service.extractPageId('')).toBe(null);
+      });
+    });
+  });
 });

--- a/src/main/infrastructure/confluence/confluenceService.ts
+++ b/src/main/infrastructure/confluence/confluenceService.ts
@@ -160,4 +160,49 @@ export class ConfluenceService implements DocumentationProvider {
       throw error;
     }
   }
+
+  isDocPageUrl(url: string): boolean {
+    if (!this.url || !url) return false;
+    try {
+      let base = this.url.trim();
+      if (!base.startsWith('http://') && !base.startsWith('https://')) {
+        base = `https://${base}`;
+      }
+      const configUrl = new URL(base);
+
+      const targetUrl = new URL(url.trim());
+      if (targetUrl.hostname !== configUrl.hostname) {
+        return false;
+      }
+
+      return this.extractPageId(url) !== null;
+    } catch {
+      return false;
+    }
+  }
+
+  extractPageId(url: string): string | null {
+    if (!url) return null;
+    try {
+      const parsedUrl = new URL(url.trim());
+
+      const pageId = parsedUrl.searchParams.get('pageId');
+      if (pageId && /^\d+$/.test(pageId)) {
+        return pageId;
+      }
+
+      const pathParts = parsedUrl.pathname.split('/');
+      const pagesIndex = pathParts.indexOf('pages');
+      if (pagesIndex !== -1 && pagesIndex + 1 < pathParts.length) {
+        const nextPart = pathParts[pagesIndex + 1];
+        if (/^\d+$/.test(nextPart)) {
+          return nextPart;
+        }
+      }
+
+      return null;
+    } catch {
+      return null;
+    }
+  }
 }

--- a/src/main/infrastructure/providers/DocumentationProvider.ts
+++ b/src/main/infrastructure/providers/DocumentationProvider.ts
@@ -3,4 +3,6 @@ import { DocPageData } from '../../../types';
 export interface DocumentationProvider {
   fetchPage(pageId: string): Promise<DocPageData>;
   searchPages(query: string): Promise<DocPageData[]>;
+  isDocPageUrl(url: string): boolean;
+  extractPageId(url: string): string | null;
 }


### PR DESCRIPTION
The initial implementation of the Story Elaborator was limited in that it could only use the ticket content. If the story linked to a confluence page for most details we didn't allow the agent any way to read that.

This PR allows the agent to send a structured message, using the established JSONL format, to request a document. We will then retrieve and pass the document back to the agent and notify the user that the agent read the document in the chat window.

Resolves #97 