### PR TITLE
feat: documentation retrieval tool

### DIFF
--- a/src/main/features/story-elaborator/__tests__/storyElaboratorService.test.ts
+++ b/src/main/features/story-elaborator/__tests__/storyElaboratorService.test.ts
@@ -109,7 +109,14 @@ describe('StoryElaborator feature', () => {
       expect(mockCopilotService.createClientAndSession).toHaveBeenCalledWith(
         undefined,
         'gpt-4',
-        { availableTools: [] },
+        expect.objectContaining({
+          availableTools: ['custom:request_documentation'],
+          tools: expect.arrayContaining([
+            expect.objectContaining({
+              name: 'request_documentation',
+            }),
+          ]),
+        }),
       );
       expect(mockCopilotService.sendAndCollectStream).toHaveBeenCalledWith(
         mockSession,
@@ -207,77 +214,64 @@ describe('StoryElaborator feature', () => {
       );
     });
 
-    it('should recursively fetch and feed back documents requested via request_doc', async () => {
+    it('should register request_documentation tool and fetch page content when called', async () => {
       const ticket: TicketData = {
         id: 'US-200',
         title: 'Story 200',
         description: 'No links here',
       };
 
-      // 1. Initial turn: Agent requests doc 123
       mockCopilotService.sendAndCollectStream.mockResolvedValueOnce(
-        JSON.stringify({ type: 'request_doc', documentId: '123' }),
+        JSON.stringify({ type: 'status', text: 'Elaborating...' }),
       );
 
-      // 2. Second turn: Agent gets doc content, then responds with a clarifying question
-      mockCopilotService.sendAndCollectStream.mockResolvedValueOnce(
-        JSON.stringify({ type: 'question', text: 'Which DB field?' }),
-      );
-
-      const onLineSpy = vi.fn();
-
-      const result = await service.startStoryElaboration(
+      await service.startStoryElaboration(
         ticket,
         null,
         '',
         'gpt-4',
         defaultSettings,
-        onLineSpy,
       );
 
-      // Verify final response is the question
-      expect(result).toContain('Which DB field?');
+      // Verify createClientAndSession was called with the tool
+      expect(mockCopilotService.createClientAndSession).toHaveBeenCalledWith(
+        undefined,
+        'gpt-4',
+        expect.objectContaining({
+          tools: expect.arrayContaining([
+            expect.objectContaining({
+              name: 'request_documentation',
+            }),
+          ]),
+        }),
+      );
 
-      // Verify Confluence fetch occurred
+      // Retrieve the registered tool
+      const createCallArgs =
+        mockCopilotService.createClientAndSession.mock.calls[0][2];
+      const tool = createCallArgs.tools.find(
+        (t: any) => t.name === 'request_documentation',
+      );
+      expect(tool).toBeDefined();
+
+      // Call the handler
+      const result = await tool.handler({ documentId: '123' });
+
       expect(mockDocProvider.fetchPage).toHaveBeenCalledWith('123');
-
-      // Verify the document content was sent back to copilot
-      expect(mockCopilotService.sendAndCollectStream).toHaveBeenNthCalledWith(
-        2,
-        mockSession,
-        expect.stringContaining('Content of Doc 123'),
-        onLineSpy,
-        expect.any(Function),
-      );
-
-      // Verify the status updates were streamed back to the renderer
-      expect(onLineSpy).toHaveBeenCalledWith(
-        expect.stringContaining(
-          '"type":"status","text":"Agent viewed document: Doc 123"',
-        ),
-      );
+      expect(result).toContain('Title: Doc 123');
+      expect(result).toContain('ID: 123');
+      expect(result).toContain('Content:\nContent of Doc 123');
     });
 
-    it('should refuse to fetch a document that has already been provided to prevent loops', async () => {
+    it('should refuse to fetch a duplicate document in request_documentation handler', async () => {
       const ticket: TicketData = {
         id: 'US-300',
         title: 'Story 300',
         description: 'No links',
       };
 
-      // 1. Initial turn: Agent requests doc 999
       mockCopilotService.sendAndCollectStream.mockResolvedValueOnce(
-        JSON.stringify({ type: 'request_doc', documentId: '999' }),
-      );
-
-      // 2. Second turn: Agent receives doc 999, then requests it AGAIN (duplicate)
-      mockCopilotService.sendAndCollectStream.mockResolvedValueOnce(
-        JSON.stringify({ type: 'request_doc', documentId: '999' }),
-      );
-
-      // 3. Third turn: Agent receives error about duplicate request, then asks a question
-      mockCopilotService.sendAndCollectStream.mockResolvedValueOnce(
-        JSON.stringify({ type: 'question', text: 'Understood' }),
+        JSON.stringify({ type: 'status', text: 'Elaborating...' }),
       );
 
       const onLineSpy = vi.fn();
@@ -291,20 +285,31 @@ describe('StoryElaborator feature', () => {
         onLineSpy,
       );
 
-      // Verify doc 999 was only fetched ONCE from confluence
-      expect(mockDocProvider.fetchPage).toHaveBeenCalledTimes(1);
-
-      // Verify that the duplicate warning was fed back to copilot
-      expect(mockCopilotService.sendAndCollectStream).toHaveBeenLastCalledWith(
-        mockSession,
-        expect.stringContaining(
-          'already been provided to you. Do not request it again',
-        ),
-        onLineSpy,
-        expect.any(Function),
+      const createCallArgs =
+        mockCopilotService.createClientAndSession.mock.calls[0][2];
+      const tool = createCallArgs.tools.find(
+        (t: any) => t.name === 'request_documentation',
       );
 
-      // Verify status update for duplicate warning was streamed to user
+      // Fetch once
+      const result1 = await tool.handler({ documentId: '999' });
+      expect(result1).not.toContain('Error:');
+
+      // Fetch again (duplicate)
+      const result2 = await tool.handler({ documentId: '999' });
+      expect(result2).toContain(
+        'Error: Document with ID 999 has already been provided to you',
+      );
+
+      // Doc fetch only called once
+      expect(mockDocProvider.fetchPage).toHaveBeenCalledTimes(1);
+
+      // Verify status updates were streamed via onLineSpy
+      expect(onLineSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          '"type":"status","text":"Agent viewed document: Doc 999"',
+        ),
+      );
       expect(onLineSpy).toHaveBeenCalledWith(
         expect.stringContaining(
           '"type":"status","text":"Agent requested duplicate document ID: 999 (declined)"',

--- a/src/main/features/story-elaborator/storyElaboratorPrompts.ts
+++ b/src/main/features/story-elaborator/storyElaboratorPrompts.ts
@@ -29,7 +29,7 @@ Do NOT attempt to run any filesystem or command tools, as no repository context 
       .map((d) => `- "${d.title}" (ID: ${d.id})`)
       .join('\n');
     docsInstructions = `
-You have identified the following documentation links in this ticket. You can request the content of any of these documents using the "request_doc" command.
+You have identified the following documentation links in this ticket. You can request the content of any of these documents using the "request_documentation" tool with the corresponding document ID:
 ${docsList}
 `;
   }
@@ -65,14 +65,10 @@ You must choose one of the following JSON formats for each line you output:
 3. The Final Plan (when all questions are answered and the plan is ready. In this case, output a single JSON object:
    \`{"type": "plan", "text": "# Detailed Implementation Plan\\n\\n### Proposed Changes..."}\`
 
-4. Request Documentation (if you want to fetch and read the content of a known Confluence page):
-   \`{"type": "request_doc", "documentId": "12345"}\` or \`{"type": "request_doc", "id": "12345"}\`
-   *IMPORTANT*: When you request documentation, you must not output any other JSON lines in that turn. You must end your turn immediately so the host application can retrieve the document and provide it to you.
-
 Follow this process:
 1. Analyze the ticket, and if a repository is available, inspect the files using your tools.
-2. If you want to request any of the known documents, output the "request_doc" message in JSONL and end your turn. The host application will fetch it and provide the document content in the next turn.
-3. If you are still analyzing or reading files, call your filesystem/grep tools to continue. Each turn where you do not call a tool must ask the user a clarifying question, request a document, or present the final plan. Do not stop without either calling a tool or asking a question/requesting a document/plan.
+2. If you want to request the content of any of the known documents, use the "request_documentation" tool to fetch its content.
+3. If you are still analyzing or reading files, call your filesystem/grep tools to continue. Each turn where you do not call a tool must ask the user a clarifying question or present the final plan. Do not stop without either calling a tool or asking a question/presenting the plan.
 4. Ask clarifying questions one by one, stopping after each question to wait for the user's response.
 5. Once all details are resolved, draft the detailed implementation plan and return the "plan" message in JSONL format.
 

--- a/src/main/features/story-elaborator/storyElaboratorService.ts
+++ b/src/main/features/story-elaborator/storyElaboratorService.ts
@@ -98,8 +98,6 @@ export class StoryElaboratorService {
         knownDocs,
       );
 
-      console.log(prompt);
-
       return await this.runElaborationTurn(ticketData.id || '', prompt, onLine);
     } catch (error) {
       console.error('Error starting story elaboration:', error);

--- a/src/main/features/story-elaborator/storyElaboratorService.ts
+++ b/src/main/features/story-elaborator/storyElaboratorService.ts
@@ -11,7 +11,6 @@ export class StoryElaboratorService {
     {
       client: any;
       session: any;
-      providedDocIds: Set<string>;
       onLine?: (line: string) => void;
     }
   >();
@@ -33,11 +32,8 @@ export class StoryElaboratorService {
     await this.stopStoryElaboration(ticketData.id || '');
 
     try {
-      const providedDocIds = new Set<string>();
-
       const requestDocumentationTool = createRequestDocumentationTool(
         this.getDocProvider,
-        providedDocIds,
         () => this.activeElaborations.get(ticketData.id || '')?.onLine,
       );
 
@@ -60,7 +56,6 @@ export class StoryElaboratorService {
       this.activeElaborations.set(ticketData.id || '', {
         client,
         session,
-        providedDocIds,
         onLine,
       });
 

--- a/src/main/features/story-elaborator/storyElaboratorService.ts
+++ b/src/main/features/story-elaborator/storyElaboratorService.ts
@@ -3,11 +3,17 @@ import { TicketData, AppSettings } from '../../../types';
 import { CopilotService } from '../../infrastructure/copilot/copilotService';
 import { DocumentationProvider } from '../../infrastructure/providers/DocumentationProvider';
 import { buildStoryElaboratorPrompt } from './storyElaboratorPrompts';
+import { createRequestDocumentationTool } from '../../infrastructure/copilot/tools/documentationTool';
 
 export class StoryElaboratorService {
   private activeElaborations = new Map<
     string,
-    { client: any; session: any; providedDocIds: Set<string> }
+    {
+      client: any;
+      session: any;
+      providedDocIds: Set<string>;
+      onLine?: (line: string) => void;
+    }
   >();
 
   constructor(
@@ -27,19 +33,35 @@ export class StoryElaboratorService {
     await this.stopStoryElaboration(ticketData.id || '');
 
     try {
+      const providedDocIds = new Set<string>();
+
+      const requestDocumentationTool = createRequestDocumentationTool(
+        this.getDocProvider,
+        providedDocIds,
+        () => this.activeElaborations.get(ticketData.id || '')?.onLine,
+      );
+
       const { client, session } =
         await this.copilotService.createClientAndSession(
           settings.copilotToken,
           modelOverride,
-          repoPath ? { workingDirectory: repoPath } : { availableTools: [] },
+          repoPath
+            ? {
+                workingDirectory: repoPath,
+                tools: [requestDocumentationTool],
+              }
+            : {
+                availableTools: ['custom:request_documentation'],
+                tools: [requestDocumentationTool],
+              },
         );
 
-      const providedDocIds = new Set<string>();
       // Store in map so we can continue or stop later
       this.activeElaborations.set(ticketData.id || '', {
         client,
         session,
         providedDocIds,
+        onLine,
       });
 
       // Find links and fetch titles for knownDocs
@@ -97,6 +119,10 @@ export class StoryElaboratorService {
     answer: string,
     onLine?: (line: string) => void,
   ): Promise<string> {
+    const data = this.activeElaborations.get(ticketId);
+    if (data) {
+      data.onLine = onLine;
+    }
     return await this.runElaborationTurn(ticketId, answer, onLine);
   }
 
@@ -111,7 +137,7 @@ export class StoryElaboratorService {
         `No active story elaboration session found for ticket ID: ${ticketId}`,
       );
     }
-    const { session, providedDocIds } = data;
+    const { session } = data;
 
     const onToolCallback = (
       type: 'start' | 'end',
@@ -134,89 +160,12 @@ export class StoryElaboratorService {
       }
     };
 
-    let response = await this.copilotService.sendAndCollectStream(
+    return await this.copilotService.sendAndCollectStream(
       session,
       inputContent,
       onLine,
       onToolCallback,
     );
-
-    let requestedDocId = this.extractDocRequest(response);
-    while (requestedDocId) {
-      const docProvider = await this.getDocProvider();
-      if (!docProvider) {
-        const errorMsg =
-          'Documentation provider not configured. Cannot retrieve document.';
-        if (onLine) {
-          onLine(JSON.stringify({ type: 'status', text: errorMsg }));
-        }
-        response = await this.copilotService.sendAndCollectStream(
-          session,
-          `Error: ${errorMsg}`,
-          onLine,
-          onToolCallback,
-        );
-      } else if (providedDocIds.has(requestedDocId)) {
-        const warningMsg = `Document with ID ${requestedDocId} has already been provided to you. Do not request it again. Use the information already in your context.`;
-        if (onLine) {
-          onLine(
-            JSON.stringify({
-              type: 'status',
-              text: `Agent requested duplicate document ID: ${requestedDocId} (declined)`,
-            }),
-          );
-        }
-        response = await this.copilotService.sendAndCollectStream(
-          session,
-          `Error: ${warningMsg}`,
-          onLine,
-          onToolCallback,
-        );
-      } else {
-        try {
-          const page = await docProvider.fetchPage(requestedDocId);
-          providedDocIds.add(requestedDocId);
-
-          if (onLine) {
-            onLine(
-              JSON.stringify({
-                type: 'status',
-                text: `Agent viewed document: ${page.title}`,
-              }),
-            );
-          }
-
-          const docPrompt = `
-Here is the requested document content:
-Title: ${page.title}
-ID: ${page.id}
-Content:
-${page.body}
-`;
-          response = await this.copilotService.sendAndCollectStream(
-            session,
-            docPrompt,
-            onLine,
-            onToolCallback,
-          );
-        } catch (e: any) {
-          const errorMsg = `Failed to fetch document: ${e.message || e}`;
-          if (onLine) {
-            onLine(JSON.stringify({ type: 'status', text: errorMsg }));
-          }
-          response = await this.copilotService.sendAndCollectStream(
-            session,
-            `Error: ${errorMsg}`,
-            onLine,
-            onToolCallback,
-          );
-        }
-      }
-
-      requestedDocId = this.extractDocRequest(response);
-    }
-
-    return response;
   }
 
   private extractUrls(text: string): string[] {
@@ -234,36 +183,6 @@ ${page.body}
       }
     }
     return urls;
-  }
-
-  private extractDocRequest(text: string): string | null {
-    const lines = text.split('\n');
-    for (const line of lines) {
-      const trimmed = line.trim();
-      if (!trimmed) continue;
-      try {
-        const obj = JSON.parse(trimmed);
-        if (obj && obj.type === 'request_doc') {
-          return obj.documentId || obj.id || null;
-        }
-      } catch {
-        // Ignore
-      }
-    }
-
-    const regex =
-      /"type"\s*:\s*"request_doc"\s*,\s*"(documentId|id)"\s*:\s*"([^"]+)"/i;
-    const match = regex.exec(text);
-    if (match) {
-      return match[2];
-    }
-    const regexAlt =
-      /"(documentId|id)"\s*:\s*"([^"]+)"\s*,\s*"type"\s*:\s*"request_doc"/i;
-    const matchAlt = regexAlt.exec(text);
-    if (matchAlt) {
-      return matchAlt[2];
-    }
-    return null;
   }
 
   async stopStoryElaboration(ticketId: string): Promise<void> {

--- a/src/main/infrastructure/copilot/copilotService.ts
+++ b/src/main/infrastructure/copilot/copilotService.ts
@@ -246,6 +246,7 @@ export class CopilotService {
     options: {
       workingDirectory?: string | null;
       availableTools?: any[];
+      tools?: any[];
       streaming?: boolean;
     },
   ): Promise<{ client: any; session: any; approveAll: any }> {
@@ -260,6 +261,9 @@ export class CopilotService {
       sessionOptions.workingDirectory = options.workingDirectory;
     } else if (options.availableTools) {
       sessionOptions.availableTools = options.availableTools;
+    }
+    if (options.tools) {
+      sessionOptions.tools = options.tools;
     }
     const session = await client.createSession(sessionOptions);
     return { client, session, approveAll };

--- a/src/main/infrastructure/copilot/tools/documentationTool.ts
+++ b/src/main/infrastructure/copilot/tools/documentationTool.ts
@@ -1,0 +1,72 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { DocumentationProvider } from '../../providers/DocumentationProvider';
+
+export function createRequestDocumentationTool(
+  getDocProvider: () => Promise<DocumentationProvider | null>,
+  providedDocIds: Set<string>,
+  getOnLine: () => ((line: string) => void) | undefined,
+) {
+  return {
+    name: 'request_documentation',
+    description:
+      'Request the content of a document by its ID (e.g. from Confluence) to read its content.',
+    parameters: {
+      type: 'object',
+      properties: {
+        documentId: {
+          type: 'string',
+          description: 'The ID of the document to request.',
+        },
+      },
+      required: ['documentId'],
+    },
+    handler: async (args: { documentId: string }) => {
+      const docId = args.documentId;
+      const onLine = getOnLine();
+      const docProvider = await getDocProvider();
+      if (!docProvider) {
+        const errorMsg =
+          'Documentation provider not configured. Cannot retrieve document.';
+        if (onLine) {
+          onLine(JSON.stringify({ type: 'status', text: errorMsg }));
+        }
+        return `Error: ${errorMsg}`;
+      }
+
+      if (providedDocIds.has(docId)) {
+        const warningMsg = `Document with ID ${docId} has already been provided to you. Do not request it again. Use the information already in your context.`;
+        if (onLine) {
+          onLine(
+            JSON.stringify({
+              type: 'status',
+              text: `Agent requested duplicate document ID: ${docId} (declined)`,
+            }),
+          );
+        }
+        return `Error: ${warningMsg}`;
+      }
+
+      try {
+        const page = await docProvider.fetchPage(docId);
+        providedDocIds.add(docId);
+
+        if (onLine) {
+          onLine(
+            JSON.stringify({
+              type: 'status',
+              text: `Agent viewed document: ${page.title}`,
+            }),
+          );
+        }
+
+        return `Title: ${page.title}\nID: ${page.id}\nContent:\n${page.body}`;
+      } catch (e: any) {
+        const errorMsg = `Failed to fetch document: ${e.message || e}`;
+        if (onLine) {
+          onLine(JSON.stringify({ type: 'status', text: errorMsg }));
+        }
+        return `Error: ${errorMsg}`;
+      }
+    },
+  };
+}

--- a/src/main/infrastructure/copilot/tools/documentationTool.ts
+++ b/src/main/infrastructure/copilot/tools/documentationTool.ts
@@ -3,9 +3,9 @@ import { DocumentationProvider } from '../../providers/DocumentationProvider';
 
 export function createRequestDocumentationTool(
   getDocProvider: () => Promise<DocumentationProvider | null>,
-  providedDocIds: Set<string>,
   getOnLine: () => ((line: string) => void) | undefined,
 ) {
+  const providedDocIds = new Set<string>();
   return {
     name: 'request_documentation',
     description:

--- a/src/renderer/renderer.tsx
+++ b/src/renderer/renderer.tsx
@@ -1,31 +1,3 @@
-/**
- * This file will automatically be loaded by webpack and run in the "renderer" context.
- * To learn more about the differences between the "main" and the "renderer" context in
- * Electron, visit:
- *
- * https://electronjs.org/docs/latest/tutorial/process-model
- *
- * By default, Node.js integration in this file is disabled. When enabling Node.js integration
- * in a renderer process, please be aware of potential security implications. You can read
- * more about security risks here:
- *
- * https://electronjs.org/docs/tutorial/security
- *
- * To enable Node.js integration in this file, open up `main.js` and enable the `nodeIntegration`
- * flag:
- *
- * ```
- *  // Create the browser window.
- *  mainWindow = new BrowserWindow({
- *    width: 800,
- *    height: 600,
- *    webPreferences: {
- *      nodeIntegration: true
- *    }
- *  });
- * ```
- */
-
 import 'bootstrap/dist/css/bootstrap.min.css';
 import 'bootstrap/dist/js/bootstrap.bundle.min.js';
 import '@fortawesome/fontawesome-free/css/all.min.css';
@@ -41,7 +13,3 @@ if (container) {
 } else {
   console.error('Failed to find the root element');
 }
-
-console.log(
-  '👋 This message is being logged by "renderer.js", included via webpack',
-);


### PR DESCRIPTION
Replace the existing JSONL-based documentation request approach with a dedicated tool call for the agent.

While the JSONL-based approach worked sufficiently, it was quite weird that we interrupted the agent's flow and sent the requested document as a standard message and needed to reconnect the pipes to make the process continue as a seemingly constant flow. Although this generally made some sense since the Story Elaborator had a clear interruption concept with the agent asking questions - requesting documentation can be seen as just another question from the agent, just one filled by the orchestrator rather than the user themselves.

The primary motivation to move to a proper tool is that we want to allow the new PR Reviewer feature to read the story, which may contain links to documentation and it may be valuable for the agent to read the docs. This will allow a review phase of "did we actually build what was requested?". If we stick with the previous JSONL approach we would require building the same interruption mechanism there, but this flow doesn't really have an existing interruption mechanism - the data flow is unidirectional, with the agent writing comments. If we add an interruption mechanism it will complicate the process significantly.

The other benefit is that we can back-fill this in future to open up documentation retrieval capabilities to the Test Case Writer and Story Writer features, so the agent can pull more context in those too if needed, in order to produce better results.