### PR TITLE
feat(pr-reviewer): add support for attaching linked stories

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -2,9 +2,10 @@
 
 - **Verification after changes**: Always run the linter and the tests after making any modifications to the codebase.
   - Run the linter using `npm run lint`.
+  - Run the build using `npx tsc --noEmit`
   - Run tests using `npm run test:run` (non-watch mode).
   - Ensure all checks pass before concluding a task or prompting the user for approval.
-  - Exception: Documentation-only changes (such as edits to Markdown files like `README.md`, or comment-only changes that do not affect code logic) do not require running the linter or tests.
+  - Exception: Documentation-only changes (such as edits to Markdown files like `README.md`, or comment-only changes that do not affect code logic) do not require running the linter, build, or tests.
 
 - **Committing changes**: Always commit changes using conventional commits after any change (e.g., `feat: ...`, `fix: ...`, `docs: ...`, `refactor: ...`, `chore: ...`).
   - Write a clear, concise commit message following the conventional commits format.

--- a/docs/pr-reviewer/phases.md
+++ b/docs/pr-reviewer/phases.md
@@ -45,7 +45,7 @@ Stitch:
 | `group`    | `string`   | Categorizes the phase under a group in the UI.                                                            | `"Ungrouped"`                                |
 | `include`  | `string`   | Glob pattern (parsed by `picomatch`) specifying which files must be in the PR diff for this phase to run. | None (runs on all files)                     |
 | `exclude`  | `string`   | Glob pattern specifying files that should be ignored during this phase.                                   | None                                         |
-| `attach`   | `string[]` | List of data sources to attach to the prompt context. Currently supported: `["description"]`.             | None                                         |
+| `attach`   | `string[]` | List of data sources to attach to the prompt context. Supported: `["description"]` or `["story"]`.        | None                                         |
 | `template` | `string`   | The filename of a template inside `~/.stitch/pr-reviewer/templates/` to wrap this phase's guidelines.     | None                                         |
 
 ---
@@ -69,12 +69,17 @@ filtered out by the `exclude` glob), the phase will be skipped entirely.
 ## Context Attachment (`attach`)
 
 If your phase needs additional information from the pull request (such as
-checking if the code changes meet the PR requirements), you can configure
-`attach: description`.
+checking if the code changes meet the PR requirements or user story), you can configure
+attachment sources:
 
-When set, Stitch will fetch the full pull request description via the Azure
-DevOps API and append it to the reviewer's prompt context, allowing the LLM to
-compare the changes against the stated goals of the PR.
+- **`description`**: Stitch will fetch the full pull request description via the Azure
+  DevOps API and append it to the reviewer's prompt context, allowing the LLM to
+  compare the changes against the stated goals of the PR.
+- **`story`**: Stitch will fetch the stories/work items linked to the pull request in Azure DevOps.
+  - The contents (Title, Description, and Acceptance Criteria) of the linked stories are appended to the prompt context.
+  - Any documentation/Confluence links within the stories are automatically extracted and listed.
+  - The `request_documentation` tool is registered with Copilot during this phase, enabling the LLM to request and read the full contents of these documentation pages as needed.
+  - If `attach: story` is set but there are no linked stories associated with the PR, this phase will be skipped automatically.
 
 ---
 

--- a/src/main/features/pr-reviewer/__tests__/prReviewerService.test.ts
+++ b/src/main/features/pr-reviewer/__tests__/prReviewerService.test.ts
@@ -13,7 +13,7 @@ import {
 const mockGetPullRequestById = vi.fn();
 const mockGetPullRequestsByProject = vi.fn();
 const mockCreateThread = vi.fn();
-const mockGetPullRequestWorkItems = vi.fn();
+const mockGetPullRequestWorkItemRefs = vi.fn();
 const mockConnect = vi.fn().mockResolvedValue({
   authorizedUser: { id: 'mock-user-id' },
 });
@@ -22,7 +22,7 @@ const mockGetGitApi = vi.fn().mockResolvedValue({
   getPullRequestById: mockGetPullRequestById,
   getPullRequestsByProject: mockGetPullRequestsByProject,
   createThread: mockCreateThread,
-  getPullRequestWorkItems: mockGetPullRequestWorkItems,
+  getPullRequestWorkItemRefs: mockGetPullRequestWorkItemRefs,
 });
 const mockWebApi = {
   getGitApi: mockGetGitApi,
@@ -81,7 +81,7 @@ describe('PRReviewerService', () => {
     vi.spyOn(fs, 'mkdirSync').mockImplementation(() => undefined as any);
     mockGetPullRequestById.mockReset();
     mockGetPullRequestsByProject.mockReset();
-    mockGetPullRequestWorkItems.mockReset();
+    mockGetPullRequestWorkItemRefs.mockReset();
     mockConnect.mockClear();
     mockGetGitApi.mockClear();
     mockPowerSaveBlockerStart.mockClear().mockReturnValue(42);
@@ -687,7 +687,7 @@ describe('PRReviewerService', () => {
         createdBy: { displayName: 'John Doe' },
         repository: { id: 'repo-123', name: 'my-repo' },
       });
-      mockGetPullRequestWorkItems.mockResolvedValue([{ id: 'story-123' }]);
+      mockGetPullRequestWorkItemRefs.mockResolvedValue([{ id: 'story-123' }]);
 
       const mockIssueTracker = {
         fetchTicket: vi.fn().mockResolvedValue({
@@ -746,7 +746,10 @@ describe('PRReviewerService', () => {
         },
       );
 
-      expect(mockGetPullRequestWorkItems).toHaveBeenCalledWith('repo-123', 123);
+      expect(mockGetPullRequestWorkItemRefs).toHaveBeenCalledWith(
+        'repo-123',
+        123,
+      );
       expect(mockIssueTracker.fetchTicket).toHaveBeenCalledWith('story-123');
 
       expect(mockCopilotService.createClientAndSession).toHaveBeenCalledWith(
@@ -789,7 +792,7 @@ describe('PRReviewerService', () => {
         createdBy: { displayName: 'John Doe' },
         repository: { id: 'repo-123', name: 'my-repo' },
       });
-      mockGetPullRequestWorkItems.mockResolvedValue([]);
+      mockGetPullRequestWorkItemRefs.mockResolvedValue([]);
 
       const mockIssueTracker = { fetchTicket: vi.fn() };
       const mockDocProvider = { fetchPage: vi.fn() };

--- a/src/main/features/pr-reviewer/__tests__/prReviewerService.test.ts
+++ b/src/main/features/pr-reviewer/__tests__/prReviewerService.test.ts
@@ -13,6 +13,7 @@ import {
 const mockGetPullRequestById = vi.fn();
 const mockGetPullRequestsByProject = vi.fn();
 const mockCreateThread = vi.fn();
+const mockGetPullRequestWorkItems = vi.fn();
 const mockConnect = vi.fn().mockResolvedValue({
   authorizedUser: { id: 'mock-user-id' },
 });
@@ -21,6 +22,7 @@ const mockGetGitApi = vi.fn().mockResolvedValue({
   getPullRequestById: mockGetPullRequestById,
   getPullRequestsByProject: mockGetPullRequestsByProject,
   createThread: mockCreateThread,
+  getPullRequestWorkItems: mockGetPullRequestWorkItems,
 });
 const mockWebApi = {
   getGitApi: mockGetGitApi,
@@ -73,10 +75,13 @@ describe('PRReviewerService', () => {
     prReviewerService = new PRReviewerService(
       mockGitService,
       mockCopilotService,
+      async () => null,
+      async () => null,
     );
     vi.spyOn(fs, 'mkdirSync').mockImplementation(() => undefined as any);
     mockGetPullRequestById.mockReset();
     mockGetPullRequestsByProject.mockReset();
+    mockGetPullRequestWorkItems.mockReset();
     mockConnect.mockClear();
     mockGetGitApi.mockClear();
     mockPowerSaveBlockerStart.mockClear().mockReturnValue(42);
@@ -653,6 +658,189 @@ describe('PRReviewerService', () => {
           enabledPhaseIds: ['010-templated.md'],
         }),
       ).rejects.toThrow('Template file not found: missing-template.md');
+    });
+
+    it('should fetch and attach linked Azure DevOps stories, resolve doc links, and register the request_documentation tool when phase requires Story', async () => {
+      const mockFiles = [{ path: 'src/index.ts', status: 'modified' }];
+      mockGitService.getDiffFiles.mockResolvedValue(mockFiles);
+
+      const mockSession = {
+        disconnect: vi.fn().mockResolvedValue(undefined),
+      };
+      const mockClient = {
+        stop: vi.fn().mockResolvedValue(undefined),
+      };
+      mockCopilotService.createClientAndSession.mockResolvedValue({
+        client: mockClient,
+        session: mockSession,
+      });
+      mockCopilotService.sendAndCollectStream.mockResolvedValue(
+        '{"type":"general","comment":"Reviewed story"}',
+      );
+
+      mockGetPullRequestById.mockResolvedValue({
+        pullRequestId: 123,
+        title: 'Pr Title',
+        description: 'Pr Description',
+        sourceRefName: 'refs/heads/feature-x',
+        targetRefName: 'refs/heads/main',
+        createdBy: { displayName: 'John Doe' },
+        repository: { id: 'repo-123', name: 'my-repo' },
+      });
+      mockGetPullRequestWorkItems.mockResolvedValue([{ id: 'story-123' }]);
+
+      const mockIssueTracker = {
+        fetchTicket: vi.fn().mockResolvedValue({
+          id: 'story-123',
+          title: 'My Story Title',
+          description:
+            'Please read https://confluence.com/page/456 for details.',
+          acceptanceCriteria: 'Criteria content',
+        }),
+      };
+      const mockDocProvider = {
+        isDocPageUrl: vi.fn().mockReturnValue(true),
+        extractPageId: vi.fn().mockReturnValue('page-456'),
+        fetchPage: vi.fn().mockResolvedValue({
+          id: 'page-456',
+          title: 'My Confluence Doc',
+          body: 'Confluence content',
+        }),
+      };
+
+      const customPRReviewerService = new PRReviewerService(
+        mockGitService,
+        mockCopilotService,
+        async () => mockIssueTracker as any,
+        async () => mockDocProvider as any,
+      );
+
+      vi.spyOn(customPRReviewerService, 'loadPhasesFromDisk').mockResolvedValue(
+        [
+          {
+            id: '020-story-phase.md',
+            title: 'Story Phase',
+            body: 'Phase body contents',
+            attach: 'Story',
+          },
+        ],
+      );
+
+      const localSettings = {
+        copilotToken: 'mock-token',
+        copilotModel: 'mock-model',
+        azureOrg: 'conf-org',
+        azureProject: 'conf-proj',
+        azurePat: 'conf-pat',
+      };
+
+      const onLineCallback = vi.fn();
+      await customPRReviewerService.reviewPR(
+        '/mock/repo',
+        'main',
+        localSettings,
+        {
+          enabledPhaseIds: ['020-story-phase.md'],
+          prId: '123',
+          onLine: onLineCallback,
+        },
+      );
+
+      expect(mockGetPullRequestWorkItems).toHaveBeenCalledWith('repo-123', 123);
+      expect(mockIssueTracker.fetchTicket).toHaveBeenCalledWith('story-123');
+
+      expect(mockCopilotService.createClientAndSession).toHaveBeenCalledWith(
+        'mock-token',
+        undefined,
+        expect.objectContaining({
+          workingDirectory: '/mock/repo',
+          tools: expect.any(Array),
+        }),
+      );
+
+      const expectedPrompt = buildPhaseReviewPrompt(
+        mockFiles,
+        'Story Phase',
+        'Phase body contents',
+        '',
+        undefined,
+        'Ticket ID: story-123\nTitle: My Story Title\nDescription: Please read https://confluence.com/page/456 for details.\nAcceptance Criteria: Criteria content',
+        [{ id: 'page-456', title: 'My Confluence Doc' }],
+      );
+
+      expect(mockCopilotService.sendAndCollectStream).toHaveBeenCalledWith(
+        mockSession,
+        expectedPrompt,
+        expect.any(Function),
+        expect.any(Function),
+      );
+    });
+
+    it('should skip the phase if attach is Story but no stories are linked to the PR', async () => {
+      const mockFiles = [{ path: 'src/index.ts', status: 'modified' }];
+      mockGitService.getDiffFiles.mockResolvedValue(mockFiles);
+
+      mockGetPullRequestById.mockResolvedValue({
+        pullRequestId: 123,
+        title: 'Pr Title',
+        description: 'Pr Description',
+        sourceRefName: 'refs/heads/feature-x',
+        targetRefName: 'refs/heads/main',
+        createdBy: { displayName: 'John Doe' },
+        repository: { id: 'repo-123', name: 'my-repo' },
+      });
+      mockGetPullRequestWorkItems.mockResolvedValue([]);
+
+      const mockIssueTracker = { fetchTicket: vi.fn() };
+      const mockDocProvider = { fetchPage: vi.fn() };
+
+      const customPRReviewerService = new PRReviewerService(
+        mockGitService,
+        mockCopilotService,
+        async () => mockIssueTracker as any,
+        async () => mockDocProvider as any,
+      );
+
+      vi.spyOn(customPRReviewerService, 'loadPhasesFromDisk').mockResolvedValue(
+        [
+          {
+            id: '020-story-phase.md',
+            title: 'Story Phase',
+            body: 'Phase body contents',
+            attach: 'Story',
+          },
+        ],
+      );
+
+      const localSettings = {
+        copilotToken: 'mock-token',
+        copilotModel: 'mock-model',
+        azureOrg: 'conf-org',
+        azureProject: 'conf-proj',
+        azurePat: 'conf-pat',
+      };
+
+      const onLineCallback = vi.fn();
+      await customPRReviewerService.reviewPR(
+        '/mock/repo',
+        'main',
+        localSettings,
+        {
+          enabledPhaseIds: ['020-story-phase.md'],
+          prId: '123',
+          onLine: onLineCallback,
+        },
+      );
+
+      expect(onLineCallback).toHaveBeenCalledWith(
+        JSON.stringify({
+          type: 'phase-skip',
+          phaseId: '020-story-phase.md',
+          phaseTitle: 'Story Phase',
+          reason: 'No linked stories found for this Pull Request',
+        }),
+      );
+      expect(mockCopilotService.createClientAndSession).not.toHaveBeenCalled();
     });
   });
 

--- a/src/main/features/pr-reviewer/prReviewerService.ts
+++ b/src/main/features/pr-reviewer/prReviewerService.ts
@@ -753,7 +753,7 @@ export class PRReviewerService {
             const connection = new azdev.WebApi(orgUrl, authHandler);
             const gitApi: IGitApi = await connection.getGitApi();
 
-            const workItemRefs = await gitApi.getPullRequestWorkItems(
+            const workItemRefs = await gitApi.getPullRequestWorkItemRefs(
               prDetails.repositoryId,
               prNumber,
             );

--- a/src/main/features/pr-reviewer/prReviewerService.ts
+++ b/src/main/features/pr-reviewer/prReviewerService.ts
@@ -12,7 +12,15 @@ import {
 } from 'azure-devops-node-api/interfaces/GitInterfaces';
 import { GitService } from '../../infrastructure/git/gitService';
 import { CopilotService } from '../../infrastructure/copilot/copilotService';
-import { PRMetadata, AppSettings, ReviewPhase } from '../../../types';
+import {
+  PRMetadata,
+  AppSettings,
+  ReviewPhase,
+  TicketData,
+} from '../../../types';
+import { IssueTrackerProvider } from '../../infrastructure/providers/IssueTrackerProvider';
+import { DocumentationProvider } from '../../infrastructure/providers/DocumentationProvider';
+import { createRequestDocumentationTool } from '../../infrastructure/copilot/tools/documentationTool';
 
 export function buildPhaseReviewPrompt(
   files: { path: string; status: string }[],
@@ -20,10 +28,20 @@ export function buildPhaseReviewPrompt(
   phaseContent: string,
   customInstructions = '',
   prDescription = '',
+  storyContent = '',
+  knownDocs?: { id: string; title: string }[],
 ): string {
   const filesListStr = files
     .map((file) => `- ${file.path} (${file.status})`)
     .join('\n');
+
+  let docsInstructions = '';
+  if (knownDocs && knownDocs.length > 0) {
+    const docsList = knownDocs
+      .map((d) => `- "${d.title}" (ID: ${d.id})`)
+      .join('\n');
+    docsInstructions = `\n\nYou have identified the following documentation links in the linked story. You can request the content of any of these documents using the "request_documentation" tool with the corresponding document ID:\n${docsList}\n`;
+  }
 
   return `You are an expert software engineer and code reviewer.
 Your task is to review the changes in the repository for the phase: "${phaseTitle}".
@@ -31,6 +49,7 @@ Your task is to review the changes in the repository for the phase: "${phaseTitl
 The following files have been modified/added/deleted in this Pull Request and are relevant to this phase:
 ${filesListStr}
 ${prDescription ? `\nHere is the Pull Request Description for additional context:\n--- PR DESCRIPTION ---\n${prDescription}\n----------------------\n` : ''}
+${storyContent ? `\nHere is the User Story/Work Item for additional context:\n--- LINKED STORY ---\n${storyContent}\n--------------------\n` : ''}${docsInstructions}
 Please inspect these files using your codebase tools (such as reading file contents or looking at specific ranges of files) to understand the changes made.
 You MUST use the git history (such as git diff or git log) to identify the exact changes made to the files we are reviewing. Only suggest comments on the changed (added or modified) lines. Do not suggest line-specific comments on lines of code that are outside the scope of the change.
 
@@ -157,7 +176,26 @@ export class PRReviewerService {
   constructor(
     private gitService: GitService,
     private copilotService: CopilotService,
+    private getIssueTrackerProvider: () => Promise<IssueTrackerProvider | null>,
+    private getDocProvider: () => Promise<DocumentationProvider | null>,
   ) {}
+
+  private extractUrls(text: string): string[] {
+    const urls: string[] = [];
+    const hrefRegex = /href=["'](https?:\/\/[^"']+)["']/gi;
+    let match;
+    while ((match = hrefRegex.exec(text)) !== null) {
+      urls.push(match[1]);
+    }
+    const rawRegex = /(https?:\/\/[^\s"<>]+)/gi;
+    while ((match = rawRegex.exec(text)) !== null) {
+      const url = match[1].replace(/[.,;:!?)]+$/, '');
+      if (!urls.includes(url)) {
+        urls.push(url);
+      }
+    }
+    return urls;
+  }
 
   async loadPhasesFromDisk(): Promise<ReviewPhase[]> {
     const homeDir = os.homedir();
@@ -477,6 +515,7 @@ export class PRReviewerService {
         targetBranch: cleanRef(pr.targetRefName || ''),
         author: pr.createdBy?.displayName || '',
         repositoryName: repoName,
+        repositoryId: pr.repository?.id,
         hostType: 'azure',
         url: webUrl,
       };
@@ -673,6 +712,129 @@ export class PRReviewerService {
         }
       }
 
+      let prDetails: PRMetadata | null = null;
+      if (options.prId) {
+        try {
+          prDetails = await this.getPRDetails(repoPath, options.prId, settings);
+        } catch (err) {
+          console.error(
+            `Failed to fetch PR details for PR ${options.prId}:`,
+            err,
+          );
+        }
+      }
+
+      let linkedStoriesContent = '';
+      const knownDocs: { id: string; title: string }[] = [];
+
+      const anyPhaseNeedsStory = enabledPhases.some(
+        (phase) => phase.attach && phase.attach.toLowerCase().includes('story'),
+      );
+
+      if (
+        anyPhaseNeedsStory &&
+        prDetails &&
+        prDetails.repositoryId &&
+        options.prId
+      ) {
+        try {
+          const prNumber = parseInt(prDetails.id);
+          let org = settings.azureOrg || '';
+          let project = settings.azureProject || '';
+          const parsedUrl = this.parsePRUrl(options.prId);
+          if (parsedUrl) {
+            org = parsedUrl.org;
+            project = parsedUrl.project;
+          }
+          const pat = settings.azurePat;
+          if (pat && org && project) {
+            const orgUrl = this.getOrgUrl(org);
+            const authHandler = azdev.getPersonalAccessTokenHandler(pat);
+            const connection = new azdev.WebApi(orgUrl, authHandler);
+            const gitApi: IGitApi = await connection.getGitApi();
+
+            const workItemRefs = await gitApi.getPullRequestWorkItems(
+              prDetails.repositoryId,
+              prNumber,
+            );
+
+            if (workItemRefs && workItemRefs.length > 0) {
+              const issueTracker = await this.getIssueTrackerProvider();
+              const docProvider = await this.getDocProvider();
+              const storiesList: string[] = [];
+
+              for (const ref of workItemRefs) {
+                if (ref.id) {
+                  try {
+                    let ticketData: TicketData;
+                    if (issueTracker) {
+                      ticketData = await issueTracker.fetchTicket(ref.id);
+                    } else {
+                      ticketData = {
+                        id: ref.id,
+                        title: `Work Item ${ref.id}`,
+                        description: '',
+                      };
+                    }
+
+                    const storyFormatted = `Ticket ID: ${ticketData.id || 'N/A'}\nTitle: ${ticketData.title}\nDescription: ${ticketData.description}\nAcceptance Criteria: ${ticketData.acceptanceCriteria || 'N/A'}`;
+                    storiesList.push(storyFormatted);
+
+                    if (docProvider) {
+                      const urls = [
+                        ...this.extractUrls(ticketData.description || ''),
+                        ...this.extractUrls(
+                          ticketData.acceptanceCriteria || '',
+                        ),
+                      ];
+                      const pageIds = Array.from(
+                        new Set(
+                          urls
+                            .filter((url) => docProvider.isDocPageUrl(url))
+                            .map((url) => docProvider.extractPageId(url))
+                            .filter((id): id is string => id !== null),
+                        ),
+                      );
+
+                      for (const pageId of pageIds) {
+                        try {
+                          const page = await docProvider.fetchPage(pageId);
+                          if (!knownDocs.some((d) => d.id === page.id)) {
+                            knownDocs.push({ id: page.id, title: page.title });
+                          }
+                        } catch (e) {
+                          console.error(
+                            `Failed to fetch metadata for Confluence page ${pageId}:`,
+                            e,
+                          );
+                          if (!knownDocs.some((d) => d.id === pageId)) {
+                            knownDocs.push({
+                              id: pageId,
+                              title: `Document ID: ${pageId}`,
+                            });
+                          }
+                        }
+                      }
+                    }
+                  } catch (err) {
+                    console.error(
+                      `Failed to fetch details for work item ${ref.id}:`,
+                      err,
+                    );
+                  }
+                }
+              }
+
+              if (storiesList.length > 0) {
+                linkedStoriesContent = storiesList.join('\n\n');
+              }
+            }
+          }
+        } catch (err) {
+          console.error('Failed to retrieve associated work items:', err);
+        }
+      }
+
       let accumulatedResult = '';
 
       for (const phase of enabledPhases) {
@@ -710,6 +872,23 @@ export class PRReviewerService {
           continue;
         }
 
+        const attachStory =
+          phase.attach && phase.attach.toLowerCase().includes('story');
+
+        if (attachStory && !linkedStoriesContent) {
+          if (options.onLine) {
+            options.onLine(
+              JSON.stringify({
+                type: 'phase-skip',
+                phaseId: phase.id,
+                phaseTitle: phase.title,
+                reason: 'No linked stories found for this Pull Request',
+              }),
+            );
+          }
+          continue;
+        }
+
         if (options.onLine) {
           options.onLine(
             JSON.stringify({
@@ -720,33 +899,31 @@ export class PRReviewerService {
           );
         }
 
+        const sessionOpts = attachStory
+          ? {
+              workingDirectory: repoPath,
+              tools: [
+                createRequestDocumentationTool(
+                  this.getDocProvider,
+                  () => options.onLine,
+                ),
+              ],
+            }
+          : { workingDirectory: repoPath };
+
         const { client, session } =
           await this.copilotService.createClientAndSession(
             settings.copilotToken,
             options.modelOverride,
-            { workingDirectory: repoPath },
+            sessionOpts,
           );
 
         const attachDescription =
           phase.attach && phase.attach.toLowerCase().includes('description');
 
         let fullDescription = options.prDescription;
-        if (attachDescription && options.prId) {
-          try {
-            const prDetails = await this.getPRDetails(
-              repoPath,
-              options.prId,
-              settings,
-            );
-            if (prDetails && prDetails.description) {
-              fullDescription = prDetails.description;
-            }
-          } catch (err) {
-            console.error(
-              `Failed to fetch full PR description for PR ${options.prId}:`,
-              err,
-            );
-          }
+        if (attachDescription && prDetails && prDetails.description) {
+          fullDescription = prDetails.description;
         }
 
         const prompt = buildPhaseReviewPrompt(
@@ -755,6 +932,8 @@ export class PRReviewerService {
           phase.body,
           options.customInstructions,
           attachDescription ? fullDescription : undefined,
+          attachStory ? linkedStoriesContent : undefined,
+          attachStory ? knownDocs : undefined,
         );
 
         const wrappedOnLine = (line: string) => {
@@ -788,11 +967,34 @@ export class PRReviewerService {
           }
         };
 
+        const onToolCallback = (
+          type: 'start' | 'end',
+          tool: string,
+          success?: boolean,
+          error?: string,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          args?: any,
+        ) => {
+          if (options.onLine) {
+            options.onLine(
+              JSON.stringify({
+                type: 'tool',
+                status: type,
+                name: tool,
+                success,
+                error,
+                arguments: args,
+              }),
+            );
+          }
+        };
+
         try {
           const res = await this.copilotService.sendAndCollectStream(
             session,
             prompt,
             options.onLine ? wrappedOnLine : undefined,
+            ...(attachStory ? [onToolCallback] : []),
           );
           accumulatedResult += `\n--- Phase ${phase.title} Result ---\n${res}`;
         } catch (err) {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -63,7 +63,24 @@ const storyElaboratorService = new StoryElaboratorService(
 );
 const promptComplexityService = new PromptComplexityService(copilotService);
 const gitService = new GitService();
-const prReviewerService = new PRReviewerService(gitService, copilotService);
+const prReviewerService = new PRReviewerService(
+  gitService,
+  copilotService,
+  async () => {
+    try {
+      return await getAzureService();
+    } catch {
+      return null;
+    }
+  },
+  async () => {
+    try {
+      return await getConfluenceService();
+    } catch {
+      return null;
+    }
+  },
+);
 
 // Handle creating/removing shortcuts on Windows when installing/uninstalling.
 // eslint-disable-next-line @typescript-eslint/no-require-imports

--- a/src/types.ts
+++ b/src/types.ts
@@ -100,6 +100,7 @@ export interface PRMetadata {
   targetBranch: string;
   author?: string;
   repositoryName: string;
+  repositoryId?: string;
   hostType: 'azure' | 'unknown';
   url?: string;
 }


### PR DESCRIPTION
In addition to the current `Attach: Description` in the phase front matter, for attaching the PR description to the review context, this PR adds `Attach: Story` capability.

This is to allow a phase of the PR reviewer to check the code against the ticket and confirm whether it was fully implemented as requested or if anything is missing. It will also be able to identify if any changes were outside what was requested.

Since with #108 being merged, the agent can also retrieve documentation autonomously, so if the story links to a confluence page, the agent can retrieve it and use those details to influence its analysis of the code change.

> [!IMPORTANT]
> If the review phase requests the story, but no story is linked to the PR, the phase is **skipped**. This is because the orchestrator presumes that if you're attaching the story to the phase it must be important for the purpose of providing a valid review in the phase.
> 
> This is visually represented within the app the same way as a phase with an `Include` which matches no changes, or an `Exclude` which matches every eligible file.