### PR TITLE
feat: Improve prompt checker

### DIFF
--- a/src/main/features/settings/__tests__/promptComplexityService.test.ts
+++ b/src/main/features/settings/__tests__/promptComplexityService.test.ts
@@ -52,7 +52,7 @@ describe('PromptComplexity feature', () => {
       expect(result).toBe('Mocked complexity response');
       expect(mockCopilotService.createClientAndSession).toHaveBeenCalledWith(
         undefined,
-        undefined,
+        'auto',
         { availableTools: [], streaming: false },
       );
       expect(mockCopilotService.sendAndCollectStream).toHaveBeenCalledWith(
@@ -76,7 +76,7 @@ describe('PromptComplexity feature', () => {
       expect(result).toBe('Mocked complexity response');
       expect(mockCopilotService.createClientAndSession).toHaveBeenCalledWith(
         undefined,
-        undefined,
+        'auto',
         { availableTools: [], streaming: false },
       );
       expect(mockCopilotService.sendAndCollectStream).toHaveBeenCalledWith(

--- a/src/main/features/settings/__tests__/promptComplexityService.test.ts
+++ b/src/main/features/settings/__tests__/promptComplexityService.test.ts
@@ -44,7 +44,11 @@ describe('PromptComplexity feature', () => {
         prompts: {},
       };
 
-      const result = await service.checkPromptComplexity('story', {}, settings);
+      const result = await service.checkPromptComplexity(
+        'story',
+        { general: 'My customized instructions' },
+        settings,
+      );
       expect(result).toBe('Mocked complexity response');
       expect(mockCopilotService.createClientAndSession).toHaveBeenCalledWith(
         undefined,
@@ -66,7 +70,7 @@ describe('PromptComplexity feature', () => {
 
       const result = await service.checkPromptComplexity(
         'testcase',
-        {},
+        { general: 'My customized instructions' },
         settings,
       );
       expect(result).toBe('Mocked complexity response');
@@ -81,6 +85,18 @@ describe('PromptComplexity feature', () => {
       );
       expect(mockSession.disconnect).toHaveBeenCalled();
       expect(mockClient.stop).toHaveBeenCalled();
+    });
+
+    it('should throw an error if no custom prompt statements are provided', async () => {
+      const settings: AppSettings = {
+        prompts: {},
+      };
+
+      await expect(
+        service.checkPromptComplexity('story', {}, settings),
+      ).rejects.toThrow(
+        'No customized prompt statements detected. Please customize at least one field before checking.',
+      );
     });
   });
 });

--- a/src/main/features/settings/__tests__/promptComplexityService.test.ts
+++ b/src/main/features/settings/__tests__/promptComplexityService.test.ts
@@ -87,15 +87,14 @@ describe('PromptComplexity feature', () => {
       expect(mockClient.stop).toHaveBeenCalled();
     });
 
-    it('should throw an error if no custom prompt statements are provided', async () => {
+    it('should return PASS message if no custom prompt statements are provided', async () => {
       const settings: AppSettings = {
         prompts: {},
       };
 
-      await expect(
-        service.checkPromptComplexity('story', {}, settings),
-      ).rejects.toThrow(
-        'No customized prompt statements detected. Please customize at least one field before checking.',
+      const result = await service.checkPromptComplexity('story', {}, settings);
+      expect(result).toBe(
+        'PASS: No customized prompt statements detected. Please customize at least one field before checking.',
       );
     });
   });

--- a/src/main/features/settings/__tests__/promptComplexityService.test.ts
+++ b/src/main/features/settings/__tests__/promptComplexityService.test.ts
@@ -6,14 +6,17 @@ import { AppSettings } from '../../../../types';
 
 describe('PromptComplexity feature', () => {
   describe('buildPromptComplexityCheckPrompt', () => {
-    it('should generate prompt complexity check prompt containing the prompt to check', () => {
+    it('should generate prompt complexity check prompt containing the prompt context and user statements', () => {
       const testPrompt = 'This is a test prompt content';
-      const prompt = buildPromptComplexityCheckPrompt(testPrompt);
+      const customInputs = { general: 'Custom general instruction', notes: '' };
+      const prompt = buildPromptComplexityCheckPrompt(testPrompt, customInputs);
 
       expect(prompt).toContain(
         'You are an expert AI prompt engineer and validator.',
       );
       expect(prompt).toContain('This is a test prompt content');
+      expect(prompt).toContain('[Customized Field: general]');
+      expect(prompt).toContain('Custom general instruction');
     });
   });
 

--- a/src/main/features/settings/promptComplexityPrompts.ts
+++ b/src/main/features/settings/promptComplexityPrompts.ts
@@ -1,19 +1,34 @@
 export function buildPromptComplexityCheckPrompt(
   promptToCheck: string,
+  customInputs: Record<string, string>,
 ): string {
+  const activeInputsList = Object.entries(customInputs)
+    .filter(([_, val]) => typeof val === 'string' && val.trim() !== '')
+    .map(([key, val]) => `[Customized Field: ${key}]\n${val.trim()}`)
+    .join('\n\n');
+
   return `
 You are an expert AI prompt engineer and validator.
-Review the following prompt template which is intended to guide an AI to generate JSON Lines (JSONL) output.
-Is there anything in the instructions or fields that is likely to confuse you (or any other LLM) or cause you to violate the requirement to produce valid JSONL?
-Specifically check if any of the custom descriptions might encourage code blocks, markdown fences, unescaped double quotes, or raw newlines inside JSON properties.
+Review the following complete prompt template (which is intended to guide an AI to generate JSON Lines (JSONL) output), focusing SPECIFICALLY on the user-customized statements listed at the end.
 
-Avoid being unnecessarily pessimistic. If the prompt is sufficiently clear DO NOT invent potential issues.
+Your task is to identify if there is anything in the user-customized statements that is likely to confuse the LLM or cause it to violate the requirements specified in the overall template (such as the requirement to produce valid JSONL).
 
-Explain any issues detected clearly and suggest action-oriented improvements, or respond with a confirmation that the prompt template looks perfectly safe and compliant. Keep your response brief, clear, and formatted nicely as markdown.
+CRITICAL INSTRUCTIONS:
+1. ONLY evaluate and flag issues present in the user-customized statements listed in the "USER-CUSTOMIZED STATEMENTS TO EVALUATE" section below.
+2. DO NOT flag or invent issues for the fixed, default parts of the template.
+3. Assess the user-customized statements in relation to the rules and structure of the overall prompt template. Specifically check if any custom inputs might encourage code blocks, markdown fences, unescaped double quotes, or raw newlines inside JSON properties.
+4. Avoid being unnecessarily pessimistic. If the user-customized statements are clear and safe, DO NOT invent potential issues.
 
-PROMPT TEMPLATE TO REVIEW:
+Explain any issues detected in the user-customized statements clearly and suggest action-oriented improvements, or respond with a confirmation that the prompt template looks perfectly safe and compliant. Keep your response brief, clear, and formatted nicely as markdown.
+
+OVERALL PROMPT TEMPLATE CONTEXT:
 """
 ${promptToCheck.trim()}
+"""
+
+USER-CUSTOMIZED STATEMENTS TO EVALUATE:
+"""
+${activeInputsList || 'No custom prompt statements entered.'}
 """
   `;
 }

--- a/src/main/features/settings/promptComplexityPrompts.ts
+++ b/src/main/features/settings/promptComplexityPrompts.ts
@@ -19,7 +19,20 @@ CRITICAL INSTRUCTIONS:
 3. Assess the user-customized statements in relation to the rules and structure of the overall prompt template. Specifically check if any custom inputs might encourage code blocks, markdown fences, unescaped double quotes, or raw newlines inside JSON properties.
 4. Avoid being unnecessarily pessimistic. If the user-customized statements are clear and safe, DO NOT invent potential issues.
 
-Explain any issues detected in the user-customized statements clearly and suggest action-oriented improvements, or respond with a confirmation that the prompt template looks perfectly safe and compliant. Keep your response brief, clear, and formatted nicely as markdown.
+CRITICAL FORMATTING REQUIREMENT:
+You MUST start your response with either "PASS:", "FAIL:", or no prefix at all.
+- Start with "PASS:" (followed by a space and then your feedback/confirmation) if, on balance, the custom prompt statements are likely to work correctly without causing issues. Be lenient; do not fail prompts for minor style preferences or low-risk phrasing.
+- Start with "FAIL:" (followed by a space and then your feedback/issues list) ONLY if there are significant, high-probability risks to the output format (such as violating the requirement to produce valid JSONL, causing unescaped quotes, or breaking JSON syntax).
+- Start with NO prefix (e.g., start directly with your markdown text feedback) if you are uncertain, or if there are mild issues that do not justify a full FAIL but aren't a clean PASS. An uncertain or mild issue is better off without a prefix than an overzealous FAIL.
+
+Example PASS response:
+PASS: The custom prompt statements are clear and fully compliant.
+
+Example FAIL response:
+FAIL: The customized statements contain formatting risks.
+- **general**: Avoid requesting raw newlines as it may break JSONL structures.
+
+Keep your response brief, clear, and formatted nicely as markdown.
 
 OVERALL PROMPT TEMPLATE CONTEXT:
 """

--- a/src/main/features/settings/promptComplexityService.ts
+++ b/src/main/features/settings/promptComplexityService.ts
@@ -41,7 +41,10 @@ export class PromptComplexityService {
         );
       }
 
-      const metaPrompt = buildPromptComplexityCheckPrompt(promptToCheck);
+      const metaPrompt = buildPromptComplexityCheckPrompt(
+        promptToCheck,
+        prompts,
+      );
 
       return await this.copilotService.sendAndCollectStream(
         session,

--- a/src/main/features/settings/promptComplexityService.ts
+++ b/src/main/features/settings/promptComplexityService.ts
@@ -19,9 +19,7 @@ export class PromptComplexityService {
     );
 
     if (!hasCustomPrompt) {
-      throw new Error(
-        'No customized prompt statements detected. Please customize at least one field before checking.',
-      );
+      return 'PASS: No customized prompt statements detected. Please customize at least one field before checking.';
     }
 
     const { client, session } =

--- a/src/main/features/settings/promptComplexityService.ts
+++ b/src/main/features/settings/promptComplexityService.ts
@@ -14,6 +14,16 @@ export class PromptComplexityService {
     settings: AppSettings,
     modelOverride?: string,
   ): Promise<string> {
+    const hasCustomPrompt = Object.values(prompts).some(
+      (val) => typeof val === 'string' && val.trim() !== '',
+    );
+
+    if (!hasCustomPrompt) {
+      throw new Error(
+        'No customized prompt statements detected. Please customize at least one field before checking.',
+      );
+    }
+
     const { client, session } =
       await this.copilotService.createClientAndSession(
         settings.copilotToken,

--- a/src/main/features/settings/promptComplexityService.ts
+++ b/src/main/features/settings/promptComplexityService.ts
@@ -12,7 +12,6 @@ export class PromptComplexityService {
     type: 'story' | 'testcase',
     prompts: any,
     settings: AppSettings,
-    modelOverride?: string,
   ): Promise<string> {
     const hasCustomPrompt = Object.values(prompts).some(
       (val) => typeof val === 'string' && val.trim() !== '',
@@ -25,7 +24,7 @@ export class PromptComplexityService {
     const { client, session } =
       await this.copilotService.createClientAndSession(
         settings.copilotToken,
-        modelOverride,
+        'auto',
         { availableTools: [], streaming: false },
       );
 

--- a/src/renderer/features/settings/components/PromptSettings.tsx
+++ b/src/renderer/features/settings/components/PromptSettings.tsx
@@ -76,6 +76,11 @@ const PromptSettings: React.FC<PromptSettingsProps> = ({
   const [showModal, setShowModal] = useState(false);
   const [modalTab, setModalTab] = useState<'story' | 'testcase' | null>(null);
 
+  const [lastCheckedStory, setLastCheckedStory] = useState<string | null>(null);
+  const [lastCheckedTestCase, setLastCheckedTestCase] = useState<string | null>(
+    null,
+  );
+
   const handleResetStoryDefaults = () => {
     setStoryGeneral('');
     setStoryTitle('');
@@ -111,6 +116,21 @@ const PromptSettings: React.FC<PromptSettingsProps> = ({
         'No customized prompt statements detected. Please customize at least one field before checking.',
       );
       setStoryResult(null);
+      setLastCheckedStory(null);
+      setModalTab('story');
+      setShowModal(true);
+      return;
+    }
+
+    const currentKey = JSON.stringify({
+      general: storyGeneral,
+      title: storyTitle,
+      description: storyDescription,
+      acceptanceCriteria: storyAcceptanceCriteria,
+      notes: storyNotes,
+    });
+
+    if ((storyResult || storyError) && currentKey === lastCheckedStory) {
       setModalTab('story');
       setShowModal(true);
       return;
@@ -130,11 +150,13 @@ const PromptSettings: React.FC<PromptSettingsProps> = ({
         notes: storyNotes,
       });
       setStoryResult(response);
+      setLastCheckedStory(currentKey);
     } catch (err) {
       const errorMsg = err instanceof Error ? err.message : String(err);
       setStoryError(
         errorMsg || 'An error occurred while validating the prompt.',
       );
+      setLastCheckedStory(currentKey);
     } finally {
       setCheckingStory(false);
     }
@@ -155,6 +177,25 @@ const PromptSettings: React.FC<PromptSettingsProps> = ({
         'No customized prompt statements detected. Please customize at least one field before checking.',
       );
       setTestCaseResult(null);
+      setLastCheckedTestCase(null);
+      setModalTab('testcase');
+      setShowModal(true);
+      return;
+    }
+
+    const currentKey = JSON.stringify({
+      general: testCaseGeneral,
+      id: testCaseId,
+      description: testCaseDescription,
+      preConditions: testCasePreConditions,
+      steps: testCaseSteps,
+      expectedResult: testCaseExpectedResult,
+    });
+
+    if (
+      (testCaseResult || testCaseError) &&
+      currentKey === lastCheckedTestCase
+    ) {
       setModalTab('testcase');
       setShowModal(true);
       return;
@@ -178,11 +219,13 @@ const PromptSettings: React.FC<PromptSettingsProps> = ({
         },
       );
       setTestCaseResult(response);
+      setLastCheckedTestCase(currentKey);
     } catch (err) {
       const errorMsg = err instanceof Error ? err.message : String(err);
       setTestCaseError(
         errorMsg || 'An error occurred while validating the prompt.',
       );
+      setLastCheckedTestCase(currentKey);
     } finally {
       setCheckingTestCase(false);
     }
@@ -221,18 +264,6 @@ const PromptSettings: React.FC<PromptSettingsProps> = ({
                     </>
                   )}
                 </button>
-                {(storyResult || storyError) && (
-                  <button
-                    type="button"
-                    className="btn btn-outline-secondary btn-sm d-flex align-items-center gap-2"
-                    onClick={() => {
-                      setModalTab('story');
-                      setShowModal(true);
-                    }}
-                  >
-                    <i className="fas fa-comment-dots"></i>View Feedback
-                  </button>
-                )}
                 <button
                   type="button"
                   className="btn btn-outline-secondary btn-sm"
@@ -265,18 +296,6 @@ const PromptSettings: React.FC<PromptSettingsProps> = ({
                     </>
                   )}
                 </button>
-                {(testCaseResult || testCaseError) && (
-                  <button
-                    type="button"
-                    className="btn btn-outline-secondary btn-sm d-flex align-items-center gap-2"
-                    onClick={() => {
-                      setModalTab('testcase');
-                      setShowModal(true);
-                    }}
-                  >
-                    <i className="fas fa-comment-dots"></i>View Feedback
-                  </button>
-                )}
                 <button
                   type="button"
                   className="btn btn-outline-secondary btn-sm"

--- a/src/renderer/features/settings/components/PromptSettings.tsx
+++ b/src/renderer/features/settings/components/PromptSettings.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { createPortal } from 'react-dom';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
@@ -72,6 +73,9 @@ const PromptSettings: React.FC<PromptSettingsProps> = ({
   const [testCaseResult, setTestCaseResult] = useState<string | null>(null);
   const [testCaseError, setTestCaseError] = useState<string | null>(null);
 
+  const [showModal, setShowModal] = useState(false);
+  const [modalTab, setModalTab] = useState<'story' | 'testcase' | null>(null);
+
   const handleResetStoryDefaults = () => {
     setStoryGeneral('');
     setStoryTitle('');
@@ -97,6 +101,8 @@ const PromptSettings: React.FC<PromptSettingsProps> = ({
     setCheckingStory(true);
     setStoryResult(null);
     setStoryError(null);
+    setModalTab('story');
+    setShowModal(true);
     try {
       const response = await window.electronAPI.checkPromptComplexity('story', {
         general: storyGeneral,
@@ -120,6 +126,8 @@ const PromptSettings: React.FC<PromptSettingsProps> = ({
     setCheckingTestCase(true);
     setTestCaseResult(null);
     setTestCaseError(null);
+    setModalTab('testcase');
+    setShowModal(true);
     try {
       const response = await window.electronAPI.checkPromptComplexity(
         'testcase',
@@ -176,6 +184,18 @@ const PromptSettings: React.FC<PromptSettingsProps> = ({
                     </>
                   )}
                 </button>
+                {(storyResult || storyError) && (
+                  <button
+                    type="button"
+                    className="btn btn-outline-secondary btn-sm d-flex align-items-center gap-2"
+                    onClick={() => {
+                      setModalTab('story');
+                      setShowModal(true);
+                    }}
+                  >
+                    <i className="fas fa-comment-dots"></i>View Feedback
+                  </button>
+                )}
                 <button
                   type="button"
                   className="btn btn-outline-secondary btn-sm"
@@ -208,6 +228,18 @@ const PromptSettings: React.FC<PromptSettingsProps> = ({
                     </>
                   )}
                 </button>
+                {(testCaseResult || testCaseError) && (
+                  <button
+                    type="button"
+                    className="btn btn-outline-secondary btn-sm d-flex align-items-center gap-2"
+                    onClick={() => {
+                      setModalTab('testcase');
+                      setShowModal(true);
+                    }}
+                  >
+                    <i className="fas fa-comment-dots"></i>View Feedback
+                  </button>
+                )}
                 <button
                   type="button"
                   className="btn btn-outline-secondary btn-sm"
@@ -346,27 +378,6 @@ const PromptSettings: React.FC<PromptSettingsProps> = ({
                 Instruct what extra warnings, assumptions, or notes to include.
               </div>
             </div>
-
-            {storyResult && (
-              <div className="card border-info bg-info-subtle mt-4">
-                <div className="card-header bg-transparent border-0 pt-3 pb-0 fw-semibold text-info-emphasis d-flex align-items-center gap-2">
-                  <i className="fas fa-magnifying-glass-chart"></i>Prompt
-                  Analysis Feedback
-                </div>
-                <div className="card-body markdown-content p-3">
-                  <ReactMarkdown remarkPlugins={[remarkGfm]}>
-                    {storyResult}
-                  </ReactMarkdown>
-                </div>
-              </div>
-            )}
-
-            {storyError && (
-              <div className="alert alert-danger mt-4 d-flex align-items-start gap-2 border-0 bg-danger-subtle text-danger-emphasis">
-                <i className="fas fa-triangle-exclamation mt-1"></i>
-                <div>{storyError}</div>
-              </div>
-            )}
           </div>
         )}
 
@@ -487,27 +498,6 @@ const PromptSettings: React.FC<PromptSettingsProps> = ({
                 cannot be customized.
               </div>
             </div>
-
-            {testCaseResult && (
-              <div className="card border-info bg-info-subtle mt-4">
-                <div className="card-header bg-transparent border-0 pt-3 pb-0 fw-semibold text-info-emphasis d-flex align-items-center gap-2">
-                  <i className="fas fa-magnifying-glass-chart"></i>Prompt
-                  Analysis Feedback
-                </div>
-                <div className="card-body markdown-content p-3">
-                  <ReactMarkdown remarkPlugins={[remarkGfm]}>
-                    {testCaseResult}
-                  </ReactMarkdown>
-                </div>
-              </div>
-            )}
-
-            {testCaseError && (
-              <div className="alert alert-danger mt-4 d-flex align-items-start gap-2 border-0 bg-danger-subtle text-danger-emphasis">
-                <i className="fas fa-triangle-exclamation mt-1"></i>
-                <div>{testCaseError}</div>
-              </div>
-            )}
           </div>
         )}
 
@@ -537,6 +527,129 @@ const PromptSettings: React.FC<PromptSettingsProps> = ({
           </div>
         )}
       </div>
+
+      {showModal &&
+        modalTab &&
+        createPortal(
+          <div className="env-error-overlay" style={{ zIndex: 3000 }}>
+            <div
+              className="near-full-modal text-start align-items-stretch"
+              style={{ width: '800px', padding: '30px' }}
+            >
+              <button
+                type="button"
+                className="btn btn-link text-secondary position-absolute"
+                style={{
+                  top: '20px',
+                  right: '20px',
+                  fontSize: '1.2rem',
+                  padding: '5px',
+                  textDecoration: 'none',
+                }}
+                onClick={() => {
+                  setShowModal(false);
+                  setModalTab(null);
+                }}
+              >
+                <i className="fas fa-times"></i>
+              </button>
+
+              <div className="d-flex align-items-center gap-3 border-bottom pb-3 mb-4">
+                <div
+                  className="env-error-icon bg-info text-white m-0"
+                  style={{
+                    width: '50px',
+                    height: '50px',
+                    fontSize: '1.2rem',
+                    flexShrink: 0,
+                  }}
+                >
+                  <i className="fas fa-magnifying-glass-chart"></i>
+                </div>
+                <div>
+                  <h4 className="mb-1 fw-bold text-body">
+                    Prompt Analysis Feedback
+                  </h4>
+                  <span className="badge bg-primary-subtle text-primary border border-primary-subtle">
+                    {modalTab === 'story' ? 'Story Writer' : 'Test Case Writer'}
+                  </span>
+                </div>
+              </div>
+
+              <div
+                className="overflow-y-auto px-1"
+                style={{ maxHeight: '60vh' }}
+              >
+                {/* Loading State */}
+                {((modalTab === 'story' && checkingStory) ||
+                  (modalTab === 'testcase' && checkingTestCase)) && (
+                  <div className="d-flex flex-column align-items-center justify-content-center py-5 my-3">
+                    <span
+                      className="spinner-border text-info mb-3"
+                      style={{ width: '3rem', height: '3rem' }}
+                      role="status"
+                      aria-hidden="true"
+                    ></span>
+                    <p className="text-muted fw-semibold">
+                      Analyzing prompt structure & complexity...
+                    </p>
+                  </div>
+                )}
+
+                {/* Results */}
+                {modalTab === 'story' && !checkingStory && (
+                  <>
+                    {storyResult && (
+                      <div className="markdown-content selectable-text bg-body-secondary p-4 rounded-4 border border-light-subtle shadow-sm">
+                        <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                          {storyResult}
+                        </ReactMarkdown>
+                      </div>
+                    )}
+                    {storyError && (
+                      <div className="alert alert-danger d-flex align-items-start gap-2 border-0 bg-danger-subtle text-danger-emphasis p-4 rounded-4">
+                        <i className="fas fa-triangle-exclamation mt-1"></i>
+                        <div>{storyError}</div>
+                      </div>
+                    )}
+                  </>
+                )}
+
+                {modalTab === 'testcase' && !checkingTestCase && (
+                  <>
+                    {testCaseResult && (
+                      <div className="markdown-content selectable-text bg-body-secondary p-4 rounded-4 border border-light-subtle shadow-sm">
+                        <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                          {testCaseResult}
+                        </ReactMarkdown>
+                      </div>
+                    )}
+                    {testCaseError && (
+                      <div className="alert alert-danger d-flex align-items-start gap-2 border-0 bg-danger-subtle text-danger-emphasis p-4 rounded-4">
+                        <i className="fas fa-triangle-exclamation mt-1"></i>
+                        <div>{testCaseError}</div>
+                      </div>
+                    )}
+                  </>
+                )}
+              </div>
+
+              <div className="d-flex justify-content-end mt-4 pt-3 border-top">
+                <button
+                  type="button"
+                  className="btn btn-outline-secondary px-4 py-2 fw-semibold"
+                  onClick={() => {
+                    setShowModal(false);
+                    setModalTab(null);
+                  }}
+                >
+                  Close
+                </button>
+              </div>
+            </div>
+          </div>,
+          document.body,
+        )}
     </div>
   );
 };

--- a/src/renderer/features/settings/components/PromptSettings.tsx
+++ b/src/renderer/features/settings/components/PromptSettings.tsx
@@ -98,6 +98,24 @@ const PromptSettings: React.FC<PromptSettingsProps> = ({
   };
 
   const handleCheckStory = async () => {
+    const hasCustom = [
+      storyGeneral,
+      storyTitle,
+      storyDescription,
+      storyAcceptanceCriteria,
+      storyNotes,
+    ].some((val) => val && val.trim() !== '');
+
+    if (!hasCustom) {
+      setStoryError(
+        'No customized prompt statements detected. Please customize at least one field before checking.',
+      );
+      setStoryResult(null);
+      setModalTab('story');
+      setShowModal(true);
+      return;
+    }
+
     setCheckingStory(true);
     setStoryResult(null);
     setStoryError(null);
@@ -123,6 +141,25 @@ const PromptSettings: React.FC<PromptSettingsProps> = ({
   };
 
   const handleCheckTestCase = async () => {
+    const hasCustom = [
+      testCaseGeneral,
+      testCaseId,
+      testCaseDescription,
+      testCasePreConditions,
+      testCaseSteps,
+      testCaseExpectedResult,
+    ].some((val) => val && val.trim() !== '');
+
+    if (!hasCustom) {
+      setTestCaseError(
+        'No customized prompt statements detected. Please customize at least one field before checking.',
+      );
+      setTestCaseResult(null);
+      setModalTab('testcase');
+      setShowModal(true);
+      return;
+    }
+
     setCheckingTestCase(true);
     setTestCaseResult(null);
     setTestCaseError(null);

--- a/src/renderer/features/settings/components/PromptSettings.tsx
+++ b/src/renderer/features/settings/components/PromptSettings.tsx
@@ -112,10 +112,10 @@ const PromptSettings: React.FC<PromptSettingsProps> = ({
     ].some((val) => val && val.trim() !== '');
 
     if (!hasCustom) {
-      setStoryError(
-        'No customized prompt statements detected. Please customize at least one field before checking.',
+      setStoryResult(
+        'PASS: No customized prompt statements detected. Please customize at least one field before checking.',
       );
-      setStoryResult(null);
+      setStoryError(null);
       setLastCheckedStory(null);
       setModalTab('story');
       setShowModal(true);
@@ -173,10 +173,10 @@ const PromptSettings: React.FC<PromptSettingsProps> = ({
     ].some((val) => val && val.trim() !== '');
 
     if (!hasCustom) {
-      setTestCaseError(
-        'No customized prompt statements detected. Please customize at least one field before checking.',
+      setTestCaseResult(
+        'PASS: No customized prompt statements detected. Please customize at least one field before checking.',
       );
-      setTestCaseResult(null);
+      setTestCaseError(null);
       setLastCheckedTestCase(null);
       setModalTab('testcase');
       setShowModal(true);
@@ -587,123 +587,160 @@ const PromptSettings: React.FC<PromptSettingsProps> = ({
       {showModal &&
         modalTab &&
         createPortal(
-          <div className="env-error-overlay" style={{ zIndex: 3000 }}>
-            <div
-              className="near-full-modal text-start align-items-stretch"
-              style={{ width: '800px', padding: '30px' }}
-            >
-              <button
-                type="button"
-                className="btn btn-link text-secondary position-absolute"
-                style={{
-                  top: '20px',
-                  right: '20px',
-                  fontSize: '1.2rem',
-                  padding: '5px',
-                  textDecoration: 'none',
-                }}
-                onClick={() => {
-                  setShowModal(false);
-                  setModalTab(null);
-                }}
-              >
-                <i className="fas fa-times"></i>
-              </button>
+          (() => {
+            const resultText =
+              modalTab === 'story' ? storyResult : testCaseResult;
+            const errorText = modalTab === 'story' ? storyError : testCaseError;
+            const checking =
+              modalTab === 'story' ? checkingStory : checkingTestCase;
 
-              <div className="d-flex align-items-center gap-3 border-bottom pb-3 mb-4">
+            const isPass = resultText?.trim().toUpperCase().startsWith('PASS:');
+            const isFail = resultText?.trim().toUpperCase().startsWith('FAIL:');
+
+            const cleanResultText = (text: string | null) => {
+              if (!text) return '';
+              return text.replace(/^(PASS|FAIL):\s*/i, '');
+            };
+
+            return (
+              <div className="env-error-overlay" style={{ zIndex: 3000 }}>
                 <div
-                  className="env-error-icon bg-info text-white m-0"
-                  style={{
-                    width: '50px',
-                    height: '50px',
-                    fontSize: '1.2rem',
-                    flexShrink: 0,
-                  }}
+                  className="near-full-modal text-start align-items-stretch"
+                  style={{ width: '800px', padding: '30px' }}
                 >
-                  <i className="fas fa-magnifying-glass-chart"></i>
-                </div>
-                <div>
-                  <h4 className="mb-1 fw-bold text-body">
-                    Prompt Analysis Feedback
-                  </h4>
-                  <span className="badge bg-primary-subtle text-primary border border-primary-subtle">
-                    {modalTab === 'story' ? 'Story Writer' : 'Test Case Writer'}
-                  </span>
-                </div>
-              </div>
+                  <button
+                    type="button"
+                    className="btn btn-link text-secondary position-absolute"
+                    style={{
+                      top: '20px',
+                      right: '20px',
+                      fontSize: '1.2rem',
+                      padding: '5px',
+                      textDecoration: 'none',
+                    }}
+                    onClick={() => {
+                      setShowModal(false);
+                      setModalTab(null);
+                    }}
+                  >
+                    <i className="fas fa-times"></i>
+                  </button>
 
-              <div
-                className="overflow-y-auto px-1"
-                style={{ maxHeight: '60vh' }}
-              >
-                {/* Loading State */}
-                {((modalTab === 'story' && checkingStory) ||
-                  (modalTab === 'testcase' && checkingTestCase)) && (
-                  <div className="d-flex flex-column align-items-center justify-content-center py-5 my-3">
-                    <span
-                      className="spinner-border text-info mb-3"
-                      style={{ width: '3rem', height: '3rem' }}
-                      role="status"
-                      aria-hidden="true"
-                    ></span>
-                    <p className="text-muted fw-semibold">
-                      Analyzing prompt structure & complexity...
-                    </p>
+                  <div className="d-flex align-items-center gap-3 border-bottom pb-3 mb-4">
+                    {/* Display outcome icon based on PASS/FAIL prefix if result is ready and not loading */}
+                    {!checking && !errorText && isPass && (
+                      <div
+                        className="env-error-icon bg-success text-white m-0"
+                        style={{
+                          width: '50px',
+                          height: '50px',
+                          fontSize: '1.2rem',
+                          flexShrink: 0,
+                        }}
+                      >
+                        <i className="fas fa-check"></i>
+                      </div>
+                    )}
+                    {!checking && !errorText && isFail && (
+                      <div
+                        className="env-error-icon text-white m-0"
+                        style={{
+                          width: '50px',
+                          height: '50px',
+                          fontSize: '1.2rem',
+                          flexShrink: 0,
+                          backgroundColor: '#f59e0b', // Premium warm orange warning color
+                        }}
+                      >
+                        <i className="fas fa-exclamation-triangle"></i>
+                      </div>
+                    )}
+
+                    <div>
+                      <h4 className="mb-1 fw-bold text-body">
+                        Prompt Analysis Feedback
+                      </h4>
+                      <span className="badge bg-primary-subtle text-primary border border-primary-subtle">
+                        {modalTab === 'story'
+                          ? 'Story Writer'
+                          : 'Test Case Writer'}
+                      </span>
+                    </div>
                   </div>
-                )}
 
-                {/* Results */}
-                {modalTab === 'story' && !checkingStory && (
-                  <>
-                    {storyResult && (
-                      <div className="markdown-content selectable-text bg-body-secondary p-4 rounded-4 border border-light-subtle shadow-sm">
-                        <ReactMarkdown remarkPlugins={[remarkGfm]}>
-                          {storyResult}
-                        </ReactMarkdown>
+                  <div
+                    className="overflow-y-auto px-1"
+                    style={{ maxHeight: '60vh' }}
+                  >
+                    {/* Loading State */}
+                    {checking && (
+                      <div className="d-flex flex-column align-items-center justify-content-center py-5 my-3">
+                        <span
+                          className="spinner-border text-info mb-3"
+                          style={{ width: '3rem', height: '3rem' }}
+                          role="status"
+                          aria-hidden="true"
+                        ></span>
+                        <p className="text-muted fw-semibold">
+                          Analyzing prompt structure & complexity...
+                        </p>
                       </div>
                     )}
-                    {storyError && (
-                      <div className="alert alert-danger d-flex align-items-start gap-2 border-0 bg-danger-subtle text-danger-emphasis p-4 rounded-4">
-                        <i className="fas fa-triangle-exclamation mt-1"></i>
-                        <div>{storyError}</div>
-                      </div>
-                    )}
-                  </>
-                )}
 
-                {modalTab === 'testcase' && !checkingTestCase && (
-                  <>
-                    {testCaseResult && (
-                      <div className="markdown-content selectable-text bg-body-secondary p-4 rounded-4 border border-light-subtle shadow-sm">
-                        <ReactMarkdown remarkPlugins={[remarkGfm]}>
-                          {testCaseResult}
-                        </ReactMarkdown>
-                      </div>
+                    {/* Results */}
+                    {modalTab === 'story' && !checkingStory && (
+                      <>
+                        {storyResult && (
+                          <div className="markdown-content selectable-text bg-body-secondary p-4 rounded-4 border border-light-subtle shadow-sm">
+                            <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                              {cleanResultText(storyResult)}
+                            </ReactMarkdown>
+                          </div>
+                        )}
+                        {storyError && (
+                          <div className="alert alert-danger d-flex align-items-start gap-2 border-0 bg-danger-subtle text-danger-emphasis p-4 rounded-4">
+                            <i className="fas fa-triangle-exclamation mt-1"></i>
+                            <div>{storyError}</div>
+                          </div>
+                        )}
+                      </>
                     )}
-                    {testCaseError && (
-                      <div className="alert alert-danger d-flex align-items-start gap-2 border-0 bg-danger-subtle text-danger-emphasis p-4 rounded-4">
-                        <i className="fas fa-triangle-exclamation mt-1"></i>
-                        <div>{testCaseError}</div>
-                      </div>
+
+                    {modalTab === 'testcase' && !checkingTestCase && (
+                      <>
+                        {testCaseResult && (
+                          <div className="markdown-content selectable-text bg-body-secondary p-4 rounded-4 border border-light-subtle shadow-sm">
+                            <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                              {cleanResultText(testCaseResult)}
+                            </ReactMarkdown>
+                          </div>
+                        )}
+                        {testCaseError && (
+                          <div className="alert alert-danger d-flex align-items-start gap-2 border-0 bg-danger-subtle text-danger-emphasis p-4 rounded-4">
+                            <i className="fas fa-triangle-exclamation mt-1"></i>
+                            <div>{testCaseError}</div>
+                          </div>
+                        )}
+                      </>
                     )}
-                  </>
-                )}
+                  </div>
+
+                  <div className="d-flex justify-content-end mt-4 pt-3 border-top">
+                    <button
+                      type="button"
+                      className="btn btn-outline-secondary px-4 py-2 fw-semibold"
+                      onClick={() => {
+                        setShowModal(false);
+                        setModalTab(null);
+                      }}
+                    >
+                      Close
+                    </button>
+                  </div>
+                </div>
               </div>
-
-              <div className="d-flex justify-content-end mt-4 pt-3 border-top">
-                <button
-                  type="button"
-                  className="btn btn-outline-secondary px-4 py-2 fw-semibold"
-                  onClick={() => {
-                    setShowModal(false);
-                    setModalTab(null);
-                  }}
-                >
-                  Close
-                </button>
-              </div>
-            </div>
-          </div>,
+            );
+          })(),
           document.body,
         )}
     </div>


### PR DESCRIPTION
Resolves #92 

Various improvements to the Prompt Checker.

1. Introduces a modal to ensure prompt checker output is visible
2. Along with the full materialised prompt, we pass the user-provided text values and tell the LLM to specifically evaluate those statements for conflicts with the overall prompt, to avoid hallucinations and the LLM flagging issues with the fixed parts of the prompt
3. Short-circuiting when the user hasn't customised the prompt
4. Asking the LLM to categorise its output as either PASS or FAIL (or neither), which is displayed visually along with the full message to simplify users understanding if there is an issue to check or not
5. Using the 'auto' model for the prompt contradiction check to reduce costs for a simple check