### PR TITLE
feat: PR Reviewer Worktrees

### DIFF
--- a/src/main/features/pr-reviewer/__tests__/prReviewerService.test.ts
+++ b/src/main/features/pr-reviewer/__tests__/prReviewerService.test.ts
@@ -1884,17 +1884,23 @@ describe('PRReviewerService', () => {
 
     it('should return hasWorktrees false and count 0 if path does not exist', async () => {
       vi.spyOn(fs, 'existsSync').mockReturnValue(false);
-      const res = await prReviewerService.checkWorktrees('/nonexistent/base');
+      const res = await prReviewerService.checkWorktrees(
+        path.resolve('/nonexistent/base'),
+      );
       expect(res).toEqual({ hasWorktrees: false, worktreeCount: 0 });
     });
 
     it('should return count of directories found in base path', async () => {
       vi.spyOn(fs, 'existsSync').mockReturnValue(true);
       vi.spyOn(fs, 'statSync').mockImplementation((p: any) => {
-        if (p === '/mock/base') {
+        const resolvedP = path.resolve(p);
+        if (resolvedP === path.resolve('/mock/base')) {
           return { isDirectory: () => true } as any;
         }
-        if (p === '/mock/base/dir1' || p === '/mock/base/dir2') {
+        if (
+          resolvedP === path.resolve('/mock/base/dir1') ||
+          resolvedP === path.resolve('/mock/base/dir2')
+        ) {
           return { isDirectory: () => true } as any;
         }
         return { isDirectory: () => false } as any;
@@ -1905,7 +1911,9 @@ describe('PRReviewerService', () => {
         'file1',
       ] as any);
 
-      const res = await prReviewerService.checkWorktrees('/mock/base');
+      const res = await prReviewerService.checkWorktrees(
+        path.resolve('/mock/base'),
+      );
       expect(res).toEqual({ hasWorktrees: true, worktreeCount: 2 });
     });
   });
@@ -1917,26 +1925,34 @@ describe('PRReviewerService', () => {
 
     it('should successfully clean up worktrees using git service where possible and fallback to force remove', async () => {
       vi.spyOn(fs, 'existsSync').mockImplementation((p: any) => {
-        if (p === '/mock/base') return true;
-        if (p === '/mock/base/wt1') return true;
-        if (p === '/mock/base/wt2') return true;
-        if (p === path.join('/mock/base/wt1', '.git')) return true;
-        if (p === path.join('/mock/base/wt2', '.git')) return false;
-        if (p === '/mock/main-repo') return true;
+        const resolvedP = path.resolve(p);
+        if (resolvedP === path.resolve('/mock/base')) return true;
+        if (resolvedP === path.resolve('/mock/base/wt1')) return true;
+        if (resolvedP === path.resolve('/mock/base/wt2')) return true;
+        if (resolvedP === path.resolve('/mock/base/wt1', '.git')) return true;
+        if (resolvedP === path.resolve('/mock/base/wt2', '.git')) return false;
+        if (resolvedP === path.resolve('/mock/main-repo')) return true;
         return false;
       });
       vi.spyOn(fs, 'statSync').mockImplementation((p: any) => {
-        if (p === '/mock/base') return { isDirectory: () => true } as any;
-        if (p === '/mock/base/wt1') return { isDirectory: () => true } as any;
-        if (p === '/mock/base/wt2') return { isDirectory: () => true } as any;
-        if (p === path.join('/mock/base/wt1', '.git'))
+        const resolvedP = path.resolve(p);
+        if (resolvedP === path.resolve('/mock/base'))
+          return { isDirectory: () => true } as any;
+        if (resolvedP === path.resolve('/mock/base/wt1'))
+          return { isDirectory: () => true } as any;
+        if (resolvedP === path.resolve('/mock/base/wt2'))
+          return { isDirectory: () => true } as any;
+        if (resolvedP === path.resolve('/mock/base/wt1', '.git'))
           return { isFile: () => true } as any;
         return { isDirectory: () => false } as any;
       });
       vi.spyOn(fs, 'readdirSync').mockReturnValue(['wt1', 'wt2'] as any);
       vi.spyOn(fs, 'readFileSync').mockImplementation((p: any) => {
-        if (p === path.join('/mock/base/wt1', '.git')) {
-          return 'gitdir: /mock/main-repo/.git/worktrees/wt1';
+        const resolvedP = path.resolve(p);
+        if (resolvedP === path.resolve('/mock/base/wt1', '.git')) {
+          return (
+            'gitdir: ' + path.resolve('/mock/main-repo/.git/worktrees/wt1')
+          );
         }
         throw new Error('Not found');
       });
@@ -1944,14 +1960,16 @@ describe('PRReviewerService', () => {
         .spyOn(fs, 'rmSync')
         .mockImplementation(() => undefined);
 
-      const res = await prReviewerService.cleanWorktrees('/mock/base');
+      const res = await prReviewerService.cleanWorktrees(
+        path.resolve('/mock/base'),
+      );
 
       expect(res).toEqual({ success: true, cleanedCount: 2, errors: [] });
       expect(mockGitService.removeWorktree).toHaveBeenCalledWith(
-        '/mock/main-repo',
-        '/mock/base/wt1',
+        path.resolve('/mock/main-repo'),
+        path.resolve('/mock/base/wt1'),
       );
-      expect(rmSyncMock).toHaveBeenCalledWith('/mock/base/wt2', {
+      expect(rmSyncMock).toHaveBeenCalledWith(path.resolve('/mock/base/wt2'), {
         recursive: true,
         force: true,
       });

--- a/src/main/features/pr-reviewer/__tests__/prReviewerService.test.ts
+++ b/src/main/features/pr-reviewer/__tests__/prReviewerService.test.ts
@@ -67,6 +67,9 @@ describe('PRReviewerService', () => {
       getFileDiff: vi.fn(),
       getCurrentRef: vi.fn().mockResolvedValue('mock-original-ref'),
       restoreRef: vi.fn().mockResolvedValue(undefined),
+      fetchPR: vi.fn(),
+      addWorktree: vi.fn(),
+      removeWorktree: vi.fn(),
     };
     mockCopilotService = {
       createClientAndSession: vi.fn(),
@@ -261,6 +264,36 @@ describe('PRReviewerService', () => {
       await expect(
         prReviewerService.checkoutAndDiff('/mock/repo', 123, 'expected-repo'),
       ).rejects.toThrow('does not match the Pull Request repository');
+    });
+    it('should create a worktree if git worktree settings are enabled', async () => {
+      mockGitService.checkGitRepo.mockResolvedValue(true);
+      mockGitService.fetchPR.mockResolvedValue('worktree-sha');
+      mockGitService.addWorktree.mockResolvedValue(undefined);
+      mockGitService.removeWorktree.mockResolvedValue(undefined);
+      vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+
+      const settings = {
+        gitWorktreeEnabled: true,
+        gitWorktreeBaseDir: '/mock/worktrees',
+      };
+
+      const result = await prReviewerService.checkoutAndDiff(
+        '/mock/repo',
+        123,
+        'repo-name',
+        settings,
+      );
+      expect(result).toEqual({ commitSha: 'worktree-sha' });
+
+      expect(mockGitService.fetchPR).toHaveBeenCalledWith('/mock/repo', 123);
+      expect(mockGitService.addWorktree).toHaveBeenCalledWith(
+        '/mock/repo',
+        expect.stringContaining('repo-name_pr_123'),
+        'worktree-sha',
+      );
+      expect(prReviewerService.getEffectiveRepoPath('/mock/repo')).toContain(
+        'repo-name_pr_123',
+      );
     });
   });
 

--- a/src/main/features/pr-reviewer/__tests__/prReviewerService.test.ts
+++ b/src/main/features/pr-reviewer/__tests__/prReviewerService.test.ts
@@ -1876,4 +1876,85 @@ describe('PRReviewerService', () => {
       );
     });
   });
+
+  describe('checkWorktrees', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('should return hasWorktrees false and count 0 if path does not exist', async () => {
+      vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+      const res = await prReviewerService.checkWorktrees('/nonexistent/base');
+      expect(res).toEqual({ hasWorktrees: false, worktreeCount: 0 });
+    });
+
+    it('should return count of directories found in base path', async () => {
+      vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+      vi.spyOn(fs, 'statSync').mockImplementation((p: any) => {
+        if (p === '/mock/base') {
+          return { isDirectory: () => true } as any;
+        }
+        if (p === '/mock/base/dir1' || p === '/mock/base/dir2') {
+          return { isDirectory: () => true } as any;
+        }
+        return { isDirectory: () => false } as any;
+      });
+      vi.spyOn(fs, 'readdirSync').mockReturnValue([
+        'dir1',
+        'dir2',
+        'file1',
+      ] as any);
+
+      const res = await prReviewerService.checkWorktrees('/mock/base');
+      expect(res).toEqual({ hasWorktrees: true, worktreeCount: 2 });
+    });
+  });
+
+  describe('cleanWorktrees', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('should successfully clean up worktrees using git service where possible and fallback to force remove', async () => {
+      vi.spyOn(fs, 'existsSync').mockImplementation((p: any) => {
+        if (p === '/mock/base') return true;
+        if (p === '/mock/base/wt1') return true;
+        if (p === '/mock/base/wt2') return true;
+        if (p === path.join('/mock/base/wt1', '.git')) return true;
+        if (p === path.join('/mock/base/wt2', '.git')) return false;
+        if (p === '/mock/main-repo') return true;
+        return false;
+      });
+      vi.spyOn(fs, 'statSync').mockImplementation((p: any) => {
+        if (p === '/mock/base') return { isDirectory: () => true } as any;
+        if (p === '/mock/base/wt1') return { isDirectory: () => true } as any;
+        if (p === '/mock/base/wt2') return { isDirectory: () => true } as any;
+        if (p === path.join('/mock/base/wt1', '.git'))
+          return { isFile: () => true } as any;
+        return { isDirectory: () => false } as any;
+      });
+      vi.spyOn(fs, 'readdirSync').mockReturnValue(['wt1', 'wt2'] as any);
+      vi.spyOn(fs, 'readFileSync').mockImplementation((p: any) => {
+        if (p === path.join('/mock/base/wt1', '.git')) {
+          return 'gitdir: /mock/main-repo/.git/worktrees/wt1';
+        }
+        throw new Error('Not found');
+      });
+      const rmSyncMock = vi
+        .spyOn(fs, 'rmSync')
+        .mockImplementation(() => undefined);
+
+      const res = await prReviewerService.cleanWorktrees('/mock/base');
+
+      expect(res).toEqual({ success: true, cleanedCount: 2, errors: [] });
+      expect(mockGitService.removeWorktree).toHaveBeenCalledWith(
+        '/mock/main-repo',
+        '/mock/base/wt1',
+      );
+      expect(rmSyncMock).toHaveBeenCalledWith('/mock/base/wt2', {
+        recursive: true,
+        force: true,
+      });
+    });
+  });
 });

--- a/src/main/features/pr-reviewer/prReviewerService.ts
+++ b/src/main/features/pr-reviewer/prReviewerService.ts
@@ -172,6 +172,10 @@ export function extractFileContextSync(
 
 export class PRReviewerService {
   private activeCheckouts = new Map<string, string>();
+  private activeWorktrees = new Map<
+    string,
+    { worktreePath: string; originalRef: string }
+  >();
 
   constructor(
     private gitService: GitService,
@@ -607,10 +611,31 @@ export class PRReviewerService {
     }
   }
 
+  getEffectiveRepoPath(repoPath: string): string {
+    const active = this.activeWorktrees.get(repoPath);
+    return active ? active.worktreePath : repoPath;
+  }
+
+  async cleanupWorktree(repoPath: string): Promise<void> {
+    const active = this.activeWorktrees.get(repoPath);
+    if (active) {
+      try {
+        await this.gitService.removeWorktree(repoPath, active.worktreePath);
+      } catch (err) {
+        console.error(
+          `Failed to clean up worktree at ${active.worktreePath}:`,
+          err,
+        );
+      }
+      this.activeWorktrees.delete(repoPath);
+    }
+  }
+
   async checkoutAndDiff(
     repoPath: string,
     prNumber: number,
     expectedRepoName?: string,
+    settings?: AppSettings,
   ): Promise<{ commitSha: string }> {
     const isRepo = await this.gitService.checkGitRepo(repoPath);
     if (!isRepo) {
@@ -632,14 +657,7 @@ export class PRReviewerService {
       }
     }
 
-    const isDirty = await this.gitService.hasUncommittedChanges(repoPath);
-    if (isDirty) {
-      throw new Error(
-        'The local git repository has uncommitted changes. Please commit, stash, or revert them first.',
-      );
-    }
-
-    // Restore any existing active checkout for this repo first to avoid leaks
+    // Restore any existing active checkout/worktree first to avoid leaks
     const existingRef = this.activeCheckouts.get(repoPath);
     if (existingRef) {
       try {
@@ -651,6 +669,40 @@ export class PRReviewerService {
         );
       }
       this.activeCheckouts.delete(repoPath);
+    }
+
+    if (settings?.gitWorktreeEnabled && settings?.gitWorktreeBaseDir) {
+      await this.cleanupWorktree(repoPath);
+
+      // Fetch the PR
+      const commitSha = await this.gitService.fetchPR(repoPath, prNumber);
+
+      // Create worktree
+      const sanitizeDirName = (name: string) =>
+        name.replace(/[^a-zA-Z0-9-_]/g, '_');
+      const worktreeName = `${sanitizeDirName(expectedRepoName || 'repo')}_pr_${prNumber}`;
+      const worktreePath = path.join(settings.gitWorktreeBaseDir, worktreeName);
+
+      if (!fs.existsSync(settings.gitWorktreeBaseDir)) {
+        fs.mkdirSync(settings.gitWorktreeBaseDir, { recursive: true });
+      }
+
+      await this.gitService.addWorktree(repoPath, worktreePath, commitSha);
+
+      // Store in worktree mapping
+      this.activeWorktrees.set(repoPath, {
+        worktreePath,
+        originalRef: commitSha,
+      });
+
+      return { commitSha };
+    }
+
+    const isDirty = await this.gitService.hasUncommittedChanges(repoPath);
+    if (isDirty) {
+      throw new Error(
+        'The local git repository has uncommitted changes. Please commit, stash, or revert them first.',
+      );
     }
 
     // Capture the current (original) ref before performing the PR checkout
@@ -687,7 +739,11 @@ export class PRReviewerService {
     try {
       blockerId = powerSaveBlocker.start('prevent-app-suspension');
 
-      const files = await this.gitService.getDiffFiles(repoPath, targetBranch);
+      const effectiveRepoPath = this.getEffectiveRepoPath(repoPath);
+      const files = await this.gitService.getDiffFiles(
+        effectiveRepoPath,
+        targetBranch,
+      );
       const phases = await this.loadPhasesFromDisk();
 
       if (phases.length === 0) {
@@ -901,7 +957,7 @@ export class PRReviewerService {
 
         const sessionOpts = attachStory
           ? {
-              workingDirectory: repoPath,
+              workingDirectory: effectiveRepoPath,
               tools: [
                 createRequestDocumentationTool(
                   this.getDocProvider,
@@ -909,7 +965,7 @@ export class PRReviewerService {
                 ),
               ],
             }
-          : { workingDirectory: repoPath };
+          : { workingDirectory: effectiveRepoPath };
 
         const { client, session } =
           await this.copilotService.createClientAndSession(
@@ -951,7 +1007,7 @@ export class PRReviewerService {
                 const contextSize =
                   typeof obj.context === 'number' ? obj.context : 0;
                 const codeLines = extractFileContextSync(
-                  repoPath,
+                  effectiveRepoPath,
                   obj.file,
                   obj.line,
                   contextSize,
@@ -1030,17 +1086,21 @@ export class PRReviewerService {
         powerSaveBlocker.stop(blockerId);
       }
 
-      const originalRef = this.activeCheckouts.get(repoPath);
-      if (originalRef) {
-        try {
-          await this.gitService.restoreRef(repoPath, originalRef);
-        } catch (err) {
-          console.error(
-            `Failed to automatically restore repository at ${repoPath}:`,
-            err,
-          );
+      if (settings.gitWorktreeEnabled && settings.gitWorktreeBaseDir) {
+        await this.cleanupWorktree(repoPath);
+      } else {
+        const originalRef = this.activeCheckouts.get(repoPath);
+        if (originalRef) {
+          try {
+            await this.gitService.restoreRef(repoPath, originalRef);
+          } catch (err) {
+            console.error(
+              `Failed to automatically restore repository at ${repoPath}:`,
+              err,
+            );
+          }
+          this.activeCheckouts.delete(repoPath);
         }
-        this.activeCheckouts.delete(repoPath);
       }
     }
   }

--- a/src/main/features/pr-reviewer/prReviewerService.ts
+++ b/src/main/features/pr-reviewer/prReviewerService.ts
@@ -631,6 +631,124 @@ export class PRReviewerService {
     }
   }
 
+  async checkWorktrees(
+    baseDir: string,
+  ): Promise<{ hasWorktrees: boolean; worktreeCount: number }> {
+    try {
+      if (!baseDir) {
+        return { hasWorktrees: false, worktreeCount: 0 };
+      }
+      const resolved = path.resolve(baseDir);
+      if (!fs.existsSync(resolved)) {
+        return { hasWorktrees: false, worktreeCount: 0 };
+      }
+      const stat = fs.statSync(resolved);
+      if (!stat.isDirectory()) {
+        return { hasWorktrees: false, worktreeCount: 0 };
+      }
+      const files = fs.readdirSync(resolved);
+      let worktreeCount = 0;
+      for (const file of files) {
+        const fullPath = path.join(resolved, file);
+        try {
+          const s = fs.statSync(fullPath);
+          if (s.isDirectory()) {
+            worktreeCount++;
+          }
+        } catch {
+          // Ignore files we cannot access
+        }
+      }
+      return {
+        hasWorktrees: worktreeCount > 0,
+        worktreeCount,
+      };
+    } catch (err) {
+      console.error(`Error in checkWorktrees for ${baseDir}:`, err);
+      return { hasWorktrees: false, worktreeCount: 0 };
+    }
+  }
+
+  async cleanWorktrees(
+    baseDir: string,
+  ): Promise<{ success: boolean; cleanedCount: number; errors: string[] }> {
+    const errors: string[] = [];
+    let cleanedCount = 0;
+    try {
+      if (!baseDir) {
+        return { success: true, cleanedCount: 0, errors: [] };
+      }
+      const resolved = path.resolve(baseDir);
+      if (!fs.existsSync(resolved)) {
+        return { success: true, cleanedCount: 0, errors: [] };
+      }
+      const files = fs.readdirSync(resolved);
+      for (const file of files) {
+        const worktreePath = path.join(resolved, file);
+        try {
+          const s = fs.statSync(worktreePath);
+          if (!s.isDirectory()) {
+            continue;
+          }
+
+          let removed = false;
+          const gitFilePath = path.join(worktreePath, '.git');
+          if (fs.existsSync(gitFilePath)) {
+            const gitFileStat = fs.statSync(gitFilePath);
+            if (gitFileStat.isFile()) {
+              const content = fs.readFileSync(gitFilePath, 'utf8');
+              const match = content.match(/gitdir:\s*(.+)/);
+              if (match) {
+                const gitDir = match[1].trim();
+                const normalizedGitDir = path.normalize(gitDir);
+                const marker = path.join('.git', 'worktrees');
+                const index = normalizedGitDir.indexOf(marker);
+                if (index !== -1) {
+                  const mainRepoPath = path.resolve(
+                    normalizedGitDir.substring(0, index),
+                  );
+                  if (fs.existsSync(mainRepoPath)) {
+                    await this.gitService.removeWorktree(
+                      mainRepoPath,
+                      worktreePath,
+                    );
+                    removed = true;
+                  }
+                }
+              }
+            }
+          }
+
+          if (!removed) {
+            if (fs.existsSync(worktreePath)) {
+              fs.rmSync(worktreePath, { recursive: true, force: true });
+            }
+          }
+          cleanedCount++;
+        } catch (err) {
+          const errMsg = err instanceof Error ? err.message : String(err);
+          errors.push(`Failed to clean up ${file}: ${errMsg}`);
+          console.error(`Error cleaning up worktree at ${worktreePath}:`, err);
+        }
+      }
+
+      this.activeWorktrees.clear();
+
+      return {
+        success: errors.length === 0,
+        cleanedCount,
+        errors,
+      };
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      return {
+        success: false,
+        cleanedCount,
+        errors: [errMsg],
+      };
+    }
+  }
+
   async checkoutAndDiff(
     repoPath: string,
     prNumber: number,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -373,6 +373,20 @@ ipcMain.handle('pr-reviewer:open-directory', async () => {
 });
 
 ipcMain.handle(
+  'pr-reviewer:check-worktrees',
+  async (event, baseDir: string) => {
+    return prReviewerService.checkWorktrees(baseDir);
+  },
+);
+
+ipcMain.handle(
+  'pr-reviewer:clean-worktrees',
+  async (event, baseDir: string) => {
+    return prReviewerService.cleanWorktrees(baseDir);
+  },
+);
+
+ipcMain.handle(
   'pr-reviewer:review',
   async (
     event,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -323,10 +323,13 @@ ipcMain.handle(
 ipcMain.handle(
   'pr-reviewer:checkout',
   async (event, repoPath, prNumber, expectedRepoName) => {
+    const s = await initStore();
+    const settings = (s.get('settings') ?? {}) as AppSettings;
     return prReviewerService.checkoutAndDiff(
       repoPath,
       prNumber,
       expectedRepoName,
+      settings,
     );
   },
 );
@@ -334,14 +337,16 @@ ipcMain.handle(
 ipcMain.handle(
   'pr-reviewer:get-diff-files',
   async (event, repoPath, targetBranch) => {
-    return gitService.getDiffFiles(repoPath, targetBranch);
+    const effectivePath = prReviewerService.getEffectiveRepoPath(repoPath);
+    return gitService.getDiffFiles(effectivePath, targetBranch);
   },
 );
 
 ipcMain.handle(
   'pr-reviewer:get-file-diff',
   async (event, repoPath, targetBranch, filePath) => {
-    return gitService.getFileDiff(repoPath, targetBranch, filePath);
+    const effectivePath = prReviewerService.getEffectiveRepoPath(repoPath);
+    return gitService.getFileDiff(effectivePath, targetBranch, filePath);
   },
 );
 

--- a/src/main/infrastructure/git/__tests__/gitService.test.ts
+++ b/src/main/infrastructure/git/__tests__/gitService.test.ts
@@ -301,4 +301,72 @@ describe('GitService', () => {
       expect(calls).toEqual(['git status --porcelain', 'git checkout master']);
     });
   });
+
+  describe('fetchPR', () => {
+    it('should fetch merge branch and return commit SHA', async () => {
+      const commandsRun: string[] = [];
+      mockExec = (cmd: string, options: any, cb: any) => {
+        commandsRun.push(cmd);
+        if (cmd === 'git rev-parse FETCH_HEAD') {
+          cb(null, { stdout: 'sha123\n' });
+        } else {
+          cb(null, { stdout: '' });
+        }
+      };
+      const sha = await gitService.fetchPR(repoPath, 123);
+      expect(sha).toBe('sha123');
+      expect(commandsRun).toEqual([
+        'git fetch origin refs/pull/123/merge',
+        'git rev-parse FETCH_HEAD',
+      ]);
+    });
+
+    it('should fallback to head branch if merge branch fetch fails', async () => {
+      const commandsRun: string[] = [];
+      mockExec = (cmd: string, options: any, cb: any) => {
+        commandsRun.push(cmd);
+        if (cmd.includes('refs/pull/123/merge')) {
+          cb(new Error('failed merge'), { stdout: '' });
+        } else if (cmd === 'git rev-parse FETCH_HEAD') {
+          cb(null, { stdout: 'sha456\n' });
+        } else {
+          cb(null, { stdout: '' });
+        }
+      };
+      const sha = await gitService.fetchPR(repoPath, 123);
+      expect(sha).toBe('sha456');
+      expect(commandsRun).toEqual([
+        'git fetch origin refs/pull/123/merge',
+        'git fetch origin refs/pull/123/head',
+        'git rev-parse FETCH_HEAD',
+      ]);
+    });
+  });
+
+  describe('addWorktree', () => {
+    it('should run worktree remove then add command', async () => {
+      const commandsRun: string[] = [];
+      mockExec = (cmd: string, options: any, cb: any) => {
+        commandsRun.push(cmd);
+        cb(null, { stdout: '' });
+      };
+      await gitService.addWorktree(repoPath, '/wt/path', 'sha123');
+      expect(commandsRun).toEqual([
+        'git worktree remove --force "/wt/path"',
+        'git worktree add --detach "/wt/path" sha123',
+      ]);
+    });
+  });
+
+  describe('removeWorktree', () => {
+    it('should run git worktree remove command', async () => {
+      const commandsRun: string[] = [];
+      mockExec = (cmd: string, options: any, cb: any) => {
+        commandsRun.push(cmd);
+        cb(null, { stdout: '' });
+      };
+      await gitService.removeWorktree(repoPath, '/wt/path');
+      expect(commandsRun).toEqual(['git worktree remove --force "/wt/path"']);
+    });
+  });
 });

--- a/src/main/infrastructure/git/gitService.ts
+++ b/src/main/infrastructure/git/gitService.ts
@@ -1,5 +1,6 @@
 import { exec } from 'child_process';
 import { promisify } from 'util';
+import fs from 'fs';
 import { PRDiffFile } from '../../../types';
 
 const execPromise = promisify(exec);
@@ -190,5 +191,65 @@ export class GitService {
       );
     }
     await this.runCommand(repoPath, `git checkout ${ref}`);
+  }
+
+  async fetchPR(repoPath: string, prNumber: number): Promise<string> {
+    try {
+      await this.runCommand(
+        repoPath,
+        `git fetch origin refs/pull/${prNumber}/merge`,
+      );
+      return await this.runCommand(repoPath, 'git rev-parse FETCH_HEAD');
+    } catch (error: unknown) {
+      try {
+        await this.runCommand(
+          repoPath,
+          `git fetch origin refs/pull/${prNumber}/head`,
+        );
+        return await this.runCommand(repoPath, 'git rev-parse FETCH_HEAD');
+      } catch (_fallbackError: unknown) {
+        const errMsg = error instanceof Error ? error.message : String(error);
+        throw new Error(`Failed to fetch PR #${prNumber}: ${errMsg}`);
+      }
+    }
+  }
+
+  async addWorktree(
+    repoPath: string,
+    worktreePath: string,
+    commitSha: string,
+  ): Promise<void> {
+    // Clean up any stale directory/worktree metadata at that location first
+    await this.removeWorktree(repoPath, worktreePath);
+    await this.runCommand(
+      repoPath,
+      `git worktree add --detach "${worktreePath}" ${commitSha}`,
+    );
+  }
+
+  async removeWorktree(repoPath: string, worktreePath: string): Promise<void> {
+    try {
+      await this.runCommand(
+        repoPath,
+        `git worktree remove --force "${worktreePath}"`,
+      );
+    } catch (_error: unknown) {
+      // Fallback: manually delete directory and run prune
+      try {
+        if (fs.existsSync(worktreePath)) {
+          fs.rmSync(worktreePath, { recursive: true, force: true });
+        }
+      } catch (rmErr) {
+        console.error(
+          `Failed to manually remove worktree directory at ${worktreePath}:`,
+          rmErr,
+        );
+      }
+      try {
+        await this.runCommand(repoPath, 'git worktree prune');
+      } catch (pruneErr) {
+        console.error(`Failed to prune worktree metadata:`, pruneErr);
+      }
+    }
   }
 }

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -140,6 +140,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('pr-reviewer:get-phases'),
   openPRReviewerDirectory: (): Promise<boolean> =>
     ipcRenderer.invoke('pr-reviewer:open-directory'),
+  checkWorktrees: (baseDir: string) =>
+    ipcRenderer.invoke('pr-reviewer:check-worktrees', baseDir),
+  cleanWorktrees: (baseDir: string) =>
+    ipcRenderer.invoke('pr-reviewer:clean-worktrees', baseDir),
+
   reviewPR: (
     repoPath: string,
     targetBranch: string,

--- a/src/renderer/features/settings/components/GeneralSettings.tsx
+++ b/src/renderer/features/settings/components/GeneralSettings.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import { createPortal } from 'react-dom';
 
 interface GeneralSettingsProps {
   theme: 'auto' | 'light' | 'dark';
@@ -17,116 +18,278 @@ const GeneralSettings: React.FC<GeneralSettingsProps> = ({
   gitWorktreeBaseDir,
   setGitWorktreeBaseDir,
 }) => {
+  const [hasWorktrees, setHasWorktrees] = useState(false);
+  const [worktreeCount, setWorktreeCount] = useState(0);
+  const [showConfirmModal, setShowConfirmModal] = useState(false);
+  const [isCleaning, setIsCleaning] = useState(false);
+  const [cleanupResult, setCleanupResult] = useState<{
+    success: boolean;
+    count: number;
+    error?: string;
+  } | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    const check = async () => {
+      if (!gitWorktreeBaseDir) {
+        setHasWorktrees(false);
+        setWorktreeCount(0);
+        return;
+      }
+      try {
+        const result =
+          await window.electronAPI.checkWorktrees(gitWorktreeBaseDir);
+        if (active) {
+          setHasWorktrees(result.hasWorktrees);
+          setWorktreeCount(result.worktreeCount);
+        }
+      } catch (err) {
+        console.error('Error checking worktrees:', err);
+        if (active) {
+          setHasWorktrees(false);
+          setWorktreeCount(0);
+        }
+      }
+    };
+    check();
+    return () => {
+      active = false;
+    };
+  }, [gitWorktreeBaseDir]);
+
+  const handleCleanWorktrees = async () => {
+    try {
+      setIsCleaning(true);
+      const result =
+        await window.electronAPI.cleanWorktrees(gitWorktreeBaseDir);
+      setCleanupResult({
+        success: result.success,
+        count: result.cleanedCount,
+        error: result.errors?.join('\n'),
+      });
+      const checkResult =
+        await window.electronAPI.checkWorktrees(gitWorktreeBaseDir);
+      setHasWorktrees(checkResult.hasWorktrees);
+      setWorktreeCount(checkResult.worktreeCount);
+    } catch (err) {
+      console.error('Failed to clean worktrees:', err);
+      const errMsg = err instanceof Error ? err.message : String(err);
+      setCleanupResult({
+        success: false,
+        count: 0,
+        error: errMsg,
+      });
+    } finally {
+      setIsCleaning(false);
+      setShowConfirmModal(false);
+    }
+  };
+
   return (
-    <div className="card shadow-sm border-0 bg-body-tertiary">
-      <div className="card-body p-4">
-        <h5 className="mb-4 border-bottom pb-2">
-          <i className="fas fa-palette me-2 text-primary"></i>Appearance
-          Settings
-        </h5>
+    <>
+      <div className="card shadow-sm border-0 bg-body-tertiary">
+        <div className="card-body p-4">
+          <h5 className="mb-4 border-bottom pb-2">
+            <i className="fas fa-palette me-2 text-primary"></i>Appearance
+            Settings
+          </h5>
 
-        <div className="mb-4 border-bottom pb-4">
-          <label className="form-label d-block fw-semibold text-muted small uppercase tracking-wider mb-3">
-            Interface Theme
-          </label>
-          <p className="text-muted small mb-3">
-            Choose how Stitch appears. Selecting "Auto" will sync with your
-            macOS system theme settings.
-          </p>
-          <div className="btn-group" role="group" aria-label="Theme selection">
-            <button
-              type="button"
-              className={`btn px-4 py-2 d-flex align-items-center gap-2 ${theme === 'auto' ? 'btn-primary' : 'btn-outline-secondary'}`}
-              onClick={() => setTheme('auto')}
-            >
-              <i className="fas fa-circle-half-stroke"></i>
-              Auto
-            </button>
-            <button
-              type="button"
-              className={`btn px-4 py-2 d-flex align-items-center gap-2 ${theme === 'light' ? 'btn-primary' : 'btn-outline-secondary'}`}
-              onClick={() => setTheme('light')}
-            >
-              <i className="fas fa-sun"></i>
-              Light
-            </button>
-            <button
-              type="button"
-              className={`btn px-4 py-2 d-flex align-items-center gap-2 ${theme === 'dark' ? 'btn-primary' : 'btn-outline-secondary'}`}
-              onClick={() => setTheme('dark')}
-            >
-              <i className="fas fa-moon"></i>
-              Dark
-            </button>
-          </div>
-        </div>
-
-        <h5 className="mb-4 mt-4 border-bottom pb-2">
-          <i className="fas fa-code-branch me-2 text-primary"></i>Git Worktree
-          Settings
-        </h5>
-
-        <div className="mb-4">
-          <div className="form-check form-switch mb-3">
-            <input
-              className="form-check-input"
-              type="checkbox"
-              id="gitWorktreeEnabled"
-              checked={gitWorktreeEnabled}
-              onChange={(e) => setGitWorktreeEnabled(e.target.checked)}
-            />
-            <label
-              className="form-check-label fw-semibold"
-              htmlFor="gitWorktreeEnabled"
-            >
-              Enable Git Worktree for PR Reviews
+          <div className="mb-4 border-bottom pb-4">
+            <label className="form-label d-block fw-semibold text-muted small uppercase tracking-wider mb-3">
+              Interface Theme
             </label>
-          </div>
-          <p className="text-muted small mb-3">
-            When enabled, Stitch will create a separate git worktree for
-            checking out the PR. This avoids dirtying or modifying your local
-            working directory during review.
-          </p>
-        </div>
-
-        {gitWorktreeEnabled && (
-          <div className="mb-3">
-            <label className="form-label fw-semibold text-muted small uppercase tracking-wider mb-2">
-              Worktree Base Directory
-            </label>
-            <div className="input-group">
-              <input
-                type="text"
-                className="form-control"
-                placeholder="Select a directory to store worktrees..."
-                value={gitWorktreeBaseDir}
-                onChange={(e) => setGitWorktreeBaseDir(e.target.value)}
-              />
+            <p className="text-muted small mb-3">
+              Choose how Stitch appears. Selecting "Auto" will sync with your
+              macOS system theme settings.
+            </p>
+            <div
+              className="btn-group"
+              role="group"
+              aria-label="Theme selection"
+            >
               <button
-                className="btn btn-outline-secondary"
                 type="button"
-                onClick={async () => {
-                  try {
-                    const path = await window.electronAPI.selectDirectory();
-                    if (path) {
-                      setGitWorktreeBaseDir(path);
-                    }
-                  } catch (err) {
-                    console.error('Failed to select worktree directory:', err);
-                  }
-                }}
+                className={`btn px-4 py-2 d-flex align-items-center gap-2 ${theme === 'auto' ? 'btn-primary' : 'btn-outline-secondary'}`}
+                onClick={() => setTheme('auto')}
               >
-                Browse...
+                <i className="fas fa-circle-half-stroke"></i>
+                Auto
+              </button>
+              <button
+                type="button"
+                className={`btn px-4 py-2 d-flex align-items-center gap-2 ${theme === 'light' ? 'btn-primary' : 'btn-outline-secondary'}`}
+                onClick={() => setTheme('light')}
+              >
+                <i className="fas fa-sun"></i>
+                Light
+              </button>
+              <button
+                type="button"
+                className={`btn px-4 py-2 d-flex align-items-center gap-2 ${theme === 'dark' ? 'btn-primary' : 'btn-outline-secondary'}`}
+                onClick={() => setTheme('dark')}
+              >
+                <i className="fas fa-moon"></i>
+                Dark
               </button>
             </div>
-            <p className="text-muted small mt-2 mb-0">
-              Stitch will create temporary directories under this base directory
-              for each PR review.
+          </div>
+
+          <h5 className="mb-4 mt-4 border-bottom pb-2">
+            <i className="fas fa-code-branch me-2 text-primary"></i>Git Worktree
+            Settings
+          </h5>
+
+          <div className="mb-4">
+            <div className="form-check form-switch mb-3">
+              <input
+                className="form-check-input"
+                type="checkbox"
+                id="gitWorktreeEnabled"
+                checked={gitWorktreeEnabled}
+                onChange={(e) => setGitWorktreeEnabled(e.target.checked)}
+              />
+              <label
+                className="form-check-label fw-semibold"
+                htmlFor="gitWorktreeEnabled"
+              >
+                Enable Git Worktree for PR Reviews
+              </label>
+            </div>
+            <p className="text-muted small mb-3">
+              When enabled, Stitch will create a separate git worktree for
+              checking out the PR. This avoids dirtying or modifying your local
+              working directory during review.
             </p>
           </div>
-        )}
+
+          {gitWorktreeEnabled && (
+            <div className="mb-3">
+              <label className="form-label fw-semibold text-muted small uppercase tracking-wider mb-2">
+                Worktree Base Directory
+              </label>
+              <div className="input-group">
+                <input
+                  type="text"
+                  className="form-control"
+                  placeholder="Select a directory to store worktrees..."
+                  value={gitWorktreeBaseDir}
+                  onChange={(e) => setGitWorktreeBaseDir(e.target.value)}
+                />
+                <button
+                  className="btn btn-outline-secondary"
+                  type="button"
+                  onClick={async () => {
+                    try {
+                      const path = await window.electronAPI.selectDirectory();
+                      if (path) {
+                        setGitWorktreeBaseDir(path);
+                      }
+                    } catch (err) {
+                      console.error(
+                        'Failed to select worktree directory:',
+                        err,
+                      );
+                    }
+                  }}
+                >
+                  Browse...
+                </button>
+              </div>
+              <p className="text-muted small mt-2 mb-3">
+                Stitch will create temporary directories under this base
+                directory for each PR review.
+              </p>
+
+              <div className="d-flex align-items-center gap-3">
+                <button
+                  type="button"
+                  className="btn btn-outline-danger d-flex align-items-center gap-2"
+                  disabled={!hasWorktrees || isCleaning}
+                  onClick={() => {
+                    setCleanupResult(null);
+                    setShowConfirmModal(true);
+                  }}
+                >
+                  <i className="fas fa-trash-can"></i>
+                  Clean Up
+                </button>
+                <span className="text-muted small">
+                  {hasWorktrees
+                    ? `Found ${worktreeCount} directory${worktreeCount > 1 ? 's' : ''} to clean up.`
+                    : 'Nothing to clean up'}
+                </span>
+              </div>
+
+              {cleanupResult && (
+                <div
+                  className={`alert ${cleanupResult.success ? 'alert-success' : 'alert-danger'} mt-3 mb-0 small p-2 w-100`}
+                  style={{ whiteSpace: 'pre-wrap' }}
+                >
+                  {cleanupResult.success
+                    ? `Successfully cleaned up ${cleanupResult.count} worktree directory(s).`
+                    : `Cleaned up ${cleanupResult.count} directory(s) with errors:\n${cleanupResult.error}`}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
       </div>
-    </div>
+
+      {showConfirmModal &&
+        createPortal(
+          <div className="env-error-overlay" style={{ zIndex: 3000 }}>
+            <div className="env-error-modal" style={{ maxWidth: '550px' }}>
+              <div className="text-danger mb-3" style={{ fontSize: '3rem' }}>
+                <i className="fas fa-exclamation-triangle"></i>
+              </div>
+              <h4 className="fw-bold mb-3">Clean Up Git Worktrees</h4>
+              <div className="alert alert-danger w-100 text-start mb-3">
+                <h6 className="fw-bold">
+                  <i className="fas fa-circle-exclamation me-2"></i>Strong
+                  Warning:
+                </h6>
+                <p className="mb-0 small">
+                  Please ensure no code reviews are actively running in any
+                  other instance of Stitch before proceeding. Force-removing
+                  worktrees that are currently in use could corrupt repositories
+                  or cause active reviews to fail.
+                </p>
+              </div>
+              <p className="mb-4 text-muted">
+                This will remove all subdirectories under{' '}
+                <code>{gitWorktreeBaseDir}</code> and clear their Git worktree
+                registrations. Are you sure?
+              </p>
+              <div className="d-flex gap-3 w-100 justify-content-center">
+                <button
+                  type="button"
+                  className="btn btn-secondary px-4"
+                  disabled={isCleaning}
+                  onClick={() => setShowConfirmModal(false)}
+                >
+                  No
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-danger px-4 d-flex align-items-center gap-2"
+                  disabled={isCleaning}
+                  onClick={handleCleanWorktrees}
+                >
+                  {isCleaning && (
+                    <span
+                      className="spinner-border spinner-border-sm"
+                      role="status"
+                      aria-hidden="true"
+                    ></span>
+                  )}
+                  Yes
+                </button>
+              </div>
+            </div>
+          </div>,
+          document.body,
+        )}
+    </>
   );
 };
 

--- a/src/renderer/features/settings/components/GeneralSettings.tsx
+++ b/src/renderer/features/settings/components/GeneralSettings.tsx
@@ -3,11 +3,19 @@ import React from 'react';
 interface GeneralSettingsProps {
   theme: 'auto' | 'light' | 'dark';
   setTheme: (theme: 'auto' | 'light' | 'dark') => void;
+  gitWorktreeEnabled: boolean;
+  setGitWorktreeEnabled: (enabled: boolean) => void;
+  gitWorktreeBaseDir: string;
+  setGitWorktreeBaseDir: (dir: string) => void;
 }
 
 const GeneralSettings: React.FC<GeneralSettingsProps> = ({
   theme,
   setTheme,
+  gitWorktreeEnabled,
+  setGitWorktreeEnabled,
+  gitWorktreeBaseDir,
+  setGitWorktreeBaseDir,
 }) => {
   return (
     <div className="card shadow-sm border-0 bg-body-tertiary">
@@ -17,7 +25,7 @@ const GeneralSettings: React.FC<GeneralSettingsProps> = ({
           Settings
         </h5>
 
-        <div className="mb-4">
+        <div className="mb-4 border-bottom pb-4">
           <label className="form-label d-block fw-semibold text-muted small uppercase tracking-wider mb-3">
             Interface Theme
           </label>
@@ -52,6 +60,71 @@ const GeneralSettings: React.FC<GeneralSettingsProps> = ({
             </button>
           </div>
         </div>
+
+        <h5 className="mb-4 mt-4 border-bottom pb-2">
+          <i className="fas fa-code-branch me-2 text-primary"></i>Git Worktree
+          Settings
+        </h5>
+
+        <div className="mb-4">
+          <div className="form-check form-switch mb-3">
+            <input
+              className="form-check-input"
+              type="checkbox"
+              id="gitWorktreeEnabled"
+              checked={gitWorktreeEnabled}
+              onChange={(e) => setGitWorktreeEnabled(e.target.checked)}
+            />
+            <label
+              className="form-check-label fw-semibold"
+              htmlFor="gitWorktreeEnabled"
+            >
+              Enable Git Worktree for PR Reviews
+            </label>
+          </div>
+          <p className="text-muted small mb-3">
+            When enabled, Stitch will create a separate git worktree for
+            checking out the PR. This avoids dirtying or modifying your local
+            working directory during review.
+          </p>
+        </div>
+
+        {gitWorktreeEnabled && (
+          <div className="mb-3">
+            <label className="form-label fw-semibold text-muted small uppercase tracking-wider mb-2">
+              Worktree Base Directory
+            </label>
+            <div className="input-group">
+              <input
+                type="text"
+                className="form-control"
+                placeholder="Select a directory to store worktrees..."
+                value={gitWorktreeBaseDir}
+                onChange={(e) => setGitWorktreeBaseDir(e.target.value)}
+              />
+              <button
+                className="btn btn-outline-secondary"
+                type="button"
+                onClick={async () => {
+                  try {
+                    const path = await window.electronAPI.selectDirectory();
+                    if (path) {
+                      setGitWorktreeBaseDir(path);
+                    }
+                  } catch (err) {
+                    console.error('Failed to select worktree directory:', err);
+                  }
+                }}
+              >
+                Browse...
+              </button>
+            </div>
+            <p className="text-muted small mt-2 mb-0">
+              Stitch will create temporary directories under this base directory
+              for each PR review.
+            </p>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/renderer/features/settings/components/Settings.tsx
+++ b/src/renderer/features/settings/components/Settings.tsx
@@ -18,6 +18,8 @@ const Settings: React.FC = () => {
   const [confluenceUser, setConfluenceUser] = useState('');
   const [confluenceToken, setConfluenceToken] = useState('');
   const [theme, setTheme] = useState<'auto' | 'light' | 'dark'>('auto');
+  const [gitWorktreeEnabled, setGitWorktreeEnabled] = useState(false);
+  const [gitWorktreeBaseDir, setGitWorktreeBaseDir] = useState('');
   const [statusMessage, setStatusMessage] = useState('');
   const [authStatus, setAuthStatus] = useState<CopilotAuth | null>(null);
   const [checkingAuth, setCheckingAuth] = useState(false);
@@ -59,6 +61,8 @@ const Settings: React.FC = () => {
           setConfluenceUser(settings.confluenceUser || '');
           setConfluenceToken(settings.confluenceToken || '');
           setTheme(settings.theme || 'auto');
+          setGitWorktreeEnabled(settings.gitWorktreeEnabled || false);
+          setGitWorktreeBaseDir(settings.gitWorktreeBaseDir || '');
 
           // Load custom prompts
           const prompts = settings.prompts || {};
@@ -101,6 +105,8 @@ const Settings: React.FC = () => {
         confluenceUser: confluenceUser,
         confluenceToken: confluenceToken,
         theme: theme,
+        gitWorktreeEnabled: gitWorktreeEnabled,
+        gitWorktreeBaseDir: gitWorktreeBaseDir,
         prompts: {
           storyWriter: {
             general: storyGeneral,
@@ -155,7 +161,16 @@ const Settings: React.FC = () => {
   const renderActiveTab = () => {
     switch (activeTab) {
       case 'general':
-        return <GeneralSettings theme={theme} setTheme={setTheme} />;
+        return (
+          <GeneralSettings
+            theme={theme}
+            setTheme={setTheme}
+            gitWorktreeEnabled={gitWorktreeEnabled}
+            setGitWorktreeEnabled={setGitWorktreeEnabled}
+            gitWorktreeBaseDir={gitWorktreeBaseDir}
+            setGitWorktreeBaseDir={setGitWorktreeBaseDir}
+          />
+        );
       case 'azure':
         return (
           <AzureSettings

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -85,6 +85,13 @@ export interface IElectronAPI {
   }>;
   getPhases: () => Promise<ReviewPhase[]>;
   openPRReviewerDirectory: () => Promise<boolean>;
+  checkWorktrees: (
+    baseDir: string,
+  ) => Promise<{ hasWorktrees: boolean; worktreeCount: number }>;
+  cleanWorktrees: (
+    baseDir: string,
+  ) => Promise<{ success: boolean; cleanedCount: number; errors: string[] }>;
+
   reviewPR: (
     repoPath: string,
     targetBranch: string,

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,8 @@ export type AppSettings = {
   confluenceUser?: string;
   confluenceToken?: string;
   theme?: 'auto' | 'light' | 'dark';
+  gitWorktreeEnabled?: boolean;
+  gitWorktreeBaseDir?: string;
   prompts?: {
     storyWriter?: {
       general?: string;


### PR DESCRIPTION
In the initial build of PR Reviewer we just directly use the local repository, checking out the changes and running the reviewer. This has a few limitations;

1. Users can't work on something else in the same repo while a review is ongoing
2. Multiple reviews against the same repo can't be processed
3. The repo must be clean before the review can occur

This PR adds an **optional** setting to enable Worktrees. The user specifies a base directory to use for any worktree, and if enabled, the PR Reviewer will use an isolated worktree, based on the Repo name and PR ID, to keep its work separate.

The application tries its best to clean up when it's done, but if it doesn't work out, the settings page offers a "Clean Up" button to force cleanup the worktree directory. Because this is dangerous, particularly if a separate instance of the app is performing a review, a very strong warning modal is displayed and the user must confirm before we clean up.