### PR TITLE
feat(pr-reviewer): run review phases in parallel using a worker pool

### DIFF
--- a/src/main/features/pr-reviewer/__tests__/prReviewerService.test.ts
+++ b/src/main/features/pr-reviewer/__tests__/prReviewerService.test.ts
@@ -595,6 +595,7 @@ describe('PRReviewerService', () => {
           context: 1,
           comment: 'Review',
           phase: 'Definition of Done',
+          phaseId: '010-definition-of-done.md',
           codeLines: [
             { line: 1, text: 'const a = 1;', isTarget: false },
             { line: 2, text: 'const b = 2;', isTarget: true },
@@ -607,7 +608,7 @@ describe('PRReviewerService', () => {
       mockReadFileSync.mockRestore();
     });
 
-    it('should wrap onLine callback and pass status message untouched when type is status', async () => {
+    it('should wrap onLine callback and tag status message when type is status', async () => {
       mockGitService.getDiffFiles.mockResolvedValue([
         { path: 'src/index.ts', status: 'modified' },
       ]);
@@ -650,6 +651,8 @@ describe('PRReviewerService', () => {
         JSON.stringify({
           type: 'status',
           status: 'Checking index.ts',
+          phase: 'Definition of Done',
+          phaseId: '010-definition-of-done.md',
         }),
       );
     });

--- a/src/main/features/pr-reviewer/prReviewerService.ts
+++ b/src/main/features/pr-reviewer/prReviewerService.ts
@@ -845,6 +845,7 @@ export class PRReviewerService {
       prDescription?: string;
       prId?: string;
       onLine?: (line: string) => void;
+      maxParallelism?: number;
     } = {},
   ): Promise<string> {
     if (!options.enabledPhaseIds || options.enabledPhaseIds.length === 0) {
@@ -1022,7 +1023,22 @@ export class PRReviewerService {
       };
 
       const numCPUs = os.cpus().length;
-      const maxWorkers = Math.max(1, Math.floor(numCPUs / 2));
+      let maxWorkers: number;
+      if (numCPUs < 4) {
+        maxWorkers = 1;
+      } else {
+        const preferredLimit =
+          options.maxParallelism ?? settings.maxParallelism;
+        if (
+          preferredLimit !== undefined &&
+          preferredLimit >= 1 &&
+          preferredLimit <= numCPUs - 2
+        ) {
+          maxWorkers = preferredLimit;
+        } else {
+          maxWorkers = Math.max(1, Math.floor(numCPUs / 2));
+        }
+      }
       const workerCount = Math.min(maxWorkers, enabledPhases.length);
 
       const runWorker = async () => {

--- a/src/main/features/pr-reviewer/prReviewerService.ts
+++ b/src/main/features/pr-reviewer/prReviewerService.ts
@@ -1009,194 +1009,250 @@ export class PRReviewerService {
         }
       }
 
-      let accumulatedResult = '';
+      const results: string[] = new Array(enabledPhases.length).fill('');
+      let firstError: Error | null = null;
+      let queueIndex = 0;
 
-      for (const phase of enabledPhases) {
-        let eligibleFiles = [...files];
+      const getNextPhase = () => {
+        if (queueIndex < enabledPhases.length) {
+          const index = queueIndex++;
+          return { phase: enabledPhases[index], phaseIdx: index };
+        }
+        return null;
+      };
 
-        if (phase.include) {
-          try {
-            const isMatch = getGlobMatcher(phase.include);
-            eligibleFiles = eligibleFiles.filter((f) => isMatch(f.path));
-          } catch (err) {
-            console.error(`Invalid include glob: ${phase.include}`, err);
+      const numCPUs = os.cpus().length;
+      const maxWorkers = Math.max(1, Math.floor(numCPUs / 2));
+      const workerCount = Math.min(maxWorkers, enabledPhases.length);
+
+      const runWorker = async () => {
+        while (true) {
+          if (firstError) {
+            break;
           }
-        }
-
-        if (phase.exclude) {
-          try {
-            const isMatch = getGlobMatcher(phase.exclude);
-            eligibleFiles = eligibleFiles.filter((f) => !isMatch(f.path));
-          } catch (err) {
-            console.error(`Invalid exclude glob: ${phase.exclude}`, err);
+          const task = getNextPhase();
+          if (!task) {
+            break;
           }
-        }
+          const { phase, phaseIdx } = task;
 
-        if (eligibleFiles.length === 0) {
-          if (options.onLine) {
-            options.onLine(
-              JSON.stringify({
-                type: 'phase-skip',
-                phaseId: phase.id,
-                phaseTitle: phase.title,
-                reason: 'No matching files found',
-              }),
-            );
-          }
-          continue;
-        }
+          let eligibleFiles = [...files];
 
-        const attachStory =
-          phase.attach && phase.attach.toLowerCase().includes('story');
-
-        if (attachStory && !linkedStoriesContent) {
-          if (options.onLine) {
-            options.onLine(
-              JSON.stringify({
-                type: 'phase-skip',
-                phaseId: phase.id,
-                phaseTitle: phase.title,
-                reason: 'No linked stories found for this Pull Request',
-              }),
-            );
-          }
-          continue;
-        }
-
-        if (options.onLine) {
-          options.onLine(
-            JSON.stringify({
-              type: 'phase-start',
-              phaseId: phase.id,
-              phaseTitle: phase.title,
-            }),
-          );
-        }
-
-        const sessionOpts = attachStory
-          ? {
-              workingDirectory: effectiveRepoPath,
-              tools: [
-                createRequestDocumentationTool(
-                  this.getDocProvider,
-                  () => options.onLine,
-                ),
-              ],
+          if (phase.include) {
+            try {
+              const isMatch = getGlobMatcher(phase.include);
+              eligibleFiles = eligibleFiles.filter((f) => isMatch(f.path));
+            } catch (err) {
+              console.error(`Invalid include glob: ${phase.include}`, err);
             }
-          : { workingDirectory: effectiveRepoPath };
+          }
 
-        const { client, session } =
-          await this.copilotService.createClientAndSession(
-            settings.copilotToken,
-            options.modelOverride,
-            sessionOpts,
-          );
+          if (phase.exclude) {
+            try {
+              const isMatch = getGlobMatcher(phase.exclude);
+              eligibleFiles = eligibleFiles.filter((f) => !isMatch(f.path));
+            } catch (err) {
+              console.error(`Invalid exclude glob: ${phase.exclude}`, err);
+            }
+          }
 
-        const attachDescription =
-          phase.attach && phase.attach.toLowerCase().includes('description');
+          if (eligibleFiles.length === 0) {
+            if (options.onLine) {
+              options.onLine(
+                JSON.stringify({
+                  type: 'phase-skip',
+                  phaseId: phase.id,
+                  phaseTitle: phase.title,
+                  reason: 'No matching files found',
+                }),
+              );
+            }
+            continue;
+          }
 
-        let fullDescription = options.prDescription;
-        if (attachDescription && prDetails && prDetails.description) {
-          fullDescription = prDetails.description;
-        }
+          const attachStory =
+            phase.attach && phase.attach.toLowerCase().includes('story');
 
-        const prompt = buildPhaseReviewPrompt(
-          eligibleFiles,
-          phase.title,
-          phase.body,
-          options.customInstructions,
-          attachDescription ? fullDescription : undefined,
-          attachStory ? linkedStoriesContent : undefined,
-          attachStory ? knownDocs : undefined,
-        );
+          if (attachStory && !linkedStoriesContent) {
+            if (options.onLine) {
+              options.onLine(
+                JSON.stringify({
+                  type: 'phase-skip',
+                  phaseId: phase.id,
+                  phaseTitle: phase.title,
+                  reason: 'No linked stories found for this Pull Request',
+                }),
+              );
+            }
+            continue;
+          }
 
-        const wrappedOnLine = (line: string) => {
-          if (!options.onLine) return;
-          try {
-            const obj = JSON.parse(line);
-            if (obj && (obj.type === 'general' || obj.type === 'line')) {
-              obj.phase = phase.title;
+          if (options.onLine) {
+            options.onLine(
+              JSON.stringify({
+                type: 'phase-start',
+                phaseId: phase.id,
+                phaseTitle: phase.title,
+              }),
+            );
+          }
 
-              if (
-                obj.type === 'line' &&
-                typeof obj.file === 'string' &&
-                typeof obj.line === 'number'
-              ) {
-                const contextSize =
-                  typeof obj.context === 'number' ? obj.context : 0;
-                const codeLines = extractFileContextSync(
-                  effectiveRepoPath,
-                  obj.file,
-                  obj.line,
-                  contextSize,
-                );
-                if (codeLines) {
-                  obj.codeLines = codeLines;
+          const wrappedOnLine = (line: string) => {
+            if (!options.onLine) return;
+            try {
+              const obj = JSON.parse(line);
+              if (obj) {
+                obj.phase = phase.title;
+                obj.phaseId = phase.id;
+
+                if (obj.type === 'status' && obj.text && !obj.status) {
+                  obj.status = obj.text;
+                }
+
+                if (
+                  obj.type === 'line' &&
+                  typeof obj.file === 'string' &&
+                  typeof obj.line === 'number'
+                ) {
+                  const contextSize =
+                    typeof obj.context === 'number' ? obj.context : 0;
+                  const codeLines = extractFileContextSync(
+                    effectiveRepoPath,
+                    obj.file,
+                    obj.line,
+                    contextSize,
+                  );
+                  if (codeLines) {
+                    obj.codeLines = codeLines;
+                  }
                 }
               }
+              options.onLine(JSON.stringify(obj));
+            } catch {
+              options.onLine(line);
             }
-            options.onLine(JSON.stringify(obj));
-          } catch {
-            options.onLine(line);
-          }
-        };
+          };
 
-        const onToolCallback = (
-          type: 'start' | 'end',
-          tool: string,
-          success?: boolean,
-          error?: string,
+          const sessionOpts = attachStory
+            ? {
+                workingDirectory: effectiveRepoPath,
+                tools: [
+                  createRequestDocumentationTool(this.getDocProvider, () =>
+                    options.onLine ? wrappedOnLine : undefined,
+                  ),
+                ],
+              }
+            : { workingDirectory: effectiveRepoPath };
+
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          args?: any,
-        ) => {
-          if (options.onLine) {
-            options.onLine(
-              JSON.stringify({
-                type: 'tool',
-                status: type,
-                name: tool,
-                success,
-                error,
-                arguments: args,
-              }),
+          let clientAndSession: { client: any; session: any } | null = null;
+          try {
+            clientAndSession = await this.copilotService.createClientAndSession(
+              settings.copilotToken,
+              options.modelOverride,
+              sessionOpts,
             );
+          } catch (err) {
+            console.error(
+              `Error creating client/session for phase ${phase.title}:`,
+              err,
+            );
+            if (!firstError) {
+              firstError = err as Error;
+            }
+            break;
           }
-        };
 
-        try {
-          const res = await this.copilotService.sendAndCollectStream(
-            session,
-            prompt,
-            options.onLine ? wrappedOnLine : undefined,
-            ...(attachStory ? [onToolCallback] : []),
+          const { client, session } = clientAndSession;
+
+          const attachDescription =
+            phase.attach && phase.attach.toLowerCase().includes('description');
+
+          let fullDescription = options.prDescription;
+          if (attachDescription && prDetails && prDetails.description) {
+            fullDescription = prDetails.description;
+          }
+
+          const prompt = buildPhaseReviewPrompt(
+            eligibleFiles,
+            phase.title,
+            phase.body,
+            options.customInstructions,
+            attachDescription ? fullDescription : undefined,
+            attachStory ? linkedStoriesContent : undefined,
+            attachStory ? knownDocs : undefined,
           );
-          accumulatedResult += `\n--- Phase ${phase.title} Result ---\n${res}`;
-        } catch (err) {
-          console.error(`Error executing phase ${phase.title}:`, err);
-          throw err;
-        } finally {
-          try {
-            await session.disconnect();
-          } catch (e) {
-            console.error('Error destroying session in reviewPR phase:', e);
-          }
-          try {
-            await client.stop();
-          } catch (e) {
-            console.error('Error stopping client in reviewPR phase:', e);
-          }
 
-          if (options.onLine) {
-            options.onLine(
-              JSON.stringify({
-                type: 'phase-end',
-                phaseId: phase.id,
-                phaseTitle: phase.title,
-              }),
+          const onToolCallback = (
+            type: 'start' | 'end',
+            tool: string,
+            success?: boolean,
+            error?: string,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            args?: any,
+          ) => {
+            if (options.onLine) {
+              options.onLine(
+                JSON.stringify({
+                  type: 'tool',
+                  status: type,
+                  name: tool,
+                  success,
+                  error,
+                  arguments: args,
+                  phaseId: phase.id,
+                  phaseTitle: phase.title,
+                }),
+              );
+            }
+          };
+
+          try {
+            const res = await this.copilotService.sendAndCollectStream(
+              session,
+              prompt,
+              options.onLine ? wrappedOnLine : undefined,
+              ...(attachStory ? [onToolCallback] : []),
             );
+            results[phaseIdx] = `\n--- Phase ${phase.title} Result ---\n${res}`;
+          } catch (err) {
+            console.error(`Error executing phase ${phase.title}:`, err);
+            if (!firstError) {
+              firstError = err as Error;
+            }
+          } finally {
+            try {
+              await session.disconnect();
+            } catch (e) {
+              console.error('Error destroying session in reviewPR phase:', e);
+            }
+            try {
+              await client.stop();
+            } catch (e) {
+              console.error('Error stopping client in reviewPR phase:', e);
+            }
+
+            if (options.onLine) {
+              options.onLine(
+                JSON.stringify({
+                  type: 'phase-end',
+                  phaseId: phase.id,
+                  phaseTitle: phase.title,
+                }),
+              );
+            }
           }
         }
+      };
+
+      const workers = Array.from({ length: workerCount }, () => runWorker());
+      await Promise.all(workers);
+
+      if (firstError) {
+        throw firstError;
       }
+
+      const accumulatedResult = results.filter((r) => r !== '').join('');
 
       return accumulatedResult;
     } finally {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -386,6 +386,10 @@ ipcMain.handle(
   },
 );
 
+ipcMain.handle('get-cpu-count', () => {
+  return os.cpus().length;
+});
+
 ipcMain.handle(
   'pr-reviewer:review',
   async (
@@ -397,6 +401,7 @@ ipcMain.handle(
     enabledPhaseIds,
     prDescription,
     prId,
+    maxParallelism,
   ) => {
     const s = await initStore();
     const settings = (s.get('settings') ?? {}) as AppSettings;
@@ -406,6 +411,7 @@ ipcMain.handle(
       enabledPhaseIds,
       prDescription,
       prId,
+      maxParallelism,
       onLine: (line: string) => {
         event.sender.send('pr-reviewer:review-line', line);
       },

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -144,6 +144,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('pr-reviewer:check-worktrees', baseDir),
   cleanWorktrees: (baseDir: string) =>
     ipcRenderer.invoke('pr-reviewer:clean-worktrees', baseDir),
+  getCpuCount: (): Promise<number> => ipcRenderer.invoke('get-cpu-count'),
 
   reviewPR: (
     repoPath: string,
@@ -153,6 +154,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     enabledPhaseIds?: string[],
     prDescription?: string,
     prId?: string,
+    maxParallelism?: number,
   ): Promise<string> =>
     ipcRenderer.invoke(
       'pr-reviewer:review',
@@ -163,6 +165,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
       enabledPhaseIds,
       prDescription,
       prId,
+      maxParallelism,
     ),
   onPRReviewLine: (callback: (line: string) => void) => {
     const listener = (_event: unknown, line: string) => callback(line);

--- a/src/renderer/features/pr-reviewer/PRReviewer.tsx
+++ b/src/renderer/features/pr-reviewer/PRReviewer.tsx
@@ -114,6 +114,7 @@ const PRReviewer: React.FC = () => {
     title: string;
     status: 'pending' | 'in-progress' | 'completed' | 'skipped';
     reason?: string;
+    statusText?: string;
   }
   const [phaseProgress, setPhaseProgress] = useState<PhaseProgress[]>([]);
   const [currentPhase, setCurrentPhase] = useState<string | null>(null);
@@ -301,11 +302,7 @@ const PRReviewer: React.FC = () => {
         if (commentObj && commentObj.type === 'phase-start') {
           setPhaseProgress((prev) =>
             prev.map((p) =>
-              p.id === commentObj.phaseId
-                ? { ...p, status: 'in-progress' }
-                : p.status === 'in-progress'
-                  ? { ...p, status: 'completed' }
-                  : p,
+              p.id === commentObj.phaseId ? { ...p, status: 'in-progress' } : p,
             ),
           );
           setCurrentPhase(commentObj.phaseTitle);
@@ -326,6 +323,15 @@ const PRReviewer: React.FC = () => {
             ),
           );
         } else if (commentObj && commentObj.type === 'status') {
+          if (commentObj.phaseId) {
+            setPhaseProgress((prev) =>
+              prev.map((p) =>
+                p.id === commentObj.phaseId
+                  ? { ...p, statusText: commentObj.status }
+                  : p,
+              ),
+            );
+          }
           setCurrentStatus(commentObj.status);
           setLastStatusTime(new Date());
         } else if (
@@ -872,7 +878,7 @@ const PRReviewer: React.FC = () => {
                           {phaseProgress.map((p) => (
                             <div
                               key={p.id}
-                              className="list-group-item d-flex align-items-center justify-content-between p-3"
+                              className="list-group-item p-3"
                               style={{
                                 backgroundColor:
                                   p.status === 'in-progress'
@@ -880,52 +886,62 @@ const PRReviewer: React.FC = () => {
                                     : 'transparent',
                               }}
                             >
-                              <div
-                                className="d-flex align-items-center gap-2 text-truncate"
-                                style={{ maxWidth: '75%' }}
-                              >
-                                {p.status === 'pending' && (
-                                  <i className="far fa-circle text-muted"></i>
+                              <div className="d-flex align-items-center justify-content-between">
+                                <div
+                                  className="d-flex align-items-center gap-2 text-truncate"
+                                  style={{ maxWidth: '75%' }}
+                                >
+                                  {p.status === 'pending' && (
+                                    <i className="far fa-circle text-muted"></i>
+                                  )}
+                                  {p.status === 'in-progress' && (
+                                    <i className="fas fa-circle-notch fa-spin text-primary"></i>
+                                  )}
+                                  {p.status === 'completed' && (
+                                    <i className="fas fa-check-circle text-success"></i>
+                                  )}
+                                  {p.status === 'skipped' && (
+                                    <i
+                                      className="fas fa-forward text-warning"
+                                      title={p.reason || 'Skipped'}
+                                    ></i>
+                                  )}
+                                  <span
+                                    className={`small text-truncate ${
+                                      p.status === 'completed'
+                                        ? 'text-decoration-line-through text-muted'
+                                        : p.status === 'skipped'
+                                          ? 'text-muted'
+                                          : 'fw-semibold text-body'
+                                    }`}
+                                    title={p.title}
+                                  >
+                                    {p.title}
+                                  </span>
+                                </div>
+                                {p.status === 'skipped' && (
+                                  <span className="badge bg-warning-subtle text-warning-emphasis font-monospace tiny-badge">
+                                    Skipped
+                                  </span>
                                 )}
                                 {p.status === 'in-progress' && (
-                                  <i className="fas fa-circle-notch fa-spin text-primary"></i>
+                                  <span className="badge bg-primary-subtle text-primary-emphasis font-monospace tiny-badge">
+                                    Running
+                                  </span>
                                 )}
                                 {p.status === 'completed' && (
-                                  <i className="fas fa-check-circle text-success"></i>
+                                  <span className="badge bg-success-subtle text-success-emphasis font-monospace tiny-badge">
+                                    Done
+                                  </span>
                                 )}
-                                {p.status === 'skipped' && (
-                                  <i
-                                    className="fas fa-forward text-warning"
-                                    title={p.reason || 'Skipped'}
-                                  ></i>
-                                )}
-                                <span
-                                  className={`small text-truncate ${
-                                    p.status === 'completed'
-                                      ? 'text-decoration-line-through text-muted'
-                                      : p.status === 'skipped'
-                                        ? 'text-muted'
-                                        : 'fw-semibold text-body'
-                                  }`}
-                                  title={p.title}
-                                >
-                                  {p.title}
-                                </span>
                               </div>
-                              {p.status === 'skipped' && (
-                                <span className="badge bg-warning-subtle text-warning-emphasis font-monospace tiny-badge">
-                                  Skipped
-                                </span>
-                              )}
-                              {p.status === 'in-progress' && (
-                                <span className="badge bg-primary-subtle text-primary-emphasis font-monospace tiny-badge">
-                                  Running
-                                </span>
-                              )}
-                              {p.status === 'completed' && (
-                                <span className="badge bg-success-subtle text-success-emphasis font-monospace tiny-badge">
-                                  Done
-                                </span>
+                              {p.status === 'in-progress' && p.statusText && (
+                                <div
+                                  className="ps-4 mt-1 text-muted small text-truncate"
+                                  title={p.statusText}
+                                >
+                                  {p.statusText}
+                                </div>
                               )}
                             </div>
                           ))}

--- a/src/renderer/features/pr-reviewer/PRReviewer.tsx
+++ b/src/renderer/features/pr-reviewer/PRReviewer.tsx
@@ -45,7 +45,6 @@ const PRReviewer: React.FC = () => {
   const [comments, setComments] = useState<ReviewComment[]>([]);
   const [isReviewing, setIsReviewing] = useState(false);
   const [hasReviewed, setHasReviewed] = useState(false);
-  const [currentStatus, setCurrentStatus] = useState<string | null>(null);
   const [lastStatusTime, setLastStatusTime] = useState<Date | null>(null);
   const [customInstructions, setCustomInstructions] = useState('');
   const { models, selectedModel, setSelectedModel, loadingModels } =
@@ -117,9 +116,36 @@ const PRReviewer: React.FC = () => {
     statusText?: string;
   }
   const [phaseProgress, setPhaseProgress] = useState<PhaseProgress[]>([]);
-  const [currentPhase, setCurrentPhase] = useState<string | null>(null);
   const [maxParallelism, setMaxParallelism] = useState<number>(2);
   const [cpuCount, setCpuCount] = useState<number>(4);
+
+  const getGeneralStatusText = () => {
+    const inProgressCount = phaseProgress.filter(
+      (p) => p.status === 'in-progress',
+    ).length;
+    const completedCount = phaseProgress.filter(
+      (p) => p.status === 'completed',
+    ).length;
+    const skippedCount = phaseProgress.filter(
+      (p) => p.status === 'skipped',
+    ).length;
+    const pendingCount = phaseProgress.filter(
+      (p) => p.status === 'pending',
+    ).length;
+
+    const parts: string[] = [];
+    if (inProgressCount > 0) parts.push(`${inProgressCount} In Progress`);
+    if (completedCount > 0) parts.push(`${completedCount} Complete`);
+    if (skippedCount > 0) parts.push(`${skippedCount} Skipped`);
+    if (pendingCount > 0 && parts.length === 0)
+      parts.push(`${pendingCount} Pending`);
+
+    let statusText = parts.length > 0 ? parts.join(', ') : 'Initializing';
+    if (isReviewing) {
+      statusText += '...';
+    }
+    return statusText;
+  };
 
   useEffect(() => {
     loadPhases();
@@ -307,8 +333,6 @@ const PRReviewer: React.FC = () => {
     setComments([]);
     setCollapsedComments({});
     setIsPostingComment({});
-    setCurrentPhase(null);
-    setCurrentStatus(null);
     setLastStatusTime(null);
 
     setPhaseProgress(
@@ -328,8 +352,6 @@ const PRReviewer: React.FC = () => {
               p.id === commentObj.phaseId ? { ...p, status: 'in-progress' } : p,
             ),
           );
-          setCurrentPhase(commentObj.phaseTitle);
-          setCurrentStatus(`Starting review phase: ${commentObj.phaseTitle}`);
           setLastStatusTime(new Date());
         } else if (commentObj && commentObj.type === 'phase-skip') {
           setPhaseProgress((prev) =>
@@ -339,12 +361,14 @@ const PRReviewer: React.FC = () => {
                 : p,
             ),
           );
+          setLastStatusTime(new Date());
         } else if (commentObj && commentObj.type === 'phase-end') {
           setPhaseProgress((prev) =>
             prev.map((p) =>
               p.id === commentObj.phaseId ? { ...p, status: 'completed' } : p,
             ),
           );
+          setLastStatusTime(new Date());
         } else if (commentObj && commentObj.type === 'status') {
           if (commentObj.phaseId) {
             setPhaseProgress((prev) =>
@@ -355,7 +379,6 @@ const PRReviewer: React.FC = () => {
               ),
             );
           }
-          setCurrentStatus(commentObj.status);
           setLastStatusTime(new Date());
         } else if (
           commentObj &&
@@ -974,9 +997,7 @@ const PRReviewer: React.FC = () => {
                         {isReviewing && (
                           <div className="mt-auto text-center text-muted small py-2 bg-body-secondary rounded">
                             <span className="spinner-border spinner-border-sm me-2 text-primary"></span>
-                            {currentPhase
-                              ? `Reviewing: ${currentPhase}`
-                              : 'Analyzing PR changes...'}
+                            {getGeneralStatusText()}
                           </div>
                         )}
 
@@ -985,7 +1006,6 @@ const PRReviewer: React.FC = () => {
                             className="btn btn-outline-primary btn-sm w-100 mt-auto fw-semibold"
                             onClick={() => {
                               setPhaseProgress([]);
-                              setCurrentPhase(null);
                             }}
                           >
                             <i className="fas fa-arrow-left me-2"></i>
@@ -1107,7 +1127,7 @@ const PRReviewer: React.FC = () => {
                       Review Comments ({comments.length})
                     </h5>
 
-                    {isReviewing && currentStatus && comments.length > 0 && (
+                    {isReviewing && comments.length > 0 && (
                       <div className="alert alert-info py-2 px-3 mb-3 d-flex align-items-center justify-content-between shadow-sm border-0 bg-info-subtle text-info-emphasis small">
                         <div className="d-flex align-items-center gap-2">
                           <span
@@ -1115,7 +1135,7 @@ const PRReviewer: React.FC = () => {
                             style={{ width: '1rem', height: '1rem' }}
                           ></span>
                           <span>
-                            <strong>Status:</strong> {currentStatus}
+                            <strong>Status:</strong> {getGeneralStatusText()}
                           </span>
                         </div>
                         {lastStatusTime && (
@@ -1155,7 +1175,7 @@ const PRReviewer: React.FC = () => {
                                 style={{ width: '3rem', height: '3rem' }}
                               ></span>
                               <p className="fw-semibold text-body mb-1">
-                                {currentStatus || 'Running Code Review...'}
+                                {getGeneralStatusText()}
                               </p>
                               {lastStatusTime && (
                                 <p className="text-muted small mb-2">

--- a/src/renderer/features/pr-reviewer/PRReviewer.tsx
+++ b/src/renderer/features/pr-reviewer/PRReviewer.tsx
@@ -118,10 +118,33 @@ const PRReviewer: React.FC = () => {
   }
   const [phaseProgress, setPhaseProgress] = useState<PhaseProgress[]>([]);
   const [currentPhase, setCurrentPhase] = useState<string | null>(null);
+  const [maxParallelism, setMaxParallelism] = useState<number>(2);
+  const [cpuCount, setCpuCount] = useState<number>(4);
 
   useEffect(() => {
     loadPhases();
+    loadParallelismSettings();
   }, []);
+
+  const loadParallelismSettings = async () => {
+    try {
+      const cpus = await window.electronAPI.getCpuCount();
+      setCpuCount(cpus);
+
+      const settings = await window.electronAPI.getSettings();
+      if (settings && settings.maxParallelism !== undefined) {
+        setMaxParallelism(settings.maxParallelism);
+      } else {
+        if (cpus < 4) {
+          setMaxParallelism(1);
+        } else {
+          setMaxParallelism(Math.max(1, Math.floor(cpus / 2)));
+        }
+      }
+    } catch (err) {
+      console.error('Failed to load parallelism settings:', err);
+    }
+  };
 
   const loadPhases = async () => {
     setIsLoadingPhases(true);
@@ -356,6 +379,7 @@ const PRReviewer: React.FC = () => {
         enabledPhaseIds,
         selectedPR.description,
         selectedPR.id,
+        maxParallelism,
       );
       setHasReviewed(true);
     } catch (err: unknown) {
@@ -983,6 +1007,45 @@ const PRReviewer: React.FC = () => {
                             onSelect={setSelectedModel}
                             loading={loadingModels}
                           />
+                        </div>
+
+                        {/* Max Parallelism */}
+                        <div className="mb-3">
+                          <label className="form-label text-muted small fw-semibold d-block mb-1">
+                            Review Agent Parallelism
+                          </label>
+                          {cpuCount < 4 ? (
+                            <div className="text-muted small">
+                              Parallelism fixed at 1 (fewer than 4 CPU cores).
+                            </div>
+                          ) : (
+                            <div>
+                              <div className="d-flex align-items-center gap-2">
+                                <input
+                                  type="range"
+                                  className="form-range"
+                                  min="1"
+                                  max={cpuCount - 2}
+                                  value={maxParallelism}
+                                  onChange={(e) =>
+                                    setMaxParallelism(parseInt(e.target.value))
+                                  }
+                                  disabled={isReviewing}
+                                  style={{ flexGrow: 1 }}
+                                />
+                                <span className="badge bg-secondary font-monospace">
+                                  {maxParallelism}x
+                                </span>
+                              </div>
+                              <span
+                                className="text-muted tiny"
+                                style={{ fontSize: '0.75rem' }}
+                              >
+                                Range: 1 to {cpuCount - 2} workers (CPUs:{' '}
+                                {cpuCount})
+                              </span>
+                            </div>
+                          )}
                         </div>
 
                         {/* Custom Review Instructions */}

--- a/src/renderer/features/settings/components/GeneralSettings.tsx
+++ b/src/renderer/features/settings/components/GeneralSettings.tsx
@@ -8,6 +8,9 @@ interface GeneralSettingsProps {
   setGitWorktreeEnabled: (enabled: boolean) => void;
   gitWorktreeBaseDir: string;
   setGitWorktreeBaseDir: (dir: string) => void;
+  maxParallelism: number;
+  setMaxParallelism: (limit: number) => void;
+  cpuCount: number;
 }
 
 const GeneralSettings: React.FC<GeneralSettingsProps> = ({
@@ -17,6 +20,9 @@ const GeneralSettings: React.FC<GeneralSettingsProps> = ({
   setGitWorktreeEnabled,
   gitWorktreeBaseDir,
   setGitWorktreeBaseDir,
+  maxParallelism,
+  setMaxParallelism,
+  cpuCount,
 }) => {
   const [hasWorktrees, setHasWorktrees] = useState(false);
   const [worktreeCount, setWorktreeCount] = useState(0);
@@ -232,6 +238,54 @@ const GeneralSettings: React.FC<GeneralSettingsProps> = ({
               )}
             </div>
           )}
+
+          <h5 className="mb-4 mt-4 border-bottom pb-2">
+            <i className="fas fa-microchip me-2 text-primary"></i>PR Reviewer
+            Concurrency Settings
+          </h5>
+
+          <div className="mb-2">
+            <label className="form-label d-block fw-semibold text-muted small uppercase tracking-wider mb-2">
+              Default Review Agent Parallelism
+            </label>
+            <p className="text-muted small mb-3">
+              Configure how many parallel GitHub Copilot agents can run reviews
+              concurrently.
+            </p>
+            {cpuCount < 4 ? (
+              <div className="alert alert-info py-2 px-3 shadow-sm border-0 bg-info-subtle text-info-emphasis small d-flex align-items-center gap-2">
+                <i className="fas fa-circle-info"></i>
+                <span>
+                  Parallelism is locked to <strong>1</strong> because your
+                  system has <strong>{cpuCount} CPU cores</strong> (fewer than 4
+                  required for parallel agents).
+                </span>
+              </div>
+            ) : (
+              <div>
+                <div className="d-flex align-items-center gap-3">
+                  <input
+                    type="range"
+                    className="form-range flex-grow-0"
+                    min="1"
+                    max={cpuCount - 2}
+                    value={maxParallelism}
+                    onChange={(e) =>
+                      setMaxParallelism(parseInt(e.target.value))
+                    }
+                    style={{ maxWidth: '300px' }}
+                  />
+                  <span className="badge bg-primary fs-6 px-3 py-2">
+                    {maxParallelism} Worker{maxParallelism > 1 ? 's' : ''}
+                  </span>
+                </div>
+                <p className="text-muted small mt-2 mb-0">
+                  Allowing between 1 and {cpuCount - 2} parallel agents (Total
+                  CPU cores: {cpuCount}).
+                </p>
+              </div>
+            )}
+          </div>
         </div>
       </div>
 

--- a/src/renderer/features/settings/components/Settings.tsx
+++ b/src/renderer/features/settings/components/Settings.tsx
@@ -20,6 +20,8 @@ const Settings: React.FC = () => {
   const [theme, setTheme] = useState<'auto' | 'light' | 'dark'>('auto');
   const [gitWorktreeEnabled, setGitWorktreeEnabled] = useState(false);
   const [gitWorktreeBaseDir, setGitWorktreeBaseDir] = useState('');
+  const [maxParallelism, setMaxParallelism] = useState<number>(2);
+  const [cpuCount, setCpuCount] = useState<number>(4);
   const [statusMessage, setStatusMessage] = useState('');
   const [authStatus, setAuthStatus] = useState<CopilotAuth | null>(null);
   const [checkingAuth, setCheckingAuth] = useState(false);
@@ -51,6 +53,9 @@ const Settings: React.FC = () => {
   useEffect(() => {
     const loadSettings = async () => {
       try {
+        const cpus = await window.electronAPI.getCpuCount();
+        setCpuCount(cpus);
+
         const settings = await window.electronAPI.getSettings();
         if (settings) {
           setAzureOrg(settings.azureOrg || '');
@@ -63,6 +68,16 @@ const Settings: React.FC = () => {
           setTheme(settings.theme || 'auto');
           setGitWorktreeEnabled(settings.gitWorktreeEnabled || false);
           setGitWorktreeBaseDir(settings.gitWorktreeBaseDir || '');
+
+          if (settings.maxParallelism !== undefined) {
+            setMaxParallelism(settings.maxParallelism);
+          } else {
+            if (cpus < 4) {
+              setMaxParallelism(1);
+            } else {
+              setMaxParallelism(Math.max(1, Math.floor(cpus / 2)));
+            }
+          }
 
           // Load custom prompts
           const prompts = settings.prompts || {};
@@ -107,6 +122,7 @@ const Settings: React.FC = () => {
         theme: theme,
         gitWorktreeEnabled: gitWorktreeEnabled,
         gitWorktreeBaseDir: gitWorktreeBaseDir,
+        maxParallelism: maxParallelism,
         prompts: {
           storyWriter: {
             general: storyGeneral,
@@ -169,6 +185,9 @@ const Settings: React.FC = () => {
             setGitWorktreeEnabled={setGitWorktreeEnabled}
             gitWorktreeBaseDir={gitWorktreeBaseDir}
             setGitWorktreeBaseDir={setGitWorktreeBaseDir}
+            maxParallelism={maxParallelism}
+            setMaxParallelism={setMaxParallelism}
+            cpuCount={cpuCount}
           />
         );
       case 'azure':

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -91,6 +91,7 @@ export interface IElectronAPI {
   cleanWorktrees: (
     baseDir: string,
   ) => Promise<{ success: boolean; cleanedCount: number; errors: string[] }>;
+  getCpuCount: () => Promise<number>;
 
   reviewPR: (
     repoPath: string,
@@ -100,6 +101,7 @@ export interface IElectronAPI {
     enabledPhaseIds?: string[],
     prDescription?: string,
     prId?: string,
+    maxParallelism?: number,
   ) => Promise<string>;
   onPRReviewLine: (callback: (line: string) => void) => () => void;
   postPRComment: (

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,7 @@ export type AppSettings = {
   theme?: 'auto' | 'light' | 'dark';
   gitWorktreeEnabled?: boolean;
   gitWorktreeBaseDir?: string;
+  maxParallelism?: number;
   prompts?: {
     storyWriter?: {
       general?: string;


### PR DESCRIPTION
Instead of running PR Reviews in series, we now run them in parallel.

By default we will use the host CPU count to determine how many phases to run in parallel - using 50% of the available CPUs. This balances host performance with reviewer performance. This is also configurable at 2 layers; the default level, configured in settings, and can be overridden when starting a review.

The highest allowed level of parallelism for both the default and override is N-2 (where N is the number of CPUs).

In order to avoid issues with pre-chunking, including imbalanced chunks leading to essentially serial processing, we use a worker pool with a shared review phase queue.