### PR TITLE
feat(story-elaborator): add worktree support

### DIFF
--- a/src/main/features/story-elaborator/__tests__/storyElaboratorService.test.ts
+++ b/src/main/features/story-elaborator/__tests__/storyElaboratorService.test.ts
@@ -4,6 +4,7 @@ import { StoryElaboratorService } from '../storyElaboratorService';
 import { buildStoryElaboratorPrompt } from '../storyElaboratorPrompts';
 import { AppSettings, TicketData } from '../../../../types';
 import fs from 'fs';
+import path from 'path';
 
 describe('StoryElaborator feature', () => {
   const defaultSettings: AppSettings = {
@@ -403,13 +404,17 @@ describe('StoryElaborator feature', () => {
         expect.stringContaining('repo-root_ticket_US-500'),
         'feature-branch',
       );
+      const expectedPath = path.join(
+        '/mock/worktrees',
+        'repo-root_ticket_US-500',
+        'src',
+        'subdir',
+      );
       expect(mockCopilotService.createClientAndSession).toHaveBeenCalledWith(
         undefined,
         'gpt-4',
         expect.objectContaining({
-          workingDirectory: expect.stringContaining(
-            '/mock/worktrees/repo-root_ticket_US-500/src/subdir',
-          ),
+          workingDirectory: expectedPath,
         }),
       );
 

--- a/src/main/features/story-elaborator/__tests__/storyElaboratorService.test.ts
+++ b/src/main/features/story-elaborator/__tests__/storyElaboratorService.test.ts
@@ -1,8 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { StoryElaboratorService } from '../storyElaboratorService';
 import { buildStoryElaboratorPrompt } from '../storyElaboratorPrompts';
 import { AppSettings, TicketData } from '../../../../types';
+import fs from 'fs';
 
 describe('StoryElaborator feature', () => {
   const defaultSettings: AppSettings = {
@@ -77,6 +78,7 @@ describe('StoryElaborator feature', () => {
     const mockClient = { stop: vi.fn() };
     const mockSession = { disconnect: vi.fn() };
 
+    let mockGitService: any;
     beforeEach(() => {
       mockCopilotService = {
         createClientAndSession: vi
@@ -85,8 +87,15 @@ describe('StoryElaborator feature', () => {
         sendAndCollectStream: vi.fn().mockResolvedValue('Mocked response'),
         getModel: vi.fn().mockReturnValue('auto'),
       };
+      mockGitService = {
+        checkGitRepo: vi.fn().mockResolvedValue(false),
+        getRepoRoot: vi.fn().mockResolvedValue(null),
+        addWorktree: vi.fn().mockResolvedValue(undefined),
+        removeWorktree: vi.fn().mockResolvedValue(undefined),
+      };
       service = new StoryElaboratorService(
         mockCopilotService,
+        mockGitService,
         async () => null,
       );
     });
@@ -148,6 +157,7 @@ describe('StoryElaborator feature', () => {
   describe('StoryElaboratorService with Documentation Retrieval', () => {
     let mockCopilotService: any;
     let mockDocProvider: any;
+    let mockGitService: any;
     let service: StoryElaboratorService;
     const mockClient = { stop: vi.fn() };
     const mockSession = { disconnect: vi.fn() };
@@ -175,8 +185,16 @@ describe('StoryElaborator feature', () => {
         sendAndCollectStream: vi.fn(),
       };
 
+      mockGitService = {
+        checkGitRepo: vi.fn().mockResolvedValue(false),
+        getRepoRoot: vi.fn().mockResolvedValue(null),
+        addWorktree: vi.fn().mockResolvedValue(undefined),
+        removeWorktree: vi.fn().mockResolvedValue(undefined),
+      };
+
       service = new StoryElaboratorService(
         mockCopilotService,
+        mockGitService,
         async () => mockDocProvider,
       );
     });
@@ -282,6 +300,7 @@ describe('StoryElaborator feature', () => {
         '',
         'gpt-4',
         defaultSettings,
+        undefined,
         onLineSpy,
       );
 
@@ -314,6 +333,183 @@ describe('StoryElaborator feature', () => {
         expect.stringContaining(
           '"type":"status","text":"Agent requested duplicate document ID: 999 (declined)"',
         ),
+      );
+    });
+  });
+
+  describe('StoryElaboratorService with Git Worktrees', () => {
+    let mockCopilotService: any;
+    let mockGitService: any;
+    let service: StoryElaboratorService;
+    const mockClient = { stop: vi.fn() };
+    const mockSession = { disconnect: vi.fn() };
+
+    beforeEach(() => {
+      mockCopilotService = {
+        createClientAndSession: vi
+          .fn()
+          .mockResolvedValue({ client: mockClient, session: mockSession }),
+        sendAndCollectStream: vi.fn().mockResolvedValue('Mocked response'),
+      };
+      mockGitService = {
+        checkGitRepo: vi.fn().mockResolvedValue(true),
+        getRepoRoot: vi.fn().mockResolvedValue('/mock/repo-root'),
+        addWorktree: vi.fn().mockResolvedValue(undefined),
+        removeWorktree: vi.fn().mockResolvedValue(undefined),
+      };
+      service = new StoryElaboratorService(
+        mockCopilotService,
+        mockGitService,
+        async () => null,
+      );
+      vi.spyOn(fs, 'mkdirSync').mockImplementation(() => undefined as any);
+      vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('should create worktree and resolve subdirectory path when enabled', async () => {
+      const ticket: TicketData = {
+        id: 'US-500',
+        title: 'Story 500',
+        description: 'desc 500',
+      };
+
+      const settings: AppSettings = {
+        gitWorktreeEnabled: true,
+        gitWorktreeBaseDir: '/mock/worktrees',
+      };
+
+      const result = await service.startStoryElaboration(
+        ticket,
+        '/mock/repo-root/src/subdir',
+        'Context',
+        'gpt-4',
+        settings,
+        'feature-branch',
+      );
+
+      expect(result).toBe('Mocked response');
+      expect(mockGitService.checkGitRepo).toHaveBeenCalledWith(
+        '/mock/repo-root/src/subdir',
+      );
+      expect(mockGitService.getRepoRoot).toHaveBeenCalledWith(
+        '/mock/repo-root/src/subdir',
+      );
+      expect(mockGitService.addWorktree).toHaveBeenCalledWith(
+        '/mock/repo-root',
+        expect.stringContaining('repo-root_ticket_US-500'),
+        'feature-branch',
+      );
+      expect(mockCopilotService.createClientAndSession).toHaveBeenCalledWith(
+        undefined,
+        'gpt-4',
+        expect.objectContaining({
+          workingDirectory: expect.stringContaining(
+            '/mock/worktrees/repo-root_ticket_US-500/src/subdir',
+          ),
+        }),
+      );
+
+      // Verify worktree is removed on stop
+      await service.stopStoryElaboration('US-500');
+      expect(mockGitService.removeWorktree).toHaveBeenCalledWith(
+        '/mock/repo-root',
+        expect.stringContaining('repo-root_ticket_US-500'),
+      );
+    });
+
+    it('should bypass worktree if path is not a git repo', async () => {
+      mockGitService.checkGitRepo.mockResolvedValue(false);
+
+      const ticket: TicketData = {
+        id: 'US-501',
+        title: 'Story 501',
+      } as any;
+
+      const settings: AppSettings = {
+        gitWorktreeEnabled: true,
+        gitWorktreeBaseDir: '/mock/worktrees',
+      };
+
+      await service.startStoryElaboration(
+        ticket,
+        '/mock/non-git-dir',
+        '',
+        'gpt-4',
+        settings,
+      );
+
+      expect(mockGitService.addWorktree).not.toHaveBeenCalled();
+      expect(mockCopilotService.createClientAndSession).toHaveBeenCalledWith(
+        undefined,
+        'gpt-4',
+        expect.objectContaining({
+          workingDirectory: '/mock/non-git-dir',
+        }),
+      );
+    });
+
+    it('should bypass worktree if worktrees are disabled in settings', async () => {
+      const ticket: TicketData = {
+        id: 'US-502',
+        title: 'Story 502',
+      } as any;
+
+      const settings: AppSettings = {
+        gitWorktreeEnabled: false,
+      };
+
+      await service.startStoryElaboration(
+        ticket,
+        '/mock/repo-root/src/subdir',
+        '',
+        'gpt-4',
+        settings,
+      );
+
+      expect(mockGitService.checkGitRepo).not.toHaveBeenCalled();
+      expect(mockGitService.addWorktree).not.toHaveBeenCalled();
+      expect(mockCopilotService.createClientAndSession).toHaveBeenCalledWith(
+        undefined,
+        'gpt-4',
+        expect.objectContaining({
+          workingDirectory: '/mock/repo-root/src/subdir',
+        }),
+      );
+    });
+
+    it('should clean up worktree if starting session throws an error', async () => {
+      mockCopilotService.createClientAndSession.mockRejectedValue(
+        new Error('Copilot Error'),
+      );
+
+      const ticket: TicketData = {
+        id: 'US-503',
+        title: 'Story 503',
+      } as any;
+
+      const settings: AppSettings = {
+        gitWorktreeEnabled: true,
+        gitWorktreeBaseDir: '/mock/worktrees',
+      };
+
+      await expect(
+        service.startStoryElaboration(
+          ticket,
+          '/mock/repo-root/src/subdir',
+          '',
+          'gpt-4',
+          settings,
+        ),
+      ).rejects.toThrow('Copilot Error');
+
+      expect(mockGitService.addWorktree).toHaveBeenCalled();
+      expect(mockGitService.removeWorktree).toHaveBeenCalledWith(
+        '/mock/repo-root',
+        expect.stringContaining('repo-root_ticket_US-503'),
       );
     });
   });

--- a/src/main/features/story-elaborator/__tests__/storyElaboratorService.test.ts
+++ b/src/main/features/story-elaborator/__tests__/storyElaboratorService.test.ts
@@ -471,6 +471,43 @@ describe('StoryElaborator feature', () => {
       );
     });
 
+    it('should throw an error and clean up if the selected subdirectory does not exist in the worktree', async () => {
+      vi.spyOn(fs, 'existsSync').mockImplementation((p: any) => {
+        if (p.includes('repo-root_ticket_US-504')) {
+          return false;
+        }
+        return true;
+      });
+
+      const ticket: TicketData = {
+        id: 'US-504',
+        title: 'Story 504',
+      } as any;
+
+      const settings: AppSettings = {
+        gitWorktreeEnabled: true,
+        gitWorktreeBaseDir: '/mock/worktrees',
+      };
+
+      await expect(
+        service.startStoryElaboration(
+          ticket,
+          '/mock/repo-root/src/non-existent-subdir',
+          '',
+          'gpt-4',
+          settings,
+        ),
+      ).rejects.toThrow(
+        'The selected directory does not exist in the checked out branch. Your local repository might be outdated. Please pull the branch and try again.',
+      );
+
+      expect(mockGitService.addWorktree).toHaveBeenCalled();
+      expect(mockGitService.removeWorktree).toHaveBeenCalledWith(
+        '/mock/repo-root',
+        expect.stringContaining('repo-root_ticket_US-504'),
+      );
+    });
+
     it('should bypass worktree if path is not a git repo', async () => {
       mockGitService.checkGitRepo.mockResolvedValue(false);
 

--- a/src/main/features/story-elaborator/__tests__/storyElaboratorService.test.ts
+++ b/src/main/features/story-elaborator/__tests__/storyElaboratorService.test.ts
@@ -93,6 +93,7 @@ describe('StoryElaborator feature', () => {
         getRepoRoot: vi.fn().mockResolvedValue(null),
         addWorktree: vi.fn().mockResolvedValue(undefined),
         removeWorktree: vi.fn().mockResolvedValue(undefined),
+        runCommand: vi.fn().mockResolvedValue(''),
       };
       service = new StoryElaboratorService(
         mockCopilotService,
@@ -191,6 +192,7 @@ describe('StoryElaborator feature', () => {
         getRepoRoot: vi.fn().mockResolvedValue(null),
         addWorktree: vi.fn().mockResolvedValue(undefined),
         removeWorktree: vi.fn().mockResolvedValue(undefined),
+        runCommand: vi.fn().mockResolvedValue(''),
       };
 
       service = new StoryElaboratorService(
@@ -357,6 +359,12 @@ describe('StoryElaborator feature', () => {
         getRepoRoot: vi.fn().mockResolvedValue('/mock/repo-root'),
         addWorktree: vi.fn().mockResolvedValue(undefined),
         removeWorktree: vi.fn().mockResolvedValue(undefined),
+        runCommand: vi.fn().mockImplementation((path, cmd) => {
+          if (cmd.includes('git rev-parse FETCH_HEAD')) {
+            return Promise.resolve('mocked-fetched-sha');
+          }
+          return Promise.resolve('');
+        }),
       };
       service = new StoryElaboratorService(
         mockCopilotService,
@@ -402,7 +410,7 @@ describe('StoryElaborator feature', () => {
       expect(mockGitService.addWorktree).toHaveBeenCalledWith(
         '/mock/repo-root',
         expect.stringContaining('repo-root_ticket_US-500'),
-        'feature-branch',
+        'mocked-fetched-sha',
       );
       const expectedPath = path.join(
         '/mock/worktrees',
@@ -423,6 +431,43 @@ describe('StoryElaborator feature', () => {
       expect(mockGitService.removeWorktree).toHaveBeenCalledWith(
         '/mock/repo-root',
         expect.stringContaining('repo-root_ticket_US-500'),
+      );
+    });
+
+    it('should fallback to local branch if fetch from origin fails', async () => {
+      mockGitService.runCommand.mockImplementation(
+        (path: string, cmd: string) => {
+          if (cmd.includes('git fetch origin')) {
+            return Promise.reject(new Error('Fetch failed'));
+          }
+          return Promise.resolve('');
+        },
+      );
+
+      const ticket: TicketData = {
+        id: 'US-500',
+        title: 'Story 500',
+        description: 'desc 500',
+      };
+
+      const settings: AppSettings = {
+        gitWorktreeEnabled: true,
+        gitWorktreeBaseDir: '/mock/worktrees',
+      };
+
+      await service.startStoryElaboration(
+        ticket,
+        '/mock/repo-root/src/subdir',
+        'Context',
+        'gpt-4',
+        settings,
+        'feature-branch',
+      );
+
+      expect(mockGitService.addWorktree).toHaveBeenCalledWith(
+        '/mock/repo-root',
+        expect.stringContaining('repo-root_ticket_US-500'),
+        'feature-branch',
       );
     });
 

--- a/src/main/features/story-elaborator/storyElaboratorService.ts
+++ b/src/main/features/story-elaborator/storyElaboratorService.ts
@@ -73,10 +73,30 @@ export class StoryElaboratorService {
             }
 
             const targetBranch = branch || 'develop';
+            let checkoutRef = targetBranch;
+            try {
+              await this.gitService.runCommand(
+                repoRoot,
+                `git fetch origin ${targetBranch}`,
+              );
+              const fetchedSha = await this.gitService.runCommand(
+                repoRoot,
+                'git rev-parse FETCH_HEAD',
+              );
+              if (fetchedSha) {
+                checkoutRef = fetchedSha;
+              }
+            } catch (err) {
+              console.warn(
+                `Failed to fetch branch ${targetBranch} from origin, falling back to local branch:`,
+                err,
+              );
+            }
+
             await this.gitService.addWorktree(
               repoRoot,
               worktreePath,
-              targetBranch,
+              checkoutRef,
             );
 
             worktreeInfo = { repoRoot, worktreePath };

--- a/src/main/features/story-elaborator/storyElaboratorService.ts
+++ b/src/main/features/story-elaborator/storyElaboratorService.ts
@@ -101,6 +101,12 @@ export class StoryElaboratorService {
 
             worktreeInfo = { repoRoot, worktreePath };
             effectiveRepoPath = path.join(worktreePath, relativeSubdir);
+
+            if (!fs.existsSync(effectiveRepoPath)) {
+              throw new Error(
+                'The selected directory does not exist in the checked out branch. Your local repository might be outdated. Please pull the branch and try again.',
+              );
+            }
           }
         }
       }

--- a/src/main/features/story-elaborator/storyElaboratorService.ts
+++ b/src/main/features/story-elaborator/storyElaboratorService.ts
@@ -4,6 +4,9 @@ import { CopilotService } from '../../infrastructure/copilot/copilotService';
 import { DocumentationProvider } from '../../infrastructure/providers/DocumentationProvider';
 import { buildStoryElaboratorPrompt } from './storyElaboratorPrompts';
 import { createRequestDocumentationTool } from '../../infrastructure/copilot/tools/documentationTool';
+import { GitService } from '../../infrastructure/git/gitService';
+import fs from 'fs';
+import path from 'path';
 
 export class StoryElaboratorService {
   private activeElaborations = new Map<
@@ -12,11 +15,16 @@ export class StoryElaboratorService {
       client: any;
       session: any;
       onLine?: (line: string) => void;
+      worktreeInfo?: {
+        repoRoot: string;
+        worktreePath: string;
+      };
     }
   >();
 
   constructor(
     private copilotService: CopilotService,
+    private gitService: GitService,
     private getDocProvider: () => Promise<DocumentationProvider | null>,
   ) {}
 
@@ -26,10 +34,14 @@ export class StoryElaboratorService {
     additionalContext: string,
     modelOverride: string,
     settings: AppSettings,
+    branch?: string,
     onLine?: (line: string) => void,
   ): Promise<string> {
     // Stop any existing session for this ticket
     await this.stopStoryElaboration(ticketData.id || '');
+
+    let effectiveRepoPath = repoPath;
+    let worktreeInfo: { repoRoot: string; worktreePath: string } | undefined;
 
     try {
       const requestDocumentationTool = createRequestDocumentationTool(
@@ -37,13 +49,49 @@ export class StoryElaboratorService {
         () => this.activeElaborations.get(ticketData.id || '')?.onLine,
       );
 
+      if (
+        repoPath &&
+        settings.gitWorktreeEnabled &&
+        settings.gitWorktreeBaseDir
+      ) {
+        const isGit = await this.gitService.checkGitRepo(repoPath);
+        if (isGit) {
+          const repoRoot = await this.gitService.getRepoRoot(repoPath);
+          if (repoRoot) {
+            const relativeSubdir = path.relative(repoRoot, repoPath);
+            const repoDirName = path.basename(repoRoot);
+            const sanitizeDirName = (name: string) =>
+              name.replace(/[^a-zA-Z0-9-_]/g, '_');
+            const worktreeName = `${sanitizeDirName(repoDirName)}_ticket_${ticketData.id || 'unknown'}`;
+            const worktreePath = path.join(
+              settings.gitWorktreeBaseDir,
+              worktreeName,
+            );
+
+            if (!fs.existsSync(settings.gitWorktreeBaseDir)) {
+              fs.mkdirSync(settings.gitWorktreeBaseDir, { recursive: true });
+            }
+
+            const targetBranch = branch || 'develop';
+            await this.gitService.addWorktree(
+              repoRoot,
+              worktreePath,
+              targetBranch,
+            );
+
+            worktreeInfo = { repoRoot, worktreePath };
+            effectiveRepoPath = path.join(worktreePath, relativeSubdir);
+          }
+        }
+      }
+
       const { client, session } =
         await this.copilotService.createClientAndSession(
           settings.copilotToken,
           modelOverride,
-          repoPath
+          effectiveRepoPath
             ? {
-                workingDirectory: repoPath,
+                workingDirectory: effectiveRepoPath,
                 tools: [requestDocumentationTool],
               }
             : {
@@ -57,6 +105,7 @@ export class StoryElaboratorService {
         client,
         session,
         onLine,
+        worktreeInfo,
       });
 
       // Find links and fetch titles for knownDocs
@@ -102,6 +151,16 @@ export class StoryElaboratorService {
     } catch (error) {
       console.error('Error starting story elaboration:', error);
       // Clean up if it failed
+      if (worktreeInfo) {
+        try {
+          await this.gitService.removeWorktree(
+            worktreeInfo.repoRoot,
+            worktreeInfo.worktreePath,
+          );
+        } catch (e) {
+          console.error('Failed to clean up worktree after error:', e);
+        }
+      }
       await this.stopStoryElaboration(ticketData.id || '');
       throw error;
     }
@@ -183,7 +242,7 @@ export class StoryElaboratorService {
     if (!data) return;
 
     this.activeElaborations.delete(ticketId);
-    const { client, session } = data;
+    const { client, session, worktreeInfo } = data;
     try {
       await session.disconnect();
     } catch (e) {
@@ -193,6 +252,16 @@ export class StoryElaboratorService {
       await client.stop();
     } catch (e) {
       console.error('Error stopping client in stopStoryElaboration:', e);
+    }
+    if (worktreeInfo) {
+      try {
+        await this.gitService.removeWorktree(
+          worktreeInfo.repoRoot,
+          worktreeInfo.worktreePath,
+        );
+      } catch (e) {
+        console.error('Error removing worktree in stopStoryElaboration:', e);
+      }
     }
   }
 
@@ -206,6 +275,19 @@ export class StoryElaboratorService {
           `Error cleaning up active elaboration session for ticket ${ticketId}:`,
           e,
         );
+      }
+      if (data.worktreeInfo) {
+        try {
+          await this.gitService.removeWorktree(
+            data.worktreeInfo.repoRoot,
+            data.worktreeInfo.worktreePath,
+          );
+        } catch (e) {
+          console.error(
+            `Error removing worktree during cleanup for ticket ${ticketId}:`,
+            e,
+          );
+        }
       }
     }
     this.activeElaborations.clear();

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -49,10 +49,12 @@ async function initStore() {
 let azureService: IssueTrackerProvider | null = null;
 let confluenceService: DocumentationProvider | null = null;
 const copilotService = new CopilotService();
+const gitService = new GitService();
 const storyWriterService = new StoryWriterService(copilotService);
 const testCaseWriterService = new TestCaseWriterService(copilotService);
 const storyElaboratorService = new StoryElaboratorService(
   copilotService,
+  gitService,
   async () => {
     try {
       return await getConfluenceService();
@@ -62,7 +64,6 @@ const storyElaboratorService = new StoryElaboratorService(
   },
 );
 const promptComplexityService = new PromptComplexityService(copilotService);
-const gitService = new GitService();
 const prReviewerService = new PRReviewerService(
   gitService,
   copilotService,
@@ -281,7 +282,14 @@ ipcMain.handle('select-directory', async () => {
 
 ipcMain.handle(
   'start-story-elaboration',
-  async (event, ticketData, repoPath, additionalContext, modelOverride) => {
+  async (
+    event,
+    ticketData,
+    repoPath,
+    additionalContext,
+    modelOverride,
+    branch,
+  ) => {
     const s = await initStore();
     const settings = (s.get('settings') ?? {}) as AppSettings;
     return storyElaboratorService.startStoryElaboration(
@@ -290,6 +298,7 @@ ipcMain.handle(
       additionalContext,
       modelOverride,
       settings,
+      branch,
       (line: string) => {
         event.sender.send('elaboration-line', line);
       },

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -68,6 +68,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     repoPath: string | null,
     additionalContext: string,
     modelOverride: string,
+    branch?: string,
   ) =>
     ipcRenderer.invoke(
       'start-story-elaboration',
@@ -75,6 +76,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
       repoPath,
       additionalContext,
       modelOverride,
+      branch,
     ),
   sendElaborationAnswer: (ticketId: string, answer: string) =>
     ipcRenderer.invoke('send-elaboration-answer', ticketId, answer),

--- a/src/renderer/features/settings/components/GeneralSettings.tsx
+++ b/src/renderer/features/settings/components/GeneralSettings.tsx
@@ -158,13 +158,14 @@ const GeneralSettings: React.FC<GeneralSettingsProps> = ({
                 className="form-check-label fw-semibold"
                 htmlFor="gitWorktreeEnabled"
               >
-                Enable Git Worktree for PR Reviews
+                Enable Git Worktree Support
               </label>
             </div>
             <p className="text-muted small mb-3">
               When enabled, Stitch will create a separate git worktree for
-              checking out the PR. This avoids dirtying or modifying your local
-              working directory during review.
+              repository tasks (such as checking out pull requests or
+              elaborating stories). This avoids dirtying or modifying your
+              primary working directory.
             </p>
           </div>
 
@@ -203,7 +204,7 @@ const GeneralSettings: React.FC<GeneralSettingsProps> = ({
               </div>
               <p className="text-muted small mt-2 mb-3">
                 Stitch will create temporary directories under this base
-                directory for each PR review.
+                directory for each worktree task.
               </p>
 
               <div className="d-flex align-items-center gap-3">

--- a/src/renderer/features/story-elaborator/StoryElaborator.tsx
+++ b/src/renderer/features/story-elaborator/StoryElaborator.tsx
@@ -13,6 +13,22 @@ interface FeedItem {
   text: string;
 }
 
+const sanitizeErrorMessage = (err: unknown, defaultMsg: string): string => {
+  if (!(err instanceof Error)) {
+    return defaultMsg;
+  }
+  let message = err.message;
+  if (message.includes('Error invoking remote method')) {
+    const match = message.match(
+      /Error invoking remote method '[^']+':\s*([\s\S]*)/,
+    );
+    if (match && match[1]) {
+      message = match[1];
+    }
+  }
+  return message;
+};
+
 const StoryElaborator: React.FC = () => {
   const { showTimeout } = useTimeoutModal();
   const isMountedRef = useRef(true);
@@ -218,10 +234,10 @@ const StoryElaborator: React.FC = () => {
     } catch (err: unknown) {
       if (!isMountedRef.current) return;
       console.error(err);
-      const errMsg =
-        err instanceof Error
-          ? err.message
-          : 'An error occurred during elaboration.';
+      const errMsg = sanitizeErrorMessage(
+        err,
+        'An error occurred during elaboration.',
+      );
       if (isTimeoutError(err)) {
         showTimeout(err);
       } else {
@@ -256,10 +272,10 @@ const StoryElaborator: React.FC = () => {
     } catch (err: unknown) {
       if (!isMountedRef.current) return;
       console.error(err);
-      const errMsg =
-        err instanceof Error
-          ? err.message
-          : 'An error occurred sending response.';
+      const errMsg = sanitizeErrorMessage(
+        err,
+        'An error occurred sending response.',
+      );
       if (isTimeoutError(err)) {
         showTimeout(err);
       } else {
@@ -283,10 +299,10 @@ const StoryElaborator: React.FC = () => {
     } catch (err: unknown) {
       if (!isMountedRef.current) return;
       console.error(err);
-      const errMsg =
-        err instanceof Error
-          ? err.message
-          : 'An error occurred sending response.';
+      const errMsg = sanitizeErrorMessage(
+        err,
+        'An error occurred sending response.',
+      );
       if (isTimeoutError(err)) {
         showTimeout(err);
       } else {

--- a/src/renderer/features/story-elaborator/StoryElaborator.tsx
+++ b/src/renderer/features/story-elaborator/StoryElaborator.tsx
@@ -24,6 +24,8 @@ const StoryElaborator: React.FC = () => {
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [repoPath, setRepoPath] = useState('');
   const [context, setContext] = useState('');
+  const [gitWorktreeEnabled, setGitWorktreeEnabled] = useState(false);
+  const [branch, setBranch] = useState('develop');
 
   // Session States
   // 'idle' | 'elaborating' | 'plan_completed'
@@ -88,6 +90,19 @@ const StoryElaborator: React.FC = () => {
     };
     document.addEventListener('mousedown', handleClickOutside);
     return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  // Load settings on mount to check if git worktree is enabled
+  useEffect(() => {
+    const loadSettings = async () => {
+      try {
+        const settings = await window.electronAPI.getSettings();
+        setGitWorktreeEnabled(settings.gitWorktreeEnabled || false);
+      } catch (err) {
+        console.error('Failed to load settings in StoryElaborator:', err);
+      }
+    };
+    loadSettings();
   }, []);
 
   // Scroll to bottom of chat
@@ -198,6 +213,7 @@ const StoryElaborator: React.FC = () => {
         repoPath.trim() ? repoPath : null,
         context,
         selectedModel,
+        gitWorktreeEnabled ? branch.trim() || 'develop' : undefined,
       );
     } catch (err: unknown) {
       if (!isMountedRef.current) return;
@@ -489,6 +505,27 @@ const StoryElaborator: React.FC = () => {
                   changes.
                 </div>
               </div>
+
+              {/* Git Branch */}
+              {gitWorktreeEnabled && (
+                <div className="mb-3 animate__animated animate__fadeIn">
+                  <label className="form-label fw-medium text-secondary">
+                    Git Branch
+                  </label>
+                  <input
+                    type="text"
+                    className="form-control border-2"
+                    placeholder="develop"
+                    value={branch}
+                    onChange={(e) => setBranch(e.target.value)}
+                    disabled={stage !== 'idle'}
+                  />
+                  <div className="form-text text-muted small">
+                    The branch to checkout in the worktree. Defaults to{' '}
+                    <code>develop</code>.
+                  </div>
+                </div>
+              )}
 
               {/* Additional Context */}
               <div className="mb-3">

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -53,6 +53,7 @@ export interface IElectronAPI {
     repoPath: string | null,
     additionalContext: string,
     modelOverride: string,
+    branch?: string,
   ) => Promise<string>;
   sendElaborationAnswer: (ticketId: string, answer: string) => Promise<string>;
   stopStoryElaboration: (ticketId: string) => Promise<void>;


### PR DESCRIPTION
Continuing on from adding Worktree support for the PR Reviewer in #116, this PR adds support to the Story Elaborator.

## The Problem

When a user runs an elaboration session and selects a project for the agent to investigate, the agent sees exactly what the user's current version of the local repo contains.

This means if their current repo is very old, is on a branch, or contains uncommitted (or unmarked) changes, the agent will base its plan on this bad foundation, which may lead to plans that are nonsensical when applied to the current (clean) state of the repo.

## The Solution

Take advantage of the recent work adding worktree support to create an isolated work area where the agent can work. We can check out and pull the latest version of a stable branch (like `develop` or `main`) to base the agent's investigation and plan on.

## Complications

Unlike the PR reviewer, where we explicitly wanted to work at the top-level of the repo to ensure the paths of reviewed files are correct when we push comments to the review platform, the Story Elaborator needs to handle monorepos and similar multi-project setups correctly. Forcefully pulling the agent to the root of the repo is unlikely to be positive - it's likely to confuse it or lead it to suggest broader changes to accomplish the task.

So we need to identify where the user selected relative to the repo root and attempt to use that relative location within the worktree.

> [!NOTE]
> While it may be possible to resolve situations where the selected directory doesn't exist in the worktree, by following the rename/move history or with things like pattern matching files and looking for similar file structures, we purposely **don't do this** and will fail fast, requiring the user to get their local repo up to date before continuing.
> This is to ensure the agent doesn't produce a bad plan because we made the wrong call, since this detection would be hidden from the user.