### PR TITLE
feat(test case writer): Basic editing

### DIFF
--- a/src/main/features/test-case-writer/__tests__/testCaseWriterService.test.ts
+++ b/src/main/features/test-case-writer/__tests__/testCaseWriterService.test.ts
@@ -25,7 +25,7 @@ describe('TestCaseWriter feature', () => {
       expect(prompt).toContain('My Ticket Description');
       expect(prompt).toContain('AC 1, AC 2');
       expect(prompt).toContain('Extra Context');
-      expect(prompt).toContain('Test Case ID (e.g., "TC01")');
+      expect(prompt).not.toContain('Test Case ID');
     });
 
     it('should generate test case prompt with custom overrides', () => {
@@ -33,7 +33,6 @@ describe('TestCaseWriter feature', () => {
         prompts: {
           testCaseWriter: {
             general: 'Custom General Test Rules',
-            id: 'Custom TC ID',
             description: 'Custom TC Description',
             preConditions: 'Custom TC Preconditions',
             steps: 'Custom TC Steps',
@@ -52,7 +51,6 @@ describe('TestCaseWriter feature', () => {
       );
 
       expect(prompt).toContain('Custom General Test Rules');
-      expect(prompt).toContain('Custom TC ID');
       expect(prompt).toContain('Custom TC Description');
       expect(prompt).toContain('Custom TC Preconditions');
       expect(prompt).toContain('Custom TC Steps');

--- a/src/main/features/test-case-writer/testCaseWriterPrompts.ts
+++ b/src/main/features/test-case-writer/testCaseWriterPrompts.ts
@@ -11,7 +11,6 @@ export function buildTestCasePrompt(
   const testCaseWriter = settings.prompts?.testCaseWriter || {};
   const generalPrompt = testCaseWriter.general || '';
 
-  const idPrompt = testCaseWriter.id || 'Test Case ID (e.g., "TC01")';
   const descriptionPrompt =
     testCaseWriter.description || 'Brief description of the test scenario';
   const preConditionsPrompt =
@@ -39,15 +38,16 @@ export function buildTestCasePrompt(
         Do NOT use markdown code blocks, fences, or any formatting other than plain JSON objects. All newlines within string values must be represented as \`\\n\` (double backslash-n), not as actual newlines.
         
         Each JSON object must have exactly the following keys:
-        - "id": (string) ${idPrompt}
         - "description": (string) ${descriptionPrompt}
         - "preConditions": (string) ${preConditionsPrompt}
         - "steps": (string) ${stepsPrompt}
         - "expectedResult": (string) ${expectedResultPrompt}
         - "priority": (string) Priority of the test (e.g., "High", "Medium", "Low")
 
+        DO NOT include an "id" key in the JSON object.
+
         For example:
-        {"id": "", "description": "It works", "preConditions": "* One\\\\n* Two\\\\n* Three", "steps": "1. Step 1\\\\n2. Step 2\\\\n3. Step 3", "expectedResult": "Nothing", "priority": "High"}
+        {"description": "It works", "preConditions": "* One\\\\n* Two\\\\n* Three", "steps": "1. Step 1\\\\n2. Step 2\\\\n3. Step 3", "expectedResult": "Nothing", "priority": "High"}
 
         All double quotes inside string values must be escaped as \\".
         Do not use markdown formatting or syntax; only plain text is allowed.

--- a/src/renderer/features/settings/components/PromptSettings.tsx
+++ b/src/renderer/features/settings/components/PromptSettings.tsx
@@ -17,8 +17,6 @@ interface PromptSettingsProps {
 
   testCaseGeneral: string;
   setTestCaseGeneral: (val: string) => void;
-  testCaseId: string;
-  setTestCaseId: (val: string) => void;
   testCaseDescription: string;
   setTestCaseDescription: (val: string) => void;
   testCasePreConditions: string;
@@ -46,8 +44,6 @@ const PromptSettings: React.FC<PromptSettingsProps> = ({
 
   testCaseGeneral,
   setTestCaseGeneral,
-  testCaseId,
-  setTestCaseId,
   testCaseDescription,
   setTestCaseDescription,
   testCasePreConditions,
@@ -91,7 +87,6 @@ const PromptSettings: React.FC<PromptSettingsProps> = ({
 
   const handleResetTestCaseDefaults = () => {
     setTestCaseGeneral('');
-    setTestCaseId('');
     setTestCaseDescription('');
     setTestCasePreConditions('');
     setTestCaseSteps('');
@@ -165,7 +160,6 @@ const PromptSettings: React.FC<PromptSettingsProps> = ({
   const handleCheckTestCase = async () => {
     const hasCustom = [
       testCaseGeneral,
-      testCaseId,
       testCaseDescription,
       testCasePreConditions,
       testCaseSteps,
@@ -185,7 +179,6 @@ const PromptSettings: React.FC<PromptSettingsProps> = ({
 
     const currentKey = JSON.stringify({
       general: testCaseGeneral,
-      id: testCaseId,
       description: testCaseDescription,
       preConditions: testCasePreConditions,
       steps: testCaseSteps,
@@ -211,7 +204,6 @@ const PromptSettings: React.FC<PromptSettingsProps> = ({
         'testcase',
         {
           general: testCaseGeneral,
-          id: testCaseId,
           description: testCaseDescription,
           preConditions: testCasePreConditions,
           steps: testCaseSteps,
@@ -464,20 +456,6 @@ const PromptSettings: React.FC<PromptSettingsProps> = ({
             <h6 className="mb-3 border-bottom pb-2 fw-semibold text-primary mt-4">
               Field Customization
             </h6>
-
-            <div className="mb-3">
-              <label className="form-label fw-semibold">Test Case ID</label>
-              <textarea
-                className="form-control"
-                rows={2}
-                value={testCaseId}
-                onChange={(e) => setTestCaseId(e.target.value)}
-                placeholder='Test Case ID (e.g., "TC01")'
-              />
-              <div className="form-text">
-                Define ID naming conventions or serial formats.
-              </div>
-            </div>
 
             <div className="mb-3">
               <label className="form-label fw-semibold">Description</label>

--- a/src/renderer/features/settings/components/Settings.tsx
+++ b/src/renderer/features/settings/components/Settings.tsx
@@ -241,8 +241,6 @@ const Settings: React.FC = () => {
             setStoryNotes={setStoryNotes}
             testCaseGeneral={testCaseGeneral}
             setTestCaseGeneral={setTestCaseGeneral}
-            testCaseId={testCaseId}
-            setTestCaseId={setTestCaseId}
             testCaseDescription={testCaseDescription}
             setTestCaseDescription={setTestCaseDescription}
             testCasePreConditions={testCasePreConditions}

--- a/src/renderer/features/test-case-writer/TestCaseWriter.tsx
+++ b/src/renderer/features/test-case-writer/TestCaseWriter.tsx
@@ -70,6 +70,10 @@ const TestCaseWriter: React.FC = () => {
   const [error, setError] = useState<string>('');
   const [isPosting, setIsPosting] = useState(false);
 
+  // Reordering states
+  const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
+  const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
+
   const searchContainerRef = useRef<HTMLDivElement>(null);
 
   // Debounced search effect
@@ -469,14 +473,14 @@ const TestCaseWriter: React.FC = () => {
                   <table className="table table-striped table-hover align-middle mb-0">
                     <thead className="table-dark">
                       <tr>
-                        <th style={{ width: '12%', minWidth: '80px' }}>ID</th>
-                        <th style={{ width: '23%', minWidth: '150px' }}>
+                        <th style={{ width: '10%', minWidth: '80px' }}>ID</th>
+                        <th style={{ width: '22%', minWidth: '150px' }}>
                           Description
                         </th>
-                        <th style={{ width: '20%', minWidth: '130px' }}>
+                        <th style={{ width: '18%', minWidth: '130px' }}>
                           Pre-conditions
                         </th>
-                        <th style={{ width: '25%', minWidth: '180px' }}>
+                        <th style={{ width: '23%', minWidth: '180px' }}>
                           Steps
                         </th>
                         <th style={{ width: '12%', minWidth: '100px' }}>
@@ -485,14 +489,66 @@ const TestCaseWriter: React.FC = () => {
                         <th style={{ width: '8%', minWidth: '80px' }}>
                           Priority
                         </th>
+                        <th
+                          style={{
+                            width: '7%',
+                            minWidth: '50px',
+                            textAlign: 'center',
+                          }}
+                        ></th>
                       </tr>
                     </thead>
                     <tbody>
                       {testCasesList.map((tc, index) => (
                         <tr
                           key={tc.id || index}
-                          className="animate__animated animate__fadeInUp"
+                          className={`animate__animated animate__fadeInUp ${
+                            draggedIndex === index ? 'is-dragging' : ''
+                          } ${
+                            dragOverIndex === index
+                              ? draggedIndex !== null && draggedIndex < index
+                                ? 'drag-over-target-bottom'
+                                : 'drag-over-target-top'
+                              : ''
+                          }`}
                           style={{ animationDuration: '0.4s' }}
+                          onDragOver={(e) => {
+                            if (draggedIndex === null) return;
+                            e.preventDefault();
+                            if (dragOverIndex !== index) {
+                              setDragOverIndex(index);
+                            }
+                          }}
+                          onDragLeave={() => {
+                            setDragOverIndex(null);
+                          }}
+                          onDrop={(e) => {
+                            e.preventDefault();
+                            if (
+                              draggedIndex === null ||
+                              draggedIndex === index
+                            ) {
+                              setDragOverIndex(null);
+                              return;
+                            }
+
+                            const listCopy = [...testCasesList];
+                            const [draggedItem] = listCopy.splice(
+                              draggedIndex,
+                              1,
+                            );
+                            listCopy.splice(index, 0, draggedItem);
+
+                            // Re-map IDs sequentially to keep them in order (TC-1, TC-2, etc.)
+                            const reorderedList = listCopy.map((item, idx) => ({
+                              ...item,
+                              id: `TC-${idx + 1}`,
+                            }));
+
+                            setTestCasesList(reorderedList);
+                            setDraggedIndex(null);
+                            setDragOverIndex(null);
+                          }}
                         >
                           <td className="fw-bold text-primary">{tc.id}</td>
                           <td className="text-secondary small">
@@ -523,6 +579,26 @@ const TestCaseWriter: React.FC = () => {
                               {tc.priority || 'Medium'}
                             </span>
                           </td>
+                          <td className="text-center">
+                            <div
+                              className="drag-handle py-1"
+                              draggable={!isGenerating}
+                              onDragStart={(e) => {
+                                e.dataTransfer.effectAllowed = 'move';
+                                e.dataTransfer.setData(
+                                  'text/plain',
+                                  index.toString(),
+                                );
+                                setDraggedIndex(index);
+                              }}
+                              onDragEnd={() => {
+                                setDraggedIndex(null);
+                                setDragOverIndex(null);
+                              }}
+                            >
+                              <i className="fas fa-grip-lines"></i>
+                            </div>
+                          </td>
                         </tr>
                       ))}
                       {isGenerating && (
@@ -537,7 +613,7 @@ const TestCaseWriter: React.FC = () => {
                               <span className="text-muted small">...</span>
                             </div>
                           </td>
-                          <td colSpan={5} className="py-3">
+                          <td colSpan={6} className="py-3">
                             <span className="text-muted small fst-italic animate__animated animate__pulse animate__infinite d-inline-block">
                               Generating next test case...
                             </span>

--- a/src/renderer/features/test-case-writer/TestCaseWriter.tsx
+++ b/src/renderer/features/test-case-writer/TestCaseWriter.tsx
@@ -543,17 +543,14 @@ const TestCaseWriter: React.FC = () => {
                                 </td>
                                 <td className="text-center">
                                   <button
-                                    className="btn btn-link text-primary p-0 border-0 fw-semibold small"
+                                    className="btn btn-link text-primary p-0 border-0"
                                     onClick={() => handleRestore(index)}
-                                    disabled={isGenerating}
                                     title="Restore test case"
                                     style={{
                                       boxShadow: 'none',
-                                      textDecoration: 'none',
                                     }}
                                   >
-                                    <i className="fas fa-undo me-1"></i>
-                                    Restore
+                                    <i className="fas fa-undo"></i>
                                   </button>
                                 </td>
                               </tr>
@@ -650,7 +647,6 @@ const TestCaseWriter: React.FC = () => {
                                   <button
                                     className="btn btn-link text-danger p-0 border-0"
                                     onClick={() => handleDelete(index)}
-                                    disabled={isGenerating}
                                     title="Delete test case"
                                     style={{ boxShadow: 'none' }}
                                   >

--- a/src/renderer/features/test-case-writer/TestCaseWriter.tsx
+++ b/src/renderer/features/test-case-writer/TestCaseWriter.tsx
@@ -581,9 +581,13 @@ const TestCaseWriter: React.FC = () => {
                           </td>
                           <td className="text-center">
                             <div
-                              className="drag-handle py-1"
+                              className={`drag-handle py-1 ${isGenerating ? 'drag-disabled' : ''}`}
                               draggable={!isGenerating}
                               onDragStart={(e) => {
+                                if (isGenerating) {
+                                  e.preventDefault();
+                                  return;
+                                }
                                 e.dataTransfer.effectAllowed = 'move';
                                 e.dataTransfer.setData(
                                   'text/plain',
@@ -595,6 +599,11 @@ const TestCaseWriter: React.FC = () => {
                                 setDraggedIndex(null);
                                 setDragOverIndex(null);
                               }}
+                              title={
+                                isGenerating
+                                  ? 'Cannot reorder while generating'
+                                  : 'Drag to reorder'
+                              }
                             >
                               <i className="fas fa-grip-lines"></i>
                             </div>

--- a/src/renderer/features/test-case-writer/TestCaseWriter.tsx
+++ b/src/renderer/features/test-case-writer/TestCaseWriter.tsx
@@ -12,6 +12,7 @@ interface TestCase {
   steps: string;
   expectedResult: string;
   priority: string;
+  deleted?: boolean;
 }
 
 const generateTicketOrCommentText = (testCases: string) =>
@@ -25,13 +26,14 @@ const generateTicketOrCommentText = (testCases: string) =>
   ].join('\n');
 
 const convertToMarkdownTable = (tcList: TestCase[]): string => {
-  if (tcList.length === 0) return '';
+  const activeList = tcList.filter((tc) => !tc.deleted);
+  if (activeList.length === 0) return '';
   const headers = [
     '| Test Case ID | Description | Pre-conditions | Steps | Expected Result | Priority |',
     '| --- | --- | --- | --- | --- | --- |',
   ];
-  const rows = tcList.map((tc) => {
-    const id = (tc.id || '').replace(/\|/g, '\\|').trim();
+  const rows = activeList.map((tc, idx) => {
+    const id = `TC-${idx + 1}`;
     const desc = (tc.description || '')
       .replace(/\|/g, '\\|')
       .replace(/\n/g, ' ')
@@ -73,6 +75,18 @@ const TestCaseWriter: React.FC = () => {
   // Reordering states
   const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
   const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
+
+  const handleDelete = (index: number) => {
+    setTestCasesList((prev) =>
+      prev.map((tc, idx) => (idx === index ? { ...tc, deleted: true } : tc)),
+    );
+  };
+
+  const handleRestore = (index: number) => {
+    setTestCasesList((prev) =>
+      prev.map((tc, idx) => (idx === index ? { ...tc, deleted: false } : tc)),
+    );
+  };
 
   const searchContainerRef = useRef<HTMLDivElement>(null);
 
@@ -480,7 +494,7 @@ const TestCaseWriter: React.FC = () => {
                         <th style={{ width: '18%', minWidth: '130px' }}>
                           Pre-conditions
                         </th>
-                        <th style={{ width: '23%', minWidth: '180px' }}>
+                        <th style={{ width: '22%', minWidth: '180px' }}>
                           Steps
                         </th>
                         <th style={{ width: '12%', minWidth: '100px' }}>
@@ -491,125 +505,192 @@ const TestCaseWriter: React.FC = () => {
                         </th>
                         <th
                           style={{
-                            width: '7%',
-                            minWidth: '50px',
+                            width: '8%',
+                            minWidth: '70px',
                             textAlign: 'center',
                           }}
                         ></th>
                       </tr>
                     </thead>
                     <tbody>
-                      {testCasesList.map((tc, index) => (
-                        <tr
-                          key={tc.id || index}
-                          className={`animate__animated animate__fadeInUp ${
-                            draggedIndex === index ? 'is-dragging' : ''
-                          } ${
-                            dragOverIndex === index
-                              ? draggedIndex !== null && draggedIndex < index
-                                ? 'drag-over-target-bottom'
-                                : 'drag-over-target-top'
-                              : ''
-                          }`}
-                          style={{ animationDuration: '0.4s' }}
-                          onDragOver={(e) => {
-                            if (draggedIndex === null) return;
-                            e.preventDefault();
-                            if (dragOverIndex !== index) {
-                              setDragOverIndex(index);
-                            }
-                          }}
-                          onDragLeave={() => {
-                            setDragOverIndex(null);
-                          }}
-                          onDrop={(e) => {
-                            e.preventDefault();
-                            if (
-                              draggedIndex === null ||
-                              draggedIndex === index
-                            ) {
-                              setDragOverIndex(null);
-                              return;
-                            }
+                      {(() => {
+                        let activeCount = 0;
+                        return testCasesList.map((tc, index) => {
+                          const isDeleted = tc.deleted;
+                          if (!isDeleted) {
+                            activeCount++;
+                          }
+                          const displayId = isDeleted
+                            ? ''
+                            : `TC-${activeCount}`;
 
-                            const listCopy = [...testCasesList];
-                            const [draggedItem] = listCopy.splice(
-                              draggedIndex,
-                              1,
+                          if (isDeleted) {
+                            return (
+                              <tr
+                                key={tc.id || index}
+                                className="table-light align-middle text-muted animate__animated animate__fadeIn"
+                                style={{ height: '45px', opacity: 0.8 }}
+                              >
+                                <td className="text-center text-muted small fst-italic">
+                                  -
+                                </td>
+                                <td
+                                  colSpan={5}
+                                  className="small fst-italic py-2"
+                                >
+                                  <i className="fas fa-trash-alt me-2 text-secondary"></i>
+                                  Test scenario deleted.
+                                </td>
+                                <td className="text-center">
+                                  <button
+                                    className="btn btn-link text-primary p-0 border-0 fw-semibold small"
+                                    onClick={() => handleRestore(index)}
+                                    disabled={isGenerating}
+                                    title="Restore test case"
+                                    style={{
+                                      boxShadow: 'none',
+                                      textDecoration: 'none',
+                                    }}
+                                  >
+                                    <i className="fas fa-undo me-1"></i>
+                                    Restore
+                                  </button>
+                                </td>
+                              </tr>
                             );
-                            listCopy.splice(index, 0, draggedItem);
+                          }
 
-                            // Re-map IDs sequentially to keep them in order (TC-1, TC-2, etc.)
-                            const reorderedList = listCopy.map((item, idx) => ({
-                              ...item,
-                              id: `TC-${idx + 1}`,
-                            }));
-
-                            setTestCasesList(reorderedList);
-                            setDraggedIndex(null);
-                            setDragOverIndex(null);
-                          }}
-                        >
-                          <td className="fw-bold text-primary">{tc.id}</td>
-                          <td className="text-secondary small">
-                            {tc.description}
-                          </td>
-                          <td className="text-secondary small whitespace-pre-wrap">
-                            {tc.preConditions}
-                          </td>
-                          <td
-                            className="text-secondary small whitespace-pre-wrap"
-                            style={{ whiteSpace: 'pre-wrap' }}
-                          >
-                            {tc.steps}
-                          </td>
-                          <td className="text-secondary small whitespace-pre-wrap">
-                            {tc.expectedResult}
-                          </td>
-                          <td>
-                            <span
-                              className={`badge rounded-pill px-3 py-2 fw-semibold ${
-                                tc.priority?.toLowerCase() === 'high'
-                                  ? 'bg-danger text-white'
-                                  : tc.priority?.toLowerCase() === 'medium'
-                                    ? 'bg-warning text-dark'
-                                    : 'bg-secondary text-white'
+                          return (
+                            <tr
+                              key={tc.id || index}
+                              className={`animate__animated animate__fadeInUp ${
+                                draggedIndex === index ? 'is-dragging' : ''
+                              } ${
+                                dragOverIndex === index
+                                  ? draggedIndex !== null &&
+                                    draggedIndex < index
+                                    ? 'drag-over-target-bottom'
+                                    : 'drag-over-target-top'
+                                  : ''
                               }`}
-                            >
-                              {tc.priority || 'Medium'}
-                            </span>
-                          </td>
-                          <td className="text-center">
-                            <div
-                              className={`drag-handle py-1 ${isGenerating ? 'drag-disabled' : ''}`}
-                              draggable={!isGenerating}
-                              onDragStart={(e) => {
-                                if (isGenerating) {
-                                  e.preventDefault();
+                              style={{ animationDuration: '0.4s' }}
+                              onDragOver={(e) => {
+                                if (draggedIndex === null) return;
+                                e.preventDefault();
+                                if (dragOverIndex !== index) {
+                                  setDragOverIndex(index);
+                                }
+                              }}
+                              onDragLeave={() => {
+                                setDragOverIndex(null);
+                              }}
+                              onDrop={(e) => {
+                                e.preventDefault();
+                                if (
+                                  draggedIndex === null ||
+                                  draggedIndex === index
+                                ) {
+                                  setDragOverIndex(null);
                                   return;
                                 }
-                                e.dataTransfer.effectAllowed = 'move';
-                                e.dataTransfer.setData(
-                                  'text/plain',
-                                  index.toString(),
+
+                                const listCopy = [...testCasesList];
+                                const [draggedItem] = listCopy.splice(
+                                  draggedIndex,
+                                  1,
                                 );
-                                setDraggedIndex(index);
-                              }}
-                              onDragEnd={() => {
+                                listCopy.splice(index, 0, draggedItem);
+
+                                // Re-map IDs sequentially to keep them in order (TC-1, TC-2, etc.)
+                                const reorderedList = listCopy.map(
+                                  (item, idx) => ({
+                                    ...item,
+                                    id: `TC-${idx + 1}`,
+                                  }),
+                                );
+
+                                setTestCasesList(reorderedList);
                                 setDraggedIndex(null);
                                 setDragOverIndex(null);
                               }}
-                              title={
-                                isGenerating
-                                  ? 'Cannot reorder while generating'
-                                  : 'Drag to reorder'
-                              }
                             >
-                              <i className="fas fa-grip-lines"></i>
-                            </div>
-                          </td>
-                        </tr>
-                      ))}
+                              <td className="fw-bold text-primary">
+                                {displayId}
+                              </td>
+                              <td className="text-secondary small">
+                                {tc.description}
+                              </td>
+                              <td className="text-secondary small whitespace-pre-wrap">
+                                {tc.preConditions}
+                              </td>
+                              <td
+                                className="text-secondary small whitespace-pre-wrap"
+                                style={{ whiteSpace: 'pre-wrap' }}
+                              >
+                                {tc.steps}
+                              </td>
+                              <td className="text-secondary small whitespace-pre-wrap">
+                                {tc.expectedResult}
+                              </td>
+                              <td>
+                                <span
+                                  className={`badge rounded-pill px-3 py-2 fw-semibold ${
+                                    tc.priority?.toLowerCase() === 'high'
+                                      ? 'bg-danger text-white'
+                                      : tc.priority?.toLowerCase() === 'medium'
+                                        ? 'bg-warning text-dark'
+                                        : 'bg-secondary text-white'
+                                  }`}
+                                >
+                                  {tc.priority || 'Medium'}
+                                </span>
+                              </td>
+                              <td className="text-center">
+                                <div className="d-flex align-items-center justify-content-center gap-2">
+                                  <button
+                                    className="btn btn-link text-danger p-0 border-0"
+                                    onClick={() => handleDelete(index)}
+                                    disabled={isGenerating}
+                                    title="Delete test case"
+                                    style={{ boxShadow: 'none' }}
+                                  >
+                                    <i className="fas fa-trash-alt"></i>
+                                  </button>
+                                  <div
+                                    className={`drag-handle py-1 ${
+                                      isGenerating ? 'drag-disabled' : ''
+                                    }`}
+                                    draggable={!isGenerating}
+                                    onDragStart={(e) => {
+                                      if (isGenerating) {
+                                        e.preventDefault();
+                                        return;
+                                      }
+                                      e.dataTransfer.effectAllowed = 'move';
+                                      e.dataTransfer.setData(
+                                        'text/plain',
+                                        index.toString(),
+                                      );
+                                      setDraggedIndex(index);
+                                    }}
+                                    onDragEnd={() => {
+                                      setDraggedIndex(null);
+                                      setDragOverIndex(null);
+                                    }}
+                                    title={
+                                      isGenerating
+                                        ? 'Cannot reorder while generating'
+                                        : 'Drag to reorder'
+                                    }
+                                  >
+                                    <i className="fas fa-grip-lines"></i>
+                                  </div>
+                                </div>
+                              </td>
+                            </tr>
+                          );
+                        });
+                      })()}
                       {isGenerating && (
                         <tr className="animate__animated animate__fadeIn opacity-75">
                           <td className="py-3">

--- a/src/renderer/features/test-case-writer/TestCaseWriter.tsx
+++ b/src/renderer/features/test-case-writer/TestCaseWriter.tsx
@@ -184,11 +184,14 @@ const TestCaseWriter: React.FC = () => {
         const testCase: TestCase = JSON.parse(trimmed);
         if (testCase && typeof testCase === 'object') {
           setTestCasesList((prev) => {
-            const exists = prev.some((tc) => tc.id === testCase.id);
+            const generatedId = `TC-${prev.length + 1}`;
+            const exists = prev.some((tc) => tc.id === generatedId);
             if (exists) {
-              return prev.map((tc) => (tc.id === testCase.id ? testCase : tc));
+              return prev.map((tc) =>
+                tc.id === generatedId ? { ...testCase, id: generatedId } : tc,
+              );
             }
-            return [...prev, testCase];
+            return [...prev, { ...testCase, id: generatedId }];
           });
         }
       } catch (err) {

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -655,3 +655,27 @@ textarea,
   display: block;
   padding: 0 4px;
 }
+
+/* Drag and Drop Table Rows styling */
+.drag-handle {
+  cursor: grab;
+  color: #adb5bd;
+  text-align: center;
+  transition: color 0.15s ease-in-out;
+}
+.drag-handle:hover {
+  color: #4f46e5;
+}
+.drag-handle:active {
+  cursor: grabbing;
+}
+tr.drag-over-target-top {
+  border-top: 2px dashed #4f46e5 !important;
+}
+tr.drag-over-target-bottom {
+  border-bottom: 2px dashed #4f46e5 !important;
+}
+tr.is-dragging {
+  opacity: 0.4;
+  background-color: var(--bs-secondary-bg) !important;
+}

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -669,6 +669,13 @@ textarea,
 .drag-handle:active {
   cursor: grabbing;
 }
+.drag-handle.drag-disabled {
+  cursor: not-allowed;
+  opacity: 0.4;
+}
+.drag-handle.drag-disabled:hover {
+  color: #adb5bd;
+}
 tr.drag-over-target-top {
   border-top: 2px dashed #4f46e5 !important;
 }


### PR DESCRIPTION
Resolves #114 

Previously the Test Case Writer output a table of test cases, and the user could only use it or discard it. This PR adds some basic editing to this flow.

Firstly, the agent generates test cases with a "Priority" (Low, Medium, High). While it generally is good at putting the most critical cases first, it's very bad at keeping the different priorities grouped - lower "High priority" cases are mixed up with Medium and Low priority cases. While this could be improved with prompt engineering, there is always a relatively high likelihood that a high priority case is identified by the agent after it has already emitted a lower priority one. This change allows the user to reorder the cases. Initially this is just a simple drag-and-drop, but we can consider adding a sort mechanism based on priority in future.

Secondly, if the agent misunderstands something or is being overly cautious, it may write test cases that are irrelevant to the current task. This change adds an ability to delete test cases.

> [!NOTE]
> In order to implement this, the agent has been stripped of the responsibility to generate Test Case IDs, as when reordered or deleted, the IDs would no longer make sense. This PR adds a fixed ID generation mechanism ("TC-<#>") so is more restrictive than the agent's ID generation which could be configured with prompt customisation.
> 
> If custom test case ID generation is useful we will reconsider adding it back, but as either a set of fixed patterns or by being provided a template, to allow the app to programmatically generate them. 