### PR TITLE
chore: strip copilot CLI and platform executables from packaged app

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -72,6 +72,7 @@ locally on the machine.
   - To prevent cross-platform execution issues in packaged environments (e.g., on Windows where system Node spawned as a child process cannot access files inside Electron's read-only `app.asar` package), Stitch manages `@github/copilot` (Copilot CLI) locally in a dedicated directory inside the application's user data path (`<userData>/copilot-cli`).
   - On launch, Stitch verifies that Node.js v22+ is installed, checks for the existence of `@github/copilot` in the managed directory, and matches the installed version against the required version range declared by `@github/copilot-sdk`.
   - If the CLI dependency is missing or outdated, an automated setup wizard displays in the UI to perform the installation seamlessly in the background via NPM.
+  - To minimize bundle size and prevent ASAR packaging/execution conflicts, the Electron Forge packaging process is configured (via `forge.config.ts`) to strip all Copilot CLI executables and platform-specific packages (`@github/copilot` and `@github/copilot-*` except `@github/copilot-sdk`) from `node_modules` before generating the final application archive.
 - **Model Selection:** Supports listing available models (e.g., GPT-4o, Claude
   3.5 Sonnet) and allowing users to choose a model for each generation session.
 - **Generation & Multi-turn Sessions:**

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -107,6 +107,32 @@ const config: ForgeConfig = {
       });
 
       console.log('Hook: External dependencies installed successfully!');
+
+      // 5. Strip Copilot CLI files from the packaged app directory
+      console.log('Hook: Stripping Copilot CLI files...');
+      const githubDir = path.join(buildPath, 'node_modules', '@github');
+      if (fs.existsSync(githubDir)) {
+        const dirs = fs.readdirSync(githubDir);
+        for (const dir of dirs) {
+          if (dir.startsWith('copilot') && dir !== 'copilot-sdk') {
+            const dirPath = path.join(githubDir, dir);
+            console.log(`- Removing directory: ${dirPath}`);
+            fs.rmSync(dirPath, { recursive: true, force: true });
+          }
+        }
+      }
+
+      const binDir = path.join(buildPath, 'node_modules', '.bin');
+      if (fs.existsSync(binDir)) {
+        const binFiles = fs.readdirSync(binDir);
+        for (const file of binFiles) {
+          if (file.startsWith('copilot')) {
+            const filePath = path.join(binDir, file);
+            console.log(`- Removing binary: ${filePath}`);
+            fs.rmSync(filePath, { recursive: true, force: true });
+          }
+        }
+      }
     },
   },
 };


### PR DESCRIPTION
For convenience, the GitHub Copilot SDK includes a bundled copy of the Copilot CLI. However, since we are running under Electron, and have issues running the bundled copy from within an ASAR, we have already moved away from this approach and self-manage our own copy of the CLI during runtime.

This PR configures electron forge to strip the Copilot CLI packages from the node_modules before packaging, leaving the Copilot SDK present. This helps reduce the package size and download and storage wastage since we don't use it anyway.

This significantly reduces the package size, going from 249MB to 136MB for the Windows package (a 45% reduction).