### PR TITLE
feat: add native OS notification when the LLM finishes or is waiting for the user

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -7,6 +7,7 @@ import {
   shell,
   nativeTheme,
   dialog,
+  Notification,
 } from 'electron';
 import { AzureDevOpsService } from './infrastructure/azure/azureDevOpsService';
 import { CopilotService } from './infrastructure/copilot/copilotService';
@@ -515,15 +516,32 @@ ipcMain.handle('create-ticket', async (event, type, parentTicketId, data) => {
   return service.createTicket(type, parentTicketId, data);
 });
 
-ipcMain.handle('focus-window', (event) => {
+ipcMain.handle('show-notification', (event, title: string, body: string) => {
   const webContents = event.sender;
   const win = BrowserWindow.fromWebContents(webContents);
-  if (win) {
-    if (win.isMinimized()) {
-      win.restore();
+  if (Notification.isSupported()) {
+    try {
+      const notification = new Notification({
+        title,
+        body,
+      });
+
+      notification.on('click', () => {
+        if (win) {
+          if (win.isMinimized()) {
+            win.restore();
+          }
+          win.show();
+          win.focus();
+        }
+      });
+
+      notification.show();
+    } catch (err) {
+      console.error('Failed to show notification:', err);
     }
-    win.show();
-    win.focus();
+  } else {
+    console.warn('Native notifications are not supported on this platform.');
   }
 });
 
@@ -558,6 +576,10 @@ const createWindow = (): void => {
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
 app.on('ready', async () => {
+  if (process.platform === 'win32') {
+    app.setAppUserModelId('com.squirrel.stitch.Stitch');
+  }
+
   const s = await initStore();
 
   // Migrate any existing plain text credentials to secure storage

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -515,6 +515,18 @@ ipcMain.handle('create-ticket', async (event, type, parentTicketId, data) => {
   return service.createTicket(type, parentTicketId, data);
 });
 
+ipcMain.handle('focus-window', (event) => {
+  const webContents = event.sender;
+  const win = BrowserWindow.fromWebContents(webContents);
+  if (win) {
+    if (win.isMinimized()) {
+      win.restore();
+    }
+    win.show();
+    win.focus();
+  }
+});
+
 const createWindow = (): void => {
   // Create the browser window.
   const mainWindow = new BrowserWindow({

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -516,6 +516,9 @@ ipcMain.handle('create-ticket', async (event, type, parentTicketId, data) => {
   return service.createTicket(type, parentTicketId, data);
 });
 
+// Keep active notifications in memory to prevent garbage collection before click/close events fire
+const activeNotifications = new Set<Notification>();
+
 ipcMain.handle('show-notification', (event, title: string, body: string) => {
   const webContents = event.sender;
   const win = BrowserWindow.fromWebContents(webContents);
@@ -526,6 +529,8 @@ ipcMain.handle('show-notification', (event, title: string, body: string) => {
         body,
       });
 
+      activeNotifications.add(notification);
+
       notification.on('click', () => {
         if (win) {
           if (win.isMinimized()) {
@@ -534,6 +539,11 @@ ipcMain.handle('show-notification', (event, title: string, body: string) => {
           win.show();
           win.focus();
         }
+        activeNotifications.delete(notification);
+      });
+
+      notification.on('close', () => {
+        activeNotifications.delete(notification);
       });
 
       notification.show();

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -195,6 +195,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
       prUrlOrId,
       comment,
     ),
-  focusWindow: (): Promise<void> => ipcRenderer.invoke('focus-window'),
+  showNotification: (title: string, body: string): Promise<void> =>
+    ipcRenderer.invoke('show-notification', title, body),
   isWindows: process.platform === 'win32',
 });

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -195,5 +195,6 @@ contextBridge.exposeInMainWorld('electronAPI', {
       prUrlOrId,
       comment,
     ),
+  focusWindow: (): Promise<void> => ipcRenderer.invoke('focus-window'),
   isWindows: process.platform === 'win32',
 });

--- a/src/renderer/features/pr-reviewer/PRReviewer.tsx
+++ b/src/renderer/features/pr-reviewer/PRReviewer.tsx
@@ -322,6 +322,29 @@ const PRReviewer: React.FC = () => {
   const handleStartReview = async () => {
     if (!selectedPR || !commitSha) return;
 
+    const triggerNotification = (title: string, body: string) => {
+      if (!document.hasFocus() && window.Notification) {
+        const show = () => {
+          const notification = new window.Notification(title, { body });
+          notification.onclick = () => {
+            window.electronAPI.focusWindow().catch((err) => {
+              console.error('Failed to focus window:', err);
+            });
+          };
+        };
+
+        if (window.Notification.permission === 'granted') {
+          show();
+        } else if (window.Notification.permission !== 'denied') {
+          window.Notification.requestPermission().then((permission) => {
+            if (permission === 'granted') {
+              show();
+            }
+          });
+        }
+      }
+    };
+
     const activePhases = phases.filter((p) => p.enabled);
     const phaseWithTemplateError = activePhases.find((p) => p.templateError);
     if (phaseWithTemplateError) {
@@ -409,10 +432,18 @@ const PRReviewer: React.FC = () => {
         maxParallelism,
       );
       setHasReviewed(true);
+      triggerNotification(
+        'PR Review Complete',
+        `The review for PR #${selectedPR.id} ("${selectedPR.title}") has completed successfully.`,
+      );
     } catch (err: unknown) {
       console.error('Review execution failed:', err);
       const msg = err instanceof Error ? err.message : String(err);
       showError(msg);
+      triggerNotification(
+        'PR Review Failed',
+        `The review for PR #${selectedPR.id} ("${selectedPR.title}") failed to complete.`,
+      );
     } finally {
       setIsReviewing(false);
       unsubscribe();

--- a/src/renderer/features/pr-reviewer/PRReviewer.tsx
+++ b/src/renderer/features/pr-reviewer/PRReviewer.tsx
@@ -323,25 +323,10 @@ const PRReviewer: React.FC = () => {
     if (!selectedPR || !commitSha) return;
 
     const triggerNotification = (title: string, body: string) => {
-      if (!document.hasFocus() && window.Notification) {
-        const show = () => {
-          const notification = new window.Notification(title, { body });
-          notification.onclick = () => {
-            window.electronAPI.focusWindow().catch((err) => {
-              console.error('Failed to focus window:', err);
-            });
-          };
-        };
-
-        if (window.Notification.permission === 'granted') {
-          show();
-        } else if (window.Notification.permission !== 'denied') {
-          window.Notification.requestPermission().then((permission) => {
-            if (permission === 'granted') {
-              show();
-            }
-          });
-        }
+      if (!document.hasFocus()) {
+        window.electronAPI.showNotification(title, body).catch((err) => {
+          console.error('Failed to show notification:', err);
+        });
       }
     };
 

--- a/src/renderer/features/settings/components/GeneralSettings.tsx
+++ b/src/renderer/features/settings/components/GeneralSettings.tsx
@@ -287,6 +287,41 @@ const GeneralSettings: React.FC<GeneralSettingsProps> = ({
               </div>
             )}
           </div>
+
+          <h5 className="mb-4 mt-4 border-bottom pb-2">
+            <i className="fas fa-bell me-2 text-primary"></i>Notification
+            Settings
+          </h5>
+
+          <div className="mb-2">
+            <p className="text-muted small mb-3">
+              Test native OS notifications to verify they are enabled and
+              working correctly.
+            </p>
+            <button
+              type="button"
+              className="btn btn-outline-primary d-flex align-items-center gap-2"
+              onClick={() => {
+                setTimeout(() => {
+                  window.electronAPI
+                    .showNotification(
+                      'Stitch Test Notification',
+                      'This is a test notification from Stitch! Click here to focus.',
+                    )
+                    .catch((err) => {
+                      console.error('Failed to send test notification:', err);
+                    });
+                }, 3000);
+              }}
+            >
+              <i className="fas fa-paper-plane"></i>
+              Send Test Notification (3s delay)
+            </button>
+            <p className="text-muted small mt-2 mb-0">
+              Click the button, then minimize or focus away from Stitch within 3
+              seconds to test.
+            </p>
+          </div>
         </div>
       </div>
 

--- a/src/renderer/features/story-elaborator/StoryElaborator.tsx
+++ b/src/renderer/features/story-elaborator/StoryElaborator.tsx
@@ -68,6 +68,14 @@ const StoryElaborator: React.FC = () => {
   const { models, selectedModel, setSelectedModel, loadingModels } =
     useCopilotModels();
 
+  const triggerNotification = (title: string, body: string) => {
+    if (!document.hasFocus()) {
+      window.electronAPI.showNotification(title, body).catch((err) => {
+        console.error('Failed to show notification:', err);
+      });
+    }
+  };
+
   // Debounced ticket search
   useEffect(() => {
     if (!searchQuery.trim()) {
@@ -205,12 +213,20 @@ const StoryElaborator: React.FC = () => {
             },
           ]);
           setCurrentSuggestions(data.suggestedAnswers || []);
+          triggerNotification(
+            'Elaborator Question',
+            `The agent has asked a question for ticket #${ticketId}.`,
+          );
         } else if (data.type === 'plan') {
           setPlanMarkdown(data.text);
           setPlanFilePath(data.filePath || '');
           setStage('plan_completed');
           setIsGenerating(false);
           setIsWaitingForUser(false);
+          triggerNotification(
+            'Elaboration Plan Completed',
+            `The agent has successfully written the plan for ticket #${ticketId}.`,
+          );
         }
       } catch (err) {
         console.warn('Failed to parse JSONL line:', trimmed, err);
@@ -245,6 +261,10 @@ const StoryElaborator: React.FC = () => {
       }
       setStage('idle');
       setIsGenerating(false);
+      triggerNotification(
+        'Elaboration Failed',
+        `Story elaboration failed for ticket #${ticketId}: ${errMsg}`,
+      );
     } finally {
       if (isMountedRef.current) {
         unsubscribeRef.current = unsubscribe;
@@ -282,6 +302,10 @@ const StoryElaborator: React.FC = () => {
         setError(errMsg);
       }
       setIsGenerating(false);
+      triggerNotification(
+        'Elaboration Error',
+        `Failed to send response: ${errMsg}`,
+      );
     }
   };
 
@@ -309,6 +333,10 @@ const StoryElaborator: React.FC = () => {
         setError(errMsg);
       }
       setIsGenerating(false);
+      triggerNotification(
+        'Elaboration Error',
+        `Failed to send response: ${errMsg}`,
+      );
     }
   };
 

--- a/src/renderer/features/story-writer/StoryWriter.tsx
+++ b/src/renderer/features/story-writer/StoryWriter.tsx
@@ -173,6 +173,14 @@ const StoryWriter: React.FC = () => {
       return;
     }
 
+    const triggerNotification = (title: string, body: string) => {
+      if (!document.hasFocus()) {
+        window.electronAPI.showNotification(title, body).catch((err) => {
+          console.error('Failed to show notification:', err);
+        });
+      }
+    };
+
     setError('');
     setIsGenerating(true);
     setGenerationStarted(true);
@@ -217,6 +225,10 @@ const StoryWriter: React.FC = () => {
         context,
         selectedModel,
       );
+      triggerNotification(
+        'Story Generation Complete',
+        `Stitch has successfully generated stories for Confluence page "${fetchedPage.title}".`,
+      );
     } catch (err: unknown) {
       if (!isMountedRef.current) return;
       console.error(err);
@@ -229,6 +241,10 @@ const StoryWriter: React.FC = () => {
       } else {
         setError(errMsg);
       }
+      triggerNotification(
+        'Story Generation Failed',
+        `Failed to generate stories: ${errMsg}`,
+      );
     } finally {
       unsubscribe();
       if (isMountedRef.current) {

--- a/src/renderer/features/test-case-writer/TestCaseWriter.tsx
+++ b/src/renderer/features/test-case-writer/TestCaseWriter.tsx
@@ -208,6 +208,14 @@ const TestCaseWriter: React.FC = () => {
       return;
     }
 
+    const triggerNotification = (title: string, body: string) => {
+      if (!document.hasFocus()) {
+        window.electronAPI.showNotification(title, body).catch((err) => {
+          console.error('Failed to show notification:', err);
+        });
+      }
+    };
+
     setError('');
     setIsGenerating(true);
     setGenerationStarted(true);
@@ -251,6 +259,10 @@ const TestCaseWriter: React.FC = () => {
         context,
         selectedModel,
       );
+      triggerNotification(
+        'Test Case Generation Complete',
+        `Stitch has successfully generated test cases for ticket #${fetchedTicket.id} ("${fetchedTicket.title}").`,
+      );
     } catch (err: unknown) {
       if (!isMountedRef.current) return;
       console.error(err);
@@ -263,6 +275,10 @@ const TestCaseWriter: React.FC = () => {
       } else {
         setError(errMsg);
       }
+      triggerNotification(
+        'Test Case Generation Failed',
+        `Failed to generate test cases: ${errMsg}`,
+      );
     } finally {
       unsubscribe();
       if (isMountedRef.current) {

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -120,6 +120,7 @@ export interface IElectronAPI {
       comment: string;
     },
   ) => Promise<void>;
+  focusWindow: () => Promise<void>;
   isWindows: boolean;
 }
 

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -120,7 +120,7 @@ export interface IElectronAPI {
       comment: string;
     },
   ) => Promise<void>;
-  focusWindow: () => Promise<void>;
+  showNotification: (title: string, body: string) => Promise<void>;
   isWindows: boolean;
 }
 


### PR DESCRIPTION
Currently the app completes tasks silently. This is annoying because some tasks take time and the user wants to start it off and just find out when it's complete rather than have to keep the window visible or regularly check it.

This PR adds the following notifications:
- Test Case Writer, Story Writer, PR Reviewer: When the agent has finished producing the requested output
- Story Elaborator: When the agent has a question or has finished producing the plan

This allows the user to start a task and minimise the window. They will be notified when their attention is required.

Notifications only appear if the app window isn't in focus, and clicking the notification makes the window reappear and brings it to the front, ready for you to work on.