### PR TITLE
feat: AzDO: add generic work item types

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ automate reviews without losing focus or context.
   into your repo.
 - **Accelerate Planning and Testing**: Generate comprehensive user stories and
   test cases from tickets in seconds, then instantly push them back to Azure
-  DevOps as PBIs or child tasks.
+  DevOps as stories or child tasks.
 
 ## Core Features
 
@@ -111,7 +111,7 @@ automate reviews without losing focus or context.
     stories with Titles, Descriptions, and Acceptance Criteria, using your
     **chosen AI model**.
   - Ability to selectively choose generated stories and write them back to Azure
-    DevOps as new **Product Backlog Items (PBIs)** linked under a specific
+    DevOps as new **Stories** linked under a specific
     Feature.
 - **Persistent Settings & Prompt Customization**:
   - **Prompt Customization**: Fine-tune the base and detail prompt templates

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -149,7 +149,7 @@ support modern ESM-only libraries like `electron-store` and
 - `list-copilot-models`: Retrieves available GitHub Copilot models.
 - `check-prompt-complexity`: Runs Copilot-based complexity and safety validation on user-customized prompt templates.
 - `add-comment`: Pushes text as a comment onto an Azure DevOps work item.
-- `create-ticket`: Creates a new work item (PBI or Task) in Azure DevOps linked to a parent.
+- `create-ticket`: Creates a new work item (Story or Task) in Azure DevOps linked to a parent.
 - `select-directory`: Triggers Electron's native `dialog.showOpenDialog` to allow user directory selection.
 - `start-story-elaboration`: Spawns a stateful `@github/copilot-sdk` session for the Story Elaborator, configured with ticket details, branch selection, and workspace context. Streams lines via `elaboration-line`.
 - `send-elaboration-answer`: Sends subsequent replies/responses to the ongoing story elaboration session.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -45,7 +45,7 @@ locally on the machine.
   - Pushes AI-generated content as **Comments** (updating `System.History`).
   - Creates new **Tasks** linked to a parent ID via `Hierarchy-Reverse`
     relationships.
-  - Creates new **Product Backlog Items (PBIs)** linked to a Feature ID.
+  - Creates new user stories/work items (e.g. Product Backlog Items) linked to a parent Feature ID using customizable work item type settings.
   - Fetches details of a specific Pull Request (`gitApi.getPullRequestById`) or lists active pull requests for the project (`gitApi.getPullRequestsByProject`).
   - Fetches work item references linked to a Pull Request (`gitApi.getPullRequestWorkItemRefs`) to attach user stories as additional code review context.
   - Posts code review findings (both general and line-specific comments) to the PR as new active comment threads (`gitApi.createThread`) targeting precise file paths and line offsets with an AI disclaimer.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -193,6 +193,14 @@ ipcMain.handle('search-tickets', async (event, query, type) => {
 });
 
 ipcMain.handle(
+  'get-azure-work-item-types',
+  async (event, org, pat, project) => {
+    const service = new AzureDevOpsService(org, pat);
+    return service.getWorkItemTypes(project);
+  },
+);
+
+ipcMain.handle(
   'generate-test-cases',
   async (event, ticketData, additionalContext, modelOverride) => {
     const settings = await getDecryptedSettings();

--- a/src/main/infrastructure/__tests__/settingsSecureStorage.test.ts
+++ b/src/main/infrastructure/__tests__/settingsSecureStorage.test.ts
@@ -147,7 +147,7 @@ describe('settingsSecureStorage', () => {
   });
 
   describe('migrateStoredSettings', () => {
-    it('should migrate plain-text secrets in the store if encryption is available', async () => {
+    it('should migrate plain-text secrets in the store and populate version/types if encryption is available', async () => {
       const mockStoreSettings = {
         azureOrg: 'my-org',
         azurePat: 'pat-123',
@@ -166,14 +166,20 @@ describe('settingsSecureStorage', () => {
         azureOrg: 'my-org',
         azurePat: 'secure:v1:bW9ja19lbmNfcGF0LTEyMw==',
         copilotToken: 'secure:v1:already-encrypted',
+        version: 1,
+        featureType: 'Feature',
+        storyType: 'Product Backlog Item',
       });
     });
 
-    it('should do nothing if all secrets are already encrypted', async () => {
+    it('should do nothing if all secrets are already encrypted and version is present', async () => {
       const mockStoreSettings = {
         azureOrg: 'my-org',
         azurePat: 'secure:v1:abc',
         copilotToken: 'secure:v1:xyz',
+        version: 1,
+        featureType: 'Feature',
+        storyType: 'Product Backlog Item',
       };
 
       const mockStore = {
@@ -185,7 +191,7 @@ describe('settingsSecureStorage', () => {
       expect(mockStore.set).not.toHaveBeenCalled();
     });
 
-    it('should do nothing if encryption is not available', async () => {
+    it('should do nothing (regarding encryption) if encryption is not available, but should still migrate version if missing', async () => {
       mockSafeStorage.isEncryptionAvailable.mockReturnValue(false);
       const mockStoreSettings = {
         azureOrg: 'my-org',
@@ -198,7 +204,69 @@ describe('settingsSecureStorage', () => {
       };
 
       await migrateStoredSettings(mockStore);
+      expect(mockStore.set).toHaveBeenCalledWith('settings', {
+        azureOrg: 'my-org',
+        azurePat: 'pat-123',
+        version: 1,
+        featureType: 'Feature',
+        storyType: 'Product Backlog Item',
+      });
+    });
+
+    it('should do nothing if no settings exist in the store', async () => {
+      const mockStore = {
+        get: vi.fn().mockReturnValue(undefined),
+        set: vi.fn(),
+      };
+
+      await migrateStoredSettings(mockStore);
       expect(mockStore.set).not.toHaveBeenCalled();
+    });
+
+    it('should migrate settings and populate version and default types if version is missing', async () => {
+      const mockStoreSettings = {
+        azureOrg: 'my-org',
+        azurePat: 'secure:v1:abc',
+      };
+
+      const mockStore = {
+        get: vi.fn().mockReturnValue(mockStoreSettings),
+        set: vi.fn(),
+      };
+
+      await migrateStoredSettings(mockStore);
+
+      expect(mockStore.set).toHaveBeenCalledWith('settings', {
+        azureOrg: 'my-org',
+        azurePat: 'secure:v1:abc',
+        version: 1,
+        featureType: 'Feature',
+        storyType: 'Product Backlog Item',
+      });
+    });
+
+    it('should not overwrite existing custom work item types during migration', async () => {
+      const mockStoreSettings = {
+        azureOrg: 'my-org',
+        azurePat: 'secure:v1:abc',
+        featureType: 'CustomFeature',
+        storyType: 'CustomStory',
+      };
+
+      const mockStore = {
+        get: vi.fn().mockReturnValue(mockStoreSettings),
+        set: vi.fn(),
+      };
+
+      await migrateStoredSettings(mockStore);
+
+      expect(mockStore.set).toHaveBeenCalledWith('settings', {
+        azureOrg: 'my-org',
+        azurePat: 'secure:v1:abc',
+        version: 1,
+        featureType: 'CustomFeature',
+        storyType: 'CustomStory',
+      });
     });
   });
 });

--- a/src/main/infrastructure/__tests__/settingsSecureStorage.test.ts
+++ b/src/main/infrastructure/__tests__/settingsSecureStorage.test.ts
@@ -169,6 +169,8 @@ describe('settingsSecureStorage', () => {
         version: 1,
         featureType: 'Feature',
         storyType: 'Product Backlog Item',
+        taskType: 'Task',
+        testTaskTitle: 'Testing',
       });
     });
 
@@ -180,6 +182,8 @@ describe('settingsSecureStorage', () => {
         version: 1,
         featureType: 'Feature',
         storyType: 'Product Backlog Item',
+        taskType: 'Task',
+        testTaskTitle: 'Testing',
       };
 
       const mockStore = {
@@ -210,6 +214,8 @@ describe('settingsSecureStorage', () => {
         version: 1,
         featureType: 'Feature',
         storyType: 'Product Backlog Item',
+        taskType: 'Task',
+        testTaskTitle: 'Testing',
       });
     });
 
@@ -242,6 +248,8 @@ describe('settingsSecureStorage', () => {
         version: 1,
         featureType: 'Feature',
         storyType: 'Product Backlog Item',
+        taskType: 'Task',
+        testTaskTitle: 'Testing',
       });
     });
 
@@ -251,6 +259,8 @@ describe('settingsSecureStorage', () => {
         azurePat: 'secure:v1:abc',
         featureType: 'CustomFeature',
         storyType: 'CustomStory',
+        taskType: 'CustomTask',
+        testTaskTitle: 'CustomTesting',
       };
 
       const mockStore = {
@@ -266,6 +276,8 @@ describe('settingsSecureStorage', () => {
         version: 1,
         featureType: 'CustomFeature',
         storyType: 'CustomStory',
+        taskType: 'CustomTask',
+        testTaskTitle: 'CustomTesting',
       });
     });
   });

--- a/src/main/infrastructure/azure/__tests__/azureDevOpsService.test.ts
+++ b/src/main/infrastructure/azure/__tests__/azureDevOpsService.test.ts
@@ -7,6 +7,7 @@ const mockWitApi = {
   createWorkItem: vi.fn(),
   queryByWiql: vi.fn(),
   getWorkItems: vi.fn(),
+  getWorkItemTypes: vi.fn(),
 };
 
 function mockWebApiFunction() {
@@ -353,6 +354,30 @@ describe('AzureDevOpsService', () => {
 
       const resultWithoutMatch = await service.searchTickets('456', 'Feature');
       expect(resultWithoutMatch.length).toBe(0);
+    });
+  });
+
+  describe('getWorkItemTypes', () => {
+    it('should retrieve work item types and map names correctly', async () => {
+      mockWitApi.getWorkItemTypes.mockResolvedValueOnce([
+        { name: 'Feature' },
+        { name: 'Product Backlog Item' },
+        { name: 'Bug' },
+      ]);
+
+      const result = await service.getWorkItemTypes('MyProject');
+
+      expect(mockWitApi.getWorkItemTypes).toHaveBeenCalledWith('MyProject');
+      expect(result).toEqual(['Feature', 'Product Backlog Item', 'Bug']);
+    });
+
+    it('should throw error when API call fails', async () => {
+      const apiError = new Error('WIT API error');
+      mockWitApi.getWorkItemTypes.mockRejectedValueOnce(apiError);
+
+      await expect(service.getWorkItemTypes('MyProject')).rejects.toThrow(
+        'WIT API error',
+      );
     });
   });
 });

--- a/src/main/infrastructure/azure/azureDevOpsService.ts
+++ b/src/main/infrastructure/azure/azureDevOpsService.ts
@@ -201,4 +201,17 @@ export class AzureDevOpsService implements IssueTrackerProvider {
       throw error;
     }
   }
+
+  async getWorkItemTypes(project: string): Promise<string[]> {
+    const witApi = await this.getApi();
+    try {
+      const types = await witApi.getWorkItemTypes(project);
+      return (types || [])
+        .map((t) => t.name)
+        .filter((name): name is string => typeof name === 'string');
+    } catch (error) {
+      console.error('Error fetching work item types:', error);
+      throw error;
+    }
+  }
 }

--- a/src/main/infrastructure/providers/IssueTrackerProvider.ts
+++ b/src/main/infrastructure/providers/IssueTrackerProvider.ts
@@ -9,4 +9,5 @@ export interface IssueTrackerProvider {
     data: TicketData,
   ): Promise<void>;
   searchTickets(query: string, type?: string): Promise<TicketData[]>;
+  getWorkItemTypes?(project: string): Promise<string[]>;
 }

--- a/src/main/infrastructure/settingsSecureStorage.ts
+++ b/src/main/infrastructure/settingsSecureStorage.ts
@@ -120,6 +120,18 @@ export async function migrateStoredSettings(store: {
     }
   }
 
+  // Version 1 Migration: populate featureType and storyType defaults if missing
+  if (updatedSettings.version === undefined || updatedSettings.version < 1) {
+    updatedSettings.version = 1;
+    if (updatedSettings.featureType === undefined) {
+      updatedSettings.featureType = 'Feature';
+    }
+    if (updatedSettings.storyType === undefined) {
+      updatedSettings.storyType = 'Product Backlog Item';
+    }
+    needsWrite = true;
+  }
+
   if (needsWrite) {
     store.set('settings', updatedSettings);
   }

--- a/src/main/infrastructure/settingsSecureStorage.ts
+++ b/src/main/infrastructure/settingsSecureStorage.ts
@@ -129,6 +129,12 @@ export async function migrateStoredSettings(store: {
     if (updatedSettings.storyType === undefined) {
       updatedSettings.storyType = 'Product Backlog Item';
     }
+    if (updatedSettings.taskType === undefined) {
+      updatedSettings.taskType = 'Task';
+    }
+    if (updatedSettings.testTaskTitle === undefined) {
+      updatedSettings.testTaskTitle = 'Testing';
+    }
     needsWrite = true;
   }
 

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -15,6 +15,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   fetchTicket: (id: string) => ipcRenderer.invoke('fetch-ticket', id),
   searchTickets: (query: string, type?: string) =>
     ipcRenderer.invoke('search-tickets', query, type),
+  getAzureWorkItemTypes: (org: string, pat: string, project: string) =>
+    ipcRenderer.invoke('get-azure-work-item-types', org, pat, project),
   generateTestCases: (
     ticketData: TicketData,
     context: string,

--- a/src/renderer/features/settings/components/AzureSettings.tsx
+++ b/src/renderer/features/settings/components/AzureSettings.tsx
@@ -11,6 +11,10 @@ interface AzureSettingsProps {
   setFeatureType: (val: string) => void;
   storyType: string;
   setStoryType: (val: string) => void;
+  taskType: string;
+  setTaskType: (val: string) => void;
+  testTaskTitle: string;
+  setTestTaskTitle: (val: string) => void;
 }
 
 const AzureSettings: React.FC<AzureSettingsProps> = ({
@@ -24,6 +28,10 @@ const AzureSettings: React.FC<AzureSettingsProps> = ({
   setFeatureType,
   storyType,
   setStoryType,
+  taskType,
+  setTaskType,
+  testTaskTitle,
+  setTestTaskTitle,
 }) => {
   const [workItemTypes, setWorkItemTypes] = useState<string[]>([]);
   const [isLoadingTypes, setIsLoadingTypes] = useState(false);
@@ -221,6 +229,53 @@ const AzureSettings: React.FC<AzureSettingsProps> = ({
               <div className="form-text">
                 Work item type used for Stories. Default is `Product Backlog
                 Item`.
+              </div>
+            </div>
+
+            <div className="col-md-6 mb-3">
+              <label className="form-label fw-semibold">
+                Task Work Item Type
+              </label>
+              {workItemTypes.length > 0 ? (
+                <select
+                  className="form-select"
+                  value={taskType}
+                  onChange={(e) => setTaskType(e.target.value)}
+                >
+                  {!workItemTypes.includes(taskType) && (
+                    <option value={taskType}>{taskType} (custom)</option>
+                  )}
+                  {workItemTypes.map((type) => (
+                    <option key={type} value={type}>
+                      {type}
+                    </option>
+                  ))}
+                </select>
+              ) : (
+                <input
+                  type="text"
+                  className="form-control"
+                  placeholder="Task"
+                  value={taskType}
+                  onChange={(e) => setTaskType(e.target.value)}
+                />
+              )}
+              <div className="form-text">
+                Work item type used for Tasks. Default is `Task`.
+              </div>
+            </div>
+
+            <div className="col-md-6 mb-3">
+              <label className="form-label fw-semibold">Test Task Title</label>
+              <input
+                type="text"
+                className="form-control"
+                placeholder="Testing"
+                value={testTaskTitle}
+                onChange={(e) => setTestTaskTitle(e.target.value)}
+              />
+              <div className="form-text">
+                Title template for testing tasks. Default is `Testing`.
               </div>
             </div>
           </div>

--- a/src/renderer/features/settings/components/AzureSettings.tsx
+++ b/src/renderer/features/settings/components/AzureSettings.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 
 interface AzureSettingsProps {
   azureOrg: string;
@@ -7,6 +7,10 @@ interface AzureSettingsProps {
   setAzureProject: (val: string) => void;
   azurePat: string;
   setAzurePat: (val: string) => void;
+  featureType: string;
+  setFeatureType: (val: string) => void;
+  storyType: string;
+  setStoryType: (val: string) => void;
 }
 
 const AzureSettings: React.FC<AzureSettingsProps> = ({
@@ -16,7 +20,49 @@ const AzureSettings: React.FC<AzureSettingsProps> = ({
   setAzureProject,
   azurePat,
   setAzurePat,
+  featureType,
+  setFeatureType,
+  storyType,
+  setStoryType,
 }) => {
+  const [workItemTypes, setWorkItemTypes] = useState<string[]>([]);
+  const [isLoadingTypes, setIsLoadingTypes] = useState(false);
+  const [fetchError, setFetchError] = useState('');
+
+  const fetchWorkItemTypes = async () => {
+    if (!azureOrg || !azurePat || !azureProject) {
+      setFetchError(
+        'Organization URL, Project Name, and PAT are required to fetch work item types.',
+      );
+      return;
+    }
+    setIsLoadingTypes(true);
+    setFetchError('');
+    try {
+      const types = await window.electronAPI.getAzureWorkItemTypes(
+        azureOrg,
+        azurePat,
+        azureProject,
+      );
+      setWorkItemTypes(types);
+    } catch (err) {
+      console.error(err);
+      const errMsg =
+        err instanceof Error
+          ? err.message
+          : 'Failed to fetch work item types. Please check your credentials and project name.';
+      setFetchError(errMsg);
+    } finally {
+      setIsLoadingTypes(false);
+    }
+  };
+
+  useEffect(() => {
+    if (azureOrg && azurePat && azureProject) {
+      fetchWorkItemTypes();
+    }
+  }, []);
+
   return (
     <div className="card shadow-sm border-0 bg-body-tertiary">
       <div className="card-body p-4">
@@ -72,6 +118,111 @@ const AzureSettings: React.FC<AzureSettingsProps> = ({
           />
           <div className="form-text">
             Ensure your PAT has read and write access scope for work items.
+          </div>
+        </div>
+
+        <div className="mb-4 mt-4 border-top pt-3">
+          <div className="d-flex justify-content-between align-items-center mb-3">
+            <h6 className="fw-bold mb-0">Work Item Types</h6>
+            <button
+              type="button"
+              className="btn btn-outline-primary btn-sm"
+              onClick={fetchWorkItemTypes}
+              disabled={
+                isLoadingTypes || !azureOrg || !azurePat || !azureProject
+              }
+            >
+              {isLoadingTypes ? (
+                <>
+                  <span
+                    className="spinner-border spinner-border-sm me-2"
+                    role="status"
+                    aria-hidden="true"
+                  ></span>
+                  Fetching...
+                </>
+              ) : (
+                <>
+                  <i className="fas fa-sync-alt me-2"></i>
+                  Fetch Types
+                </>
+              )}
+            </button>
+          </div>
+
+          {fetchError && (
+            <div className="alert alert-warning py-2 px-3 small">
+              {fetchError}
+            </div>
+          )}
+
+          <div className="row">
+            <div className="col-md-6 mb-3">
+              <label className="form-label fw-semibold">
+                Feature Work Item Type
+              </label>
+              {workItemTypes.length > 0 ? (
+                <select
+                  className="form-select"
+                  value={featureType}
+                  onChange={(e) => setFeatureType(e.target.value)}
+                >
+                  {!workItemTypes.includes(featureType) && (
+                    <option value={featureType}>{featureType} (custom)</option>
+                  )}
+                  {workItemTypes.map((type) => (
+                    <option key={type} value={type}>
+                      {type}
+                    </option>
+                  ))}
+                </select>
+              ) : (
+                <input
+                  type="text"
+                  className="form-control"
+                  placeholder="Feature"
+                  value={featureType}
+                  onChange={(e) => setFeatureType(e.target.value)}
+                />
+              )}
+              <div className="form-text">
+                Work item type used for Features. Default is `Feature`.
+              </div>
+            </div>
+
+            <div className="col-md-6 mb-3">
+              <label className="form-label fw-semibold">
+                Story Work Item Type
+              </label>
+              {workItemTypes.length > 0 ? (
+                <select
+                  className="form-select"
+                  value={storyType}
+                  onChange={(e) => setStoryType(e.target.value)}
+                >
+                  {!workItemTypes.includes(storyType) && (
+                    <option value={storyType}>{storyType} (custom)</option>
+                  )}
+                  {workItemTypes.map((type) => (
+                    <option key={type} value={type}>
+                      {type}
+                    </option>
+                  ))}
+                </select>
+              ) : (
+                <input
+                  type="text"
+                  className="form-control"
+                  placeholder="Product Backlog Item"
+                  value={storyType}
+                  onChange={(e) => setStoryType(e.target.value)}
+                />
+              )}
+              <div className="form-text">
+                Work item type used for Stories. Default is `Product Backlog
+                Item`.
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/src/renderer/features/settings/components/Settings.tsx
+++ b/src/renderer/features/settings/components/Settings.tsx
@@ -13,6 +13,8 @@ const Settings: React.FC = () => {
   const [version, setVersion] = useState<number>(1);
   const [featureType, setFeatureType] = useState('Feature');
   const [storyType, setStoryType] = useState('Product Backlog Item');
+  const [taskType, setTaskType] = useState('Task');
+  const [testTaskTitle, setTestTaskTitle] = useState('Testing');
   const [azureOrg, setAzureOrg] = useState('');
   const [azureProject, setAzureProject] = useState('');
   const [azurePat, setAzurePat] = useState('');
@@ -64,6 +66,8 @@ const Settings: React.FC = () => {
           setVersion(settings.version || 1);
           setFeatureType(settings.featureType || 'Feature');
           setStoryType(settings.storyType || 'Product Backlog Item');
+          setTaskType(settings.taskType || 'Task');
+          setTestTaskTitle(settings.testTaskTitle || 'Testing');
           setAzureOrg(settings.azureOrg || '');
           setAzureProject(settings.azureProject || '');
           setAzurePat(settings.azurePat || '');
@@ -120,6 +124,8 @@ const Settings: React.FC = () => {
         version: version,
         featureType: featureType,
         storyType: storyType,
+        taskType: taskType,
+        testTaskTitle: testTaskTitle,
         azureOrg: azureOrg,
         azureProject: azureProject,
         azurePat: azurePat,
@@ -212,6 +218,10 @@ const Settings: React.FC = () => {
             setFeatureType={setFeatureType}
             storyType={storyType}
             setStoryType={setStoryType}
+            taskType={taskType}
+            setTaskType={setTaskType}
+            testTaskTitle={testTaskTitle}
+            setTestTaskTitle={setTestTaskTitle}
           />
         );
       case 'confluence':

--- a/src/renderer/features/settings/components/Settings.tsx
+++ b/src/renderer/features/settings/components/Settings.tsx
@@ -10,6 +10,9 @@ import CopilotSettings from './CopilotSettings';
 import PromptSettings from './PromptSettings';
 
 const Settings: React.FC = () => {
+  const [version, setVersion] = useState<number>(1);
+  const [featureType, setFeatureType] = useState('Feature');
+  const [storyType, setStoryType] = useState('Product Backlog Item');
   const [azureOrg, setAzureOrg] = useState('');
   const [azureProject, setAzureProject] = useState('');
   const [azurePat, setAzurePat] = useState('');
@@ -58,6 +61,9 @@ const Settings: React.FC = () => {
 
         const settings = await window.electronAPI.getSettings();
         if (settings) {
+          setVersion(settings.version || 1);
+          setFeatureType(settings.featureType || 'Feature');
+          setStoryType(settings.storyType || 'Product Backlog Item');
           setAzureOrg(settings.azureOrg || '');
           setAzureProject(settings.azureProject || '');
           setAzurePat(settings.azurePat || '');
@@ -111,6 +117,9 @@ const Settings: React.FC = () => {
     e.preventDefault();
     try {
       await window.electronAPI.saveSettings({
+        version: version,
+        featureType: featureType,
+        storyType: storyType,
         azureOrg: azureOrg,
         azureProject: azureProject,
         azurePat: azurePat,
@@ -199,6 +208,10 @@ const Settings: React.FC = () => {
             setAzureProject={setAzureProject}
             azurePat={azurePat}
             setAzurePat={setAzurePat}
+            featureType={featureType}
+            setFeatureType={setFeatureType}
+            storyType={storyType}
+            setStoryType={setStoryType}
           />
         );
       case 'confluence':

--- a/src/renderer/features/story-writer/StoryWriter.tsx
+++ b/src/renderer/features/story-writer/StoryWriter.tsx
@@ -766,7 +766,7 @@ const StoryWriter: React.FC = () => {
                               ) : (
                                 <>
                                   <i className="fas fa-plus me-1"></i>
-                                  Create PBI
+                                  Create Story
                                 </>
                               )}
                             </button>

--- a/src/renderer/features/story-writer/StoryWriter.tsx
+++ b/src/renderer/features/story-writer/StoryWriter.tsx
@@ -17,6 +17,28 @@ interface Story {
 const StoryWriter: React.FC = () => {
   const { showTimeout } = useTimeoutModal();
   const isMountedRef = useRef(true);
+  const [featureType, setFeatureType] = useState('Feature');
+  const [storyType, setStoryType] = useState('Product Backlog Item');
+
+  useEffect(() => {
+    const fetchSettings = async () => {
+      try {
+        const settings = await window.electronAPI.getSettings();
+        if (settings) {
+          if (settings.featureType) {
+            setFeatureType(settings.featureType);
+          }
+          if (settings.storyType) {
+            setStoryType(settings.storyType);
+          }
+        }
+      } catch (err) {
+        console.error('Failed to load settings in StoryWriter:', err);
+      }
+    };
+    fetchSettings();
+  }, []);
+
   const [pageId, setPageId] = useState('');
   const [searchQuery, setSearchQuery] = useState('');
   const [searchResults, setSearchResults] = useState<DocPageData[]>([]);
@@ -98,7 +120,7 @@ const StoryWriter: React.FC = () => {
       try {
         const results = await window.electronAPI.searchTickets(
           featureSearchQuery,
-          'Feature',
+          featureType,
         );
         setFeatureSearchResults(results);
       } catch (err) {
@@ -239,7 +261,7 @@ const StoryWriter: React.FC = () => {
         '> Like any AI generated content, mistakes and hallucinations can occur. Please review before relying on it.',
       ].join('\n');
 
-      await window.electronAPI.createTicket('Product Backlog Item', featureId, {
+      await window.electronAPI.createTicket(storyType, featureId, {
         title: story.title,
         description: descriptionWithDisclaimer,
         acceptanceCriteria: story.acceptanceCriteria,

--- a/src/renderer/features/test-case-writer/TestCaseWriter.tsx
+++ b/src/renderer/features/test-case-writer/TestCaseWriter.tsx
@@ -59,6 +59,28 @@ const convertToMarkdownTable = (tcList: TestCase[]): string => {
 const TestCaseWriter: React.FC = () => {
   const { showTimeout } = useTimeoutModal();
   const isMountedRef = useRef(true);
+  const [taskType, setTaskType] = useState('Task');
+  const [testTaskTitle, setTestTaskTitle] = useState('Testing');
+
+  useEffect(() => {
+    const fetchSettings = async () => {
+      try {
+        const settings = await window.electronAPI.getSettings();
+        if (settings) {
+          if (settings.taskType) {
+            setTaskType(settings.taskType);
+          }
+          if (settings.testTaskTitle) {
+            setTestTaskTitle(settings.testTaskTitle);
+          }
+        }
+      } catch (err) {
+        console.error('Failed to load settings in TestCaseWriter:', err);
+      }
+    };
+    fetchSettings();
+  }, []);
+
   const [ticketId, setTicketId] = useState('');
   const [searchQuery, setSearchQuery] = useState('');
   const [searchResults, setSearchResults] = useState<TicketData[]>([]);
@@ -165,8 +187,8 @@ const TestCaseWriter: React.FC = () => {
     try {
       const mdTable = convertToMarkdownTable(testCasesList);
       const text = generateTicketOrCommentText(mdTable);
-      await window.electronAPI.createTicket('Task', ticketId, {
-        title: 'BA Test',
+      await window.electronAPI.createTicket(taskType, ticketId, {
+        title: testTaskTitle,
         description: text,
       });
       alert('Task created successfully!');

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -16,6 +16,11 @@ export interface IElectronAPI {
   saveSettings: (settings: AppSettings) => Promise<void>;
   fetchTicket: (id: string) => Promise<TicketData>;
   searchTickets: (query: string, type?: string) => Promise<TicketData[]>;
+  getAzureWorkItemTypes: (
+    org: string,
+    pat: string,
+    project: string,
+  ) => Promise<string[]>;
   generateTestCases: (
     ticketData: TicketData,
     context: string,

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,8 @@ export type AppSettings = {
   version?: number;
   featureType?: string;
   storyType?: string;
+  taskType?: string;
+  testTaskTitle?: string;
   azureOrg?: string;
   azureProject?: string;
   azurePat?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,7 @@
 export type AppSettings = {
+  version?: number;
+  featureType?: string;
+  storyType?: string;
   azureOrg?: string;
   azureProject?: string;
   azurePat?: string;


### PR DESCRIPTION
Previously, the Azure DevOps integration assumed users were using the **Scrum** project process. So it tried to use mappings based on that;

- **Grouping:** `Feature`
- **Individual Item:** `Product Backlog Item`
- **Task:** `Task` (for attaching the table of Test Cases if you choose to create a task rather than a comment)

The problem is that this is just one standard process in Azure DevOps, and processes are extendable, so users can use other work item types (like `User Story`) or completely define their own process with their own work item types.

This PR adds support for defining the work item types to use for "Features" and "Stories" within the app, so Stitch will use the process you use, and won't fail when it tries to filter by or create a ticket with a specific work item type.

Once the connection is configured, the user can select from a dropdown the mapping to the type within the project.

In addition to the Task type, this PR also allows the user to configure the title we use when creating the testing task, rather than always using "Testing".