### PR TITLE
Misc UI fixes

### DIFF
--- a/src/renderer/features/pr-reviewer/PRReviewer.tsx
+++ b/src/renderer/features/pr-reviewer/PRReviewer.tsx
@@ -533,11 +533,11 @@ const PRReviewer: React.FC = () => {
                 <div className="d-flex align-items-center flex-wrap gap-3">
                   <div className="text-muted small">
                     <strong>Branches:</strong>{' '}
-                    <span className="font-monospace bg-light px-2 py-1 rounded">
+                    <span className="font-monospace bg-body-secondary text-body px-2 py-1 rounded border">
                       {selectedPR.sourceBranch}
                     </span>{' '}
                     &rarr;{' '}
-                    <span className="font-monospace bg-light px-2 py-1 rounded">
+                    <span className="font-monospace bg-body-secondary text-body px-2 py-1 rounded border">
                       {selectedPR.targetBranch}
                     </span>
                   </div>

--- a/src/renderer/features/settings/components/GeneralSettings.tsx
+++ b/src/renderer/features/settings/components/GeneralSettings.tsx
@@ -106,7 +106,7 @@ const GeneralSettings: React.FC<GeneralSettingsProps> = ({
             </label>
             <p className="text-muted small mb-3">
               Choose how Stitch appears. Selecting "Auto" will sync with your
-              macOS system theme settings.
+              system theme settings.
             </p>
             <div
               className="btn-group"


### PR DESCRIPTION
- Remove the hardcoded "macOS" in the settings page to be more platform independent
- Replace the background of the branches from `bg-light` to a bootstrap background which follows the colour theme