### PR TITLE
chore: upgrade typescript to 6.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "prettier": "^3.9.5",
         "style-loader": "^4.0.0",
         "ts-loader": "^9.6.2",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "vitest": "^4.1.10"
       }
     },
@@ -3225,9 +3225,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3245,9 +3242,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3265,9 +3259,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3285,9 +3276,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3305,9 +3293,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3325,9 +3310,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11164,9 +11146,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -11188,9 +11167,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -11212,9 +11188,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -11236,9 +11209,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -17321,9 +17291,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "prettier": "^3.9.5",
     "style-loader": "^4.0.0",
     "ts-loader": "^9.6.2",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.10"
   },
   "dependencies": {

--- a/src/main/infrastructure/copilot/copilotDetector.ts
+++ b/src/main/infrastructure/copilot/copilotDetector.ts
@@ -276,7 +276,7 @@ export async function checkEnvironment(): Promise<EnvironmentCheckResult> {
       nodeVersion: nodeResult.nodeVersion,
       minRequiredVersion: MIN_NODE_VERSION,
       errorType: copilotResult.errorType,
-      message: copilotResult.message,
+      message: copilotResult.message ?? null,
       requiredCopilotVersion: copilotResult.requiredVersion,
       installedCopilotVersion: copilotResult.installedVersion,
     };
@@ -324,9 +324,11 @@ export function getCopilotScriptPath(): string | null {
       const fallbackDir = path.join(dir, '@github', 'copilot');
       if (fs.existsSync(fallbackDir)) {
         const pkgInfo = getCopilotPackageInfo(fallbackDir);
-        const fallbackCandidate = path.join(fallbackDir, pkgInfo.binScript);
-        if (fs.existsSync(fallbackCandidate)) {
-          return fallbackCandidate;
+        if (pkgInfo) {
+          const fallbackCandidate = path.join(fallbackDir, pkgInfo.binScript);
+          if (fs.existsSync(fallbackCandidate)) {
+            return fallbackCandidate;
+          }
         }
       }
       const parent = path.dirname(dir);

--- a/src/renderer/css.d.ts
+++ b/src/renderer/css.d.ts
@@ -1,0 +1,1 @@
+declare module '*.css';

--- a/src/renderer/features/settings/components/Settings.tsx
+++ b/src/renderer/features/settings/components/Settings.tsx
@@ -194,7 +194,8 @@ const Settings: React.FC = () => {
       const res = await window.electronAPI.checkCopilotAuth();
       setAuthStatus(res);
     } catch (error) {
-      setAuthStatus({ error: error.message || 'Unknown error' });
+      const errMsg = error instanceof Error ? error.message : String(error);
+      setAuthStatus({ error: errMsg });
     } finally {
       setCheckingAuth(false);
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "ignoreDeprecations": "6.0",
+    "rootDir": "src",
     "target": "ES6",
     "allowJs": true,
     "module": "commonjs",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "ignoreDeprecations": "6.0",
     "rootDir": "src",
     "target": "ES6",
     "allowJs": true,
@@ -9,14 +8,10 @@
     "esModuleInterop": true,
     "noImplicitAny": true,
     "sourceMap": true,
-    "baseUrl": ".",
     "outDir": "dist",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
-    "jsx": "react-jsx",
-    "paths": {
-      "*": ["node_modules/*"]
-    }
+    "jsx": "react-jsx"
   },
   "include": ["src/**/*"],
   "exclude": ["src/**/__tests__/*"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES6",
     "allowJs": true,
     "module": "commonjs",


### PR DESCRIPTION
Upgrade from TypeScript v5.9.3 to v6.0.3, resolve build issues, and prepare to upgrade to v7.x