### PR TITLE
refactor: decouple PR reviewer service from Azure DevOps

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -39,10 +39,10 @@ locally on the machine.
 ### Azure DevOps
 
 - **Library:** `azure-devops-node-api`
-- **Method:** Uses Personal Access Tokens (PAT) via the Work Item Tracking API.
+- **Method:** Uses Personal Access Tokens (PAT) via the Work Item Tracking API (for work items) and Git API (for pull requests via `CodeReviewProvider`).
 - **Scope:**
   - Fetches work item details (ID, Title, Description, Acceptance Criteria) and supports real-time text-based and ID-based work item searching using WIQL and exact-match prioritization.
-  - Pushes AI-generated content as **Comments** (updating `System.History`).
+  - Pushes AI-generated content as **Comments** (updating `System.History`) and manages pull request review threads.
   - Creates new **Tasks** linked to a parent ID via `Hierarchy-Reverse`
     relationships.
   - Creates new user stories/work items (e.g. Product Backlog Items) linked to a parent Feature ID using customizable work item type settings.
@@ -114,7 +114,7 @@ To prevent tool-specific logic, UI files, prompts, and backend coordination from
 
 1. **Symmetrical Feature Slices**: Feature directories under `src/main/features/` and `src/renderer/features/` encapsulate domain-specific code (e.g. `story-writer`, `test-case-writer`, `story-elaborator`, `pr-reviewer`, `settings`, `menu`).
 2. **Containment of Prompts**: Rather than using a single centralized prompt file, prompts are contained inside their respective main process feature slices (e.g., `storyWriterPrompts.ts`). The prompt validation logic (`checkPromptComplexity`) is centralized inside the `settings` feature slice (`promptComplexityService.ts`) which imports prompt templates from the individual slices to validate complexity.
-3. **Decoupled Infrastructure**: Shared, low-level integration services (like `AzureDevOpsService`, `ConfluenceService`, and `CopilotService` connection lifecycle management) reside inside `src/main/infrastructure/`. Feature services leverage these services via constructor dependency injection, keeping tool logic fully decoupled from infrastructure.
+3. **Decoupled Infrastructure**: Shared, low-level integration services (like `AzureDevOpsService`, `ConfluenceService`, `CodeReviewProvider` implementations, and `CopilotService` connection lifecycle management) reside inside `src/main/infrastructure/`. Feature services leverage these services via constructor dependency injection, keeping tool logic fully decoupled from infrastructure.
 
 ### Hybrid ESM/CommonJS Approach
 
@@ -154,17 +154,17 @@ support modern ESM-only libraries like `electron-store` and
 - `start-story-elaboration`: Spawns a stateful `@github/copilot-sdk` session for the Story Elaborator, configured with ticket details, branch selection, and workspace context. Streams lines via `elaboration-line`.
 - `send-elaboration-answer`: Sends subsequent replies/responses to the ongoing story elaboration session.
 - `stop-story-elaboration`: Cleans up and destroys an active story elaboration session.
-- `pr-reviewer:get-details`: Fetches Azure DevOps PR metadata, target/source branch references, and linked work item references.
+- `pr-reviewer:get-details`: Fetches PR metadata, target/source branch references, and linked work item references via `CodeReviewProvider`.
 - `pr-reviewer:checkout`: Sanitizes repository state, checks out the PR branch (with worktree support if configured), and returns comparison details.
 - `pr-reviewer:get-diff-files`: Lists all modified files in the repository between HEAD and the target branch.
 - `pr-reviewer:get-file-diff`: Retrieves the git diff for a specific file compared to the target branch.
-- `pr-reviewer:search-prs`: Queries Azure DevOps for active PRs matching user search criteria.
+- `pr-reviewer:search-prs`: Queries the code review host for active PRs matching user search criteria.
 - `pr-reviewer:get-phases`: Reads, parses, and sorts frontmatter metadata from review phase files in `~/.stitch/pr-reviewer/phases/`.
 - `pr-reviewer:open-directory`: Opens the local `~/.stitch/pr-reviewer/` configuration folder using the OS shell.
 - `pr-reviewer:check-worktrees`: Scans the configured base directory for active/orphaned git worktrees and returns their status and count.
 - `pr-reviewer:clean-worktrees`: Force-cleans and prunes worktrees and directories in the configured base directory.
 - `get-cpu-count`: Retrieves the CPU cores count from the operating system to establish worker pool boundaries.
 - `pr-reviewer:review`: Triggers a sequential or parallel multi-phase PR review, streaming real-time status and line-anchored code feedback to the UI.
-- `pr-reviewer:post-comment`: Submits a code review comment (general or line-anchored code block thread) back to the Azure DevOps PR.
+- `pr-reviewer:post-comment`: Submits a code review comment (general or line-anchored code block thread) back to the PR via `CodeReviewProvider`.
 - `pr-reviewer:get-repo-path-history` / `pr-reviewer:save-repo-path-history`: Stores the last used local filesystem clone path mapping for a given repository.
 - `pr-reviewer:verify-repo-path`: Asserts if a path represents a git repository, resolving its root directory if necessary.

--- a/src/main/features/pr-reviewer/__tests__/prReviewerService.test.ts
+++ b/src/main/features/pr-reviewer/__tests__/prReviewerService.test.ts
@@ -10,33 +10,14 @@ import {
   buildPhaseReviewPrompt,
 } from '../prReviewerService';
 
-const mockGetPullRequestById = vi.fn();
-const mockGetPullRequestsByProject = vi.fn();
-const mockCreateThread = vi.fn();
-const mockGetPullRequestWorkItemRefs = vi.fn();
-const mockConnect = vi.fn().mockResolvedValue({
-  authorizedUser: { id: 'mock-user-id' },
-});
-
-const mockGetGitApi = vi.fn().mockResolvedValue({
-  getPullRequestById: mockGetPullRequestById,
-  getPullRequestsByProject: mockGetPullRequestsByProject,
-  createThread: mockCreateThread,
-  getPullRequestWorkItemRefs: mockGetPullRequestWorkItemRefs,
-});
-const mockWebApi = {
-  getGitApi: mockGetGitApi,
-  connect: mockConnect,
+const mockCodeReviewProvider = {
+  parsePRUrl: vi.fn(),
+  parseRemoteUrl: vi.fn(),
+  getPRDetails: vi.fn(),
+  getProjectPRs: vi.fn(),
+  getLinkedTickets: vi.fn(),
+  postPRComment: vi.fn(),
 };
-
-vi.mock('azure-devops-node-api', () => {
-  return {
-    getPersonalAccessTokenHandler: vi.fn(),
-    WebApi: function () {
-      return mockWebApi;
-    },
-  };
-});
 
 const mockPowerSaveBlockerStart = vi.fn().mockReturnValue(42);
 const mockPowerSaveBlockerStop = vi.fn();
@@ -80,84 +61,29 @@ describe('PRReviewerService', () => {
       mockCopilotService,
       async () => null,
       async () => null,
+      async () => mockCodeReviewProvider,
     );
     vi.spyOn(fs, 'mkdirSync').mockImplementation(() => undefined as any);
-    mockGetPullRequestById.mockReset();
-    mockGetPullRequestsByProject.mockReset();
-    mockGetPullRequestWorkItemRefs.mockReset();
-    mockConnect.mockClear();
-    mockGetGitApi.mockClear();
+    mockCodeReviewProvider.parsePRUrl.mockReset();
+    mockCodeReviewProvider.parseRemoteUrl.mockReset();
+    mockCodeReviewProvider.getPRDetails.mockReset().mockResolvedValue({
+      id: '123',
+      title: 'Pr Title',
+      description: 'Pr Description',
+      sourceBranch: 'feature-x',
+      targetBranch: 'main',
+      author: 'John Doe',
+      repositoryName: 'my-repo',
+      repositoryId: 'repo-123',
+      hostType: 'azure',
+      url: 'https://dev.azure.com/mock-org/mock-project/_git/my-repo/pullrequest/123',
+    });
+    mockCodeReviewProvider.getProjectPRs.mockReset();
+    mockCodeReviewProvider.getLinkedTickets.mockReset();
+    mockCodeReviewProvider.postPRComment.mockReset();
     mockPowerSaveBlockerStart.mockClear().mockReturnValue(42);
     mockPowerSaveBlockerStop.mockClear();
     mockPowerSaveBlockerIsStarted.mockClear().mockReturnValue(true);
-  });
-
-  describe('parsePRUrl', () => {
-    it('should parse valid dev.azure.com pullrequest URLs', () => {
-      const result = prReviewerService.parsePRUrl(
-        'https://dev.azure.com/myorg/myproject/_git/myrepo/pullrequest/12345',
-      );
-      expect(result).toEqual({
-        org: 'myorg',
-        project: 'myproject',
-        repoName: 'myrepo',
-        prNumber: 12345,
-      });
-    });
-
-    it('should parse valid visualstudio.com pullrequest URLs', () => {
-      const result = prReviewerService.parsePRUrl(
-        'https://myorg.visualstudio.com/myproject/_git/myrepo/pullrequest/54321',
-      );
-      expect(result).toEqual({
-        org: 'myorg',
-        project: 'myproject',
-        repoName: 'myrepo',
-        prNumber: 54321,
-      });
-    });
-
-    it('should return null for invalid URLs', () => {
-      const result = prReviewerService.parsePRUrl(
-        'https://dev.azure.com/myorg/myproject',
-      );
-      expect(result).toBeNull();
-    });
-  });
-
-  describe('parseRemoteUrl', () => {
-    it('should parse valid HTTPS remote URLs', () => {
-      const result = prReviewerService.parseRemoteUrl(
-        'https://dev.azure.com/myorg/myproject/_git/myrepo',
-      );
-      expect(result).toEqual({
-        org: 'myorg',
-        project: 'myproject',
-        repoName: 'myrepo',
-      });
-    });
-
-    it('should parse valid HTTPS remote URLs with userInfo', () => {
-      const result = prReviewerService.parseRemoteUrl(
-        'https://user@dev.azure.com/myorg/myproject/_git/myrepo',
-      );
-      expect(result).toEqual({
-        org: 'myorg',
-        project: 'myproject',
-        repoName: 'myrepo',
-      });
-    });
-
-    it('should parse SSH remote URLs', () => {
-      const result = prReviewerService.parseRemoteUrl(
-        'git@ssh.dev.azure.com:v3/myorg/myproject/myrepo',
-      );
-      expect(result).toEqual({
-        org: 'myorg',
-        project: 'myproject',
-        repoName: 'myrepo',
-      });
-    });
   });
 
   describe('getPRDetails', () => {
@@ -171,16 +97,21 @@ describe('PRReviewerService', () => {
       },
     };
 
-    it('should fetch PR details successfully using settings when given numeric ID', async () => {
-      mockGetPullRequestById.mockResolvedValue({
-        pullRequestId: 123,
+    it('should fetch PR details successfully delegating to CodeReviewProvider', async () => {
+      mockCodeReviewProvider.getPRDetails.mockResolvedValue({
+        id: '123',
         title: 'Pr Title',
         description: 'Pr Description',
-        sourceRefName: 'refs/heads/feature-x',
-        targetRefName: 'refs/heads/main',
-        createdBy: { displayName: 'John Doe' },
-        repository: { name: 'my-repo' },
+        sourceBranch: 'feature-x',
+        targetBranch: 'main',
+        author: 'John Doe',
+        repositoryName: 'my-repo',
+        hostType: 'azure',
+        url: 'https://dev.azure.com/conf-org/conf-proj/_git/my-repo/pullrequest/123',
       });
+      mockGitService.getRemoteUrl.mockResolvedValue(
+        'https://dev.azure.com/conf-org/conf-proj/_git/my-repo',
+      );
 
       const details = await prReviewerService.getPRDetails(
         '/mock/repo',
@@ -198,37 +129,11 @@ describe('PRReviewerService', () => {
         hostType: 'azure',
         url: 'https://dev.azure.com/conf-org/conf-proj/_git/my-repo/pullrequest/123',
       });
-    });
-
-    it('should parse URL and use its org/project when given a full URL', async () => {
-      mockGetPullRequestById.mockResolvedValue({
-        pullRequestId: 999,
-        title: 'Url PR',
-        description: 'Url Desc',
-        sourceRefName: 'refs/heads/feature-url',
-        targetRefName: 'refs/heads/master',
-        createdBy: { displayName: 'Jane Doe' },
-      });
-
-      const details = await prReviewerService.getPRDetails(
+      expect(mockCodeReviewProvider.getPRDetails).toHaveBeenCalledWith(
         '/mock/repo',
-        'https://dev.azure.com/url-org/url-proj/_git/myrepo/pullrequest/999',
-        settings,
+        '123',
+        'https://dev.azure.com/conf-org/conf-proj/_git/my-repo',
       );
-      expect(details.id).toBe('999');
-      expect(details.sourceBranch).toBe('feature-url');
-      expect(details.targetBranch).toBe('master');
-    });
-
-    it('should throw if target branch ref is missing', async () => {
-      mockGetPullRequestById.mockResolvedValue({
-        pullRequestId: 123,
-        title: 'Pr Title',
-      });
-
-      await expect(
-        prReviewerService.getPRDetails('/mock/repo', '123', settings),
-      ).rejects.toThrow('missing target branch ref');
     });
   });
 
@@ -264,6 +169,11 @@ describe('PRReviewerService', () => {
       mockGitService.getRemoteUrl.mockResolvedValue(
         'https://dev.azure.com/org/proj/_git/mismatched-repo',
       );
+      mockCodeReviewProvider.parseRemoteUrl.mockReturnValue({
+        org: 'org',
+        project: 'proj',
+        repoName: 'mismatched-repo',
+      });
 
       await expect(
         prReviewerService.checkoutAndDiff('/mock/repo', 123, 'expected-repo'),
@@ -312,21 +222,8 @@ describe('PRReviewerService', () => {
       },
     };
 
-    it('should query pull requests for project and return mapped results', async () => {
-      mockGetPullRequestsByProject.mockResolvedValue([
-        {
-          pullRequestId: 444,
-          title: 'My active PR',
-          description: 'PR Description',
-          sourceRefName: 'refs/heads/feature-x',
-          targetRefName: 'refs/heads/main',
-          createdBy: { displayName: 'John Author' },
-          repository: { name: 'my-repo-name' },
-        },
-      ]);
-
-      const result = await prReviewerService.getProjectPRs('all', settings);
-      expect(result).toEqual([
+    it('should query pull requests delegating to CodeReviewProvider', async () => {
+      const mockPRs = [
         {
           id: '444',
           title: 'My active PR',
@@ -338,41 +235,12 @@ describe('PRReviewerService', () => {
           hostType: 'azure',
           url: 'https://dev.azure.com/conf-org/conf-proj/_git/my-repo-name/pullrequest/444',
         },
-      ]);
+      ] as PRMetadata[];
+      mockCodeReviewProvider.getProjectPRs.mockResolvedValue(mockPRs);
 
-      expect(mockGetPullRequestsByProject).toHaveBeenCalledWith('conf-proj', {
-        status: 1,
-      });
-    });
-
-    it('should filter by reviewer if searchType is assigned', async () => {
-      mockConnect.mockResolvedValue({
-        authorizedUser: { id: 'user-guid-123' },
-      });
-      mockGetPullRequestsByProject.mockResolvedValue([]);
-
-      await prReviewerService.getProjectPRs('assigned', settings);
-
-      expect(mockConnect).toHaveBeenCalled();
-      expect(mockGetPullRequestsByProject).toHaveBeenCalledWith('conf-proj', {
-        status: 1,
-        reviewerId: 'user-guid-123',
-      });
-    });
-
-    it('should filter by creator if searchType is created', async () => {
-      mockConnect.mockResolvedValue({
-        authorizedUser: { id: 'user-guid-123' },
-      });
-      mockGetPullRequestsByProject.mockResolvedValue([]);
-
-      await prReviewerService.getProjectPRs('created', settings);
-
-      expect(mockConnect).toHaveBeenCalled();
-      expect(mockGetPullRequestsByProject).toHaveBeenCalledWith('conf-proj', {
-        status: 1,
-        creatorId: 'user-guid-123',
-      });
+      const result = await prReviewerService.getProjectPRs('all', settings);
+      expect(result).toEqual(mockPRs);
+      expect(mockCodeReviewProvider.getProjectPRs).toHaveBeenCalledWith('all');
     });
   });
 
@@ -722,17 +590,6 @@ describe('PRReviewerService', () => {
         '{"type":"general","comment":"Reviewed story"}',
       );
 
-      mockGetPullRequestById.mockResolvedValue({
-        pullRequestId: 123,
-        title: 'Pr Title',
-        description: 'Pr Description',
-        sourceRefName: 'refs/heads/feature-x',
-        targetRefName: 'refs/heads/main',
-        createdBy: { displayName: 'John Doe' },
-        repository: { id: 'repo-123', name: 'my-repo' },
-      });
-      mockGetPullRequestWorkItemRefs.mockResolvedValue([{ id: 'story-123' }]);
-
       const mockIssueTracker = {
         fetchTicket: vi.fn().mockResolvedValue({
           id: 'story-123',
@@ -752,11 +609,14 @@ describe('PRReviewerService', () => {
         }),
       };
 
+      mockCodeReviewProvider.getLinkedTickets.mockResolvedValue(['story-123']);
+
       const customPRReviewerService = new PRReviewerService(
         mockGitService,
         mockCopilotService,
         async () => mockIssueTracker as any,
         async () => mockDocProvider as any,
+        async () => mockCodeReviewProvider as any,
       );
 
       vi.spyOn(customPRReviewerService, 'loadPhasesFromDisk').mockResolvedValue(
@@ -794,9 +654,9 @@ describe('PRReviewerService', () => {
         },
       );
 
-      expect(mockGetPullRequestWorkItemRefs).toHaveBeenCalledWith(
+      expect(mockCodeReviewProvider.getLinkedTickets).toHaveBeenCalledWith(
+        '123',
         'repo-123',
-        123,
       );
       expect(mockIssueTracker.fetchTicket).toHaveBeenCalledWith('story-123');
 
@@ -831,16 +691,7 @@ describe('PRReviewerService', () => {
       const mockFiles = [{ path: 'src/index.ts', status: 'modified' }];
       mockGitService.getDiffFiles.mockResolvedValue(mockFiles);
 
-      mockGetPullRequestById.mockResolvedValue({
-        pullRequestId: 123,
-        title: 'Pr Title',
-        description: 'Pr Description',
-        sourceRefName: 'refs/heads/feature-x',
-        targetRefName: 'refs/heads/main',
-        createdBy: { displayName: 'John Doe' },
-        repository: { id: 'repo-123', name: 'my-repo' },
-      });
-      mockGetPullRequestWorkItemRefs.mockResolvedValue([]);
+      mockCodeReviewProvider.getLinkedTickets.mockResolvedValue([]);
 
       const mockIssueTracker = { fetchTicket: vi.fn() };
       const mockDocProvider = { fetchPage: vi.fn() };
@@ -850,6 +701,7 @@ describe('PRReviewerService', () => {
         mockCopilotService,
         async () => mockIssueTracker as any,
         async () => mockDocProvider as any,
+        async () => mockCodeReviewProvider as any,
       );
 
       vi.spyOn(customPRReviewerService, 'loadPhasesFromDisk').mockResolvedValue(
@@ -956,121 +808,29 @@ describe('PRReviewerService', () => {
       promptComplexity: 'normal',
     };
 
-    it('should successfully post a general comment', async () => {
-      mockGetPullRequestById.mockResolvedValue({
-        repository: { id: 'mock-repo-id' },
-      });
-      mockCreateThread.mockResolvedValue({});
+    it('should successfully post a comment delegating to CodeReviewProvider', async () => {
+      mockCodeReviewProvider.postPRComment.mockResolvedValue(undefined);
+      mockGitService.getRemoteUrl.mockResolvedValue(
+        'https://dev.azure.com/mock-org/mock-project/_git/my-repo',
+      );
+
+      const comment = {
+        type: 'general' as const,
+        comment: 'This is a general comment',
+      };
 
       await prReviewerService.postPRComment(
         '/mock/repo',
         '123',
-        {
-          type: 'general',
-          comment: 'This is a general comment',
-        },
+        comment,
         settings,
       );
 
-      expect(mockGetPullRequestById).toHaveBeenCalledWith(123);
-      expect(mockCreateThread).toHaveBeenCalledWith(
-        {
-          comments: [
-            {
-              parentCommentId: 0,
-              content:
-                'This is a general comment\n' +
-                [
-                  '> Generated with Stitch and GitHub Copilot.',
-                  '> Like any AI generated content, mistakes and hallucinations can occur. Please review before relying on it.',
-                ].join('\n'),
-              commentType: 1,
-            },
-          ],
-          status: 1,
-        },
-        'mock-repo-id',
-        123,
-        'mock-project',
-      );
-    });
-
-    it('should successfully post a line comment with threadContext', async () => {
-      mockGetPullRequestById.mockResolvedValue({
-        repository: { id: 'mock-repo-id' },
-      });
-      mockCreateThread.mockResolvedValue({});
-
-      await prReviewerService.postPRComment(
+      expect(mockCodeReviewProvider.postPRComment).toHaveBeenCalledWith(
         '/mock/repo',
         '123',
-        {
-          type: 'line',
-          file: 'src/index.ts',
-          line: 42,
-          comment: 'Fix this line',
-        },
-        settings,
-      );
-
-      expect(mockGetPullRequestById).toHaveBeenCalledWith(123);
-      expect(mockCreateThread).toHaveBeenCalledWith(
-        {
-          comments: [
-            {
-              parentCommentId: 0,
-              content:
-                'Fix this line\n' +
-                [
-                  '> Generated with Stitch and GitHub Copilot.',
-                  '> Like any AI generated content, mistakes and hallucinations can occur. Please review before relying on it.',
-                ].join('\n'),
-              commentType: 1,
-            },
-          ],
-          status: 1,
-          threadContext: {
-            filePath: '/src/index.ts',
-            rightFileStart: { line: 42, offset: 1 },
-            rightFileEnd: { line: 43, offset: 1 },
-          },
-        },
-        'mock-repo-id',
-        123,
-        'mock-project',
-      );
-    });
-
-    it('should format Windows file paths with backslashes and ensure starting forward slash when posting a line comment', async () => {
-      mockGetPullRequestById.mockResolvedValue({
-        repository: { id: 'mock-repo-id' },
-      });
-      mockCreateThread.mockResolvedValue({});
-
-      await prReviewerService.postPRComment(
-        '/mock/repo',
-        '123',
-        {
-          type: 'line',
-          file: 'PartySystemApi\\src\\PartySystem.Domain\\Migrations\\20260624014055_Update-Table-OrganisationType-RemoveIdentity.cs',
-          line: 10,
-          comment: 'Fix this migration',
-        },
-        settings,
-      );
-
-      expect(mockCreateThread).toHaveBeenCalledWith(
-        expect.objectContaining({
-          threadContext: {
-            filePath:
-              '/PartySystemApi/src/PartySystem.Domain/Migrations/20260624014055_Update-Table-OrganisationType-RemoveIdentity.cs',
-            rightFileStart: { line: 10, offset: 1 },
-            rightFileEnd: { line: 11, offset: 1 },
-          },
-        }),
-        'mock-repo-id',
-        123,
-        'mock-project',
+        comment,
+        'https://dev.azure.com/mock-org/mock-project/_git/my-repo',
       );
     });
   });

--- a/src/main/features/pr-reviewer/prReviewerService.ts
+++ b/src/main/features/pr-reviewer/prReviewerService.ts
@@ -4,12 +4,6 @@ import os from 'os';
 import picomatch from 'picomatch';
 import matter from 'gray-matter';
 import { powerSaveBlocker } from 'electron';
-import * as azdev from 'azure-devops-node-api';
-import { IGitApi } from 'azure-devops-node-api/GitApi';
-import {
-  GitPullRequestSearchCriteria,
-  GitPullRequestCommentThread,
-} from 'azure-devops-node-api/interfaces/GitInterfaces';
 import { GitService } from '../../infrastructure/git/gitService';
 import { CopilotService } from '../../infrastructure/copilot/copilotService';
 import {
@@ -20,6 +14,7 @@ import {
 } from '../../../types';
 import { IssueTrackerProvider } from '../../infrastructure/providers/IssueTrackerProvider';
 import { DocumentationProvider } from '../../infrastructure/providers/DocumentationProvider';
+import { CodeReviewProvider } from '../../infrastructure/providers/CodeReviewProvider';
 import { createRequestDocumentationTool } from '../../infrastructure/copilot/tools/documentationTool';
 
 export function buildPhaseReviewPrompt(
@@ -182,6 +177,7 @@ export class PRReviewerService {
     private copilotService: CopilotService,
     private getIssueTrackerProvider: () => Promise<IssueTrackerProvider | null>,
     private getDocProvider: () => Promise<DocumentationProvider | null>,
+    private getCodeReviewProvider: () => Promise<CodeReviewProvider | null>,
   ) {}
 
   private extractUrls(text: string): string[] {
@@ -346,275 +342,28 @@ export class PRReviewerService {
     }
   }
 
-  parsePRUrl(url: string): {
-    org: string;
-    project: string;
-    repoName: string;
-    prNumber: number;
-  } | null {
-    const trimmed = url.trim();
-
-    // Pattern 1: dev.azure.com
-    // https://dev.azure.com/org/project/_git/repo/pullrequest/123
-    const devAzureRegex =
-      /https:\/\/dev\.azure\.com\/([^/]+)\/([^/]+)\/_git\/([^/]+)\/pullrequest\/(\d+)/i;
-    let match = devAzureRegex.exec(trimmed);
-    if (match) {
-      return {
-        org: match[1],
-        project: match[2],
-        repoName: match[3],
-        prNumber: parseInt(match[4]),
-      };
-    }
-
-    // Pattern 2: visualstudio.com
-    // https://org.visualstudio.com/project/_git/repo/pullrequest/123
-    const vsRegex =
-      /https:\/\/([^/]+)\.visualstudio\.com\/([^/]+)\/_git\/([^/]+)\/pullrequest\/(\d+)/i;
-    match = vsRegex.exec(trimmed);
-    if (match) {
-      return {
-        org: match[1],
-        project: match[2],
-        repoName: match[3],
-        prNumber: parseInt(match[4]),
-      };
-    }
-
-    return null;
-  }
-
-  parseRemoteUrl(url: string): {
-    org: string;
-    project: string;
-    repoName: string;
-  } | null {
-    const trimmed = url.trim();
-
-    // Pattern 1: HTTPS dev.azure.com
-    // https://dev.azure.com/org/project/_git/repo
-    // or https://user@dev.azure.com/org/project/_git/repo
-    const httpsRegex =
-      /https:\/\/(?:[^/]+@)?dev\.azure\.com\/([^/]+)\/([^/]+)\/_git\/([^/.]+)/i;
-    let match = httpsRegex.exec(trimmed);
-    if (match) {
-      return {
-        org: match[1],
-        project: match[2],
-        repoName: match[3],
-      };
-    }
-
-    // Pattern 2: SSH dev.azure.com
-    // git@ssh.dev.azure.com:v3/org/project/repo
-    const sshRegex = /git@ssh\.dev\.azure\.com:v3\/([^/]+)\/([^/]+)\/([^/.]+)/i;
-    match = sshRegex.exec(trimmed);
-    if (match) {
-      return {
-        org: match[1],
-        project: match[2],
-        repoName: match[3],
-      };
-    }
-
-    // Pattern 3: Legacy HTTPS visualstudio.com
-    // https://org.visualstudio.com/project/_git/repo
-    const vsRegex =
-      /https:\/\/([^/]+)\.visualstudio\.com\/([^/]+)\/_git\/([^/.]+)/i;
-    match = vsRegex.exec(trimmed);
-    if (match) {
-      return {
-        org: match[1],
-        project: match[2],
-        repoName: match[3],
-      };
-    }
-
-    return null;
-  }
-
-  private getOrgUrl(org: string): string {
-    if (org.startsWith('http://') || org.startsWith('https://')) {
-      return org;
-    }
-    return `https://dev.azure.com/${org}`;
-  }
-
   async getPRDetails(
     repoPath: string,
     prUrlOrId: string,
-    settings: AppSettings,
+    _settings: AppSettings,
   ): Promise<PRMetadata> {
-    let prNumber = parseInt(prUrlOrId);
-    const azureConn = settings.connectors?.azureDevOps;
-    let org = azureConn?.org || '';
-    let project = azureConn?.project || '';
-
-    const parsedUrl = this.parsePRUrl(prUrlOrId);
-    if (parsedUrl) {
-      prNumber = parsedUrl.prNumber;
-      org = parsedUrl.org;
-      project = parsedUrl.project;
-    } else if (isNaN(prNumber)) {
-      throw new Error(`Invalid Pull Request URL or ID format: "${prUrlOrId}"`);
-    } else {
-      // Try to detect org and project from remote URL
-      const remoteUrl = await this.gitService.getRemoteUrl(repoPath);
-      if (remoteUrl) {
-        const parsedRemote = this.parseRemoteUrl(remoteUrl);
-        if (parsedRemote) {
-          org = org || parsedRemote.org;
-          project = project || parsedRemote.project;
-        }
-      }
+    const provider = await this.getCodeReviewProvider();
+    if (!provider) {
+      throw new Error('No code review provider configured.');
     }
-
-    if (!org) {
-      throw new Error(
-        'Azure DevOps Organization is not configured in settings and could not be detected from git remote.',
-      );
-    }
-    if (!project) {
-      throw new Error(
-        'Azure DevOps Project is not configured in settings and could not be detected from git remote.',
-      );
-    }
-
-    const pat = settings.connectors?.azureDevOps?.pat;
-    if (!pat) {
-      throw new Error(
-        'Azure DevOps PAT token is missing. Please configure it in Settings.',
-      );
-    }
-
-    const orgUrl = this.getOrgUrl(org);
-    const authHandler = azdev.getPersonalAccessTokenHandler(pat);
-    const connection = new azdev.WebApi(orgUrl, authHandler);
-    const gitApi: IGitApi = await connection.getGitApi();
-
-    try {
-      const pr = await gitApi.getPullRequestById(prNumber);
-      if (!pr) {
-        throw new Error(`Pull Request #${prNumber} not found.`);
-      }
-
-      if (!pr.targetRefName) {
-        throw new Error(
-          `Pull Request #${prNumber} is missing target branch ref.`,
-        );
-      }
-
-      const cleanRef = (ref: string) => ref.replace(/^refs\/heads\//, '');
-      const orgUrl = this.getOrgUrl(org);
-      const baseUrl = orgUrl.endsWith('/') ? orgUrl.slice(0, -1) : orgUrl;
-      const prId = pr.pullRequestId?.toString() || prNumber.toString();
-      const repoName = pr.repository?.name || '';
-      const webUrl = `${baseUrl}/${project}/_git/${repoName}/pullrequest/${prId}`;
-
-      return {
-        id: prId,
-        title: pr.title || '',
-        description: pr.description || '',
-        sourceBranch: cleanRef(pr.sourceRefName || ''),
-        targetBranch: cleanRef(pr.targetRefName || ''),
-        author: pr.createdBy?.displayName || '',
-        repositoryName: repoName,
-        repositoryId: pr.repository?.id,
-        hostType: 'azure',
-        url: webUrl,
-      };
-    } catch (error: unknown) {
-      const errMsg = error instanceof Error ? error.message : String(error);
-      throw new Error(`Failed to fetch PR from Azure DevOps API: ${errMsg}`, {
-        cause: error,
-      });
-    }
+    const remoteUrl = await this.gitService.getRemoteUrl(repoPath);
+    return provider.getPRDetails(repoPath, prUrlOrId, remoteUrl);
   }
 
   async getProjectPRs(
     searchType: 'assigned' | 'created' | 'all',
-    settings: AppSettings,
+    _settings: AppSettings,
   ): Promise<PRMetadata[]> {
-    const azureConn = settings.connectors?.azureDevOps;
-    const org = azureConn?.org || '';
-    const project = azureConn?.project || '';
-    const pat = azureConn?.pat;
-
-    if (!org) {
-      throw new Error(
-        'Azure DevOps Organization is not configured in settings.',
-      );
+    const provider = await this.getCodeReviewProvider();
+    if (!provider) {
+      throw new Error('No code review provider configured.');
     }
-    if (!project) {
-      throw new Error('Azure DevOps Project is not configured in settings.');
-    }
-    if (!pat) {
-      throw new Error(
-        'Azure DevOps PAT token is missing. Please configure it in Settings.',
-      );
-    }
-
-    const orgUrl = this.getOrgUrl(org);
-    const authHandler = azdev.getPersonalAccessTokenHandler(pat);
-    const connection = new azdev.WebApi(orgUrl, authHandler);
-    const gitApi: IGitApi = await connection.getGitApi();
-
-    try {
-      let reviewerId: string | undefined;
-      let creatorId: string | undefined;
-
-      if (searchType === 'assigned' || searchType === 'created') {
-        const connectionData = await connection.connect();
-        const currentUserId = connectionData.authorizedUser?.id;
-        if (!currentUserId) {
-          throw new Error(
-            'Could not resolve current authenticated user identity ID.',
-          );
-        }
-        if (searchType === 'assigned') {
-          reviewerId = currentUserId;
-        } else {
-          creatorId = currentUserId;
-        }
-      }
-
-      const searchCriteria: GitPullRequestSearchCriteria = {
-        status: 1, // Active
-      };
-      if (reviewerId) searchCriteria.reviewerId = reviewerId;
-      if (creatorId) searchCriteria.creatorId = creatorId;
-
-      const prs = await gitApi.getPullRequestsByProject(
-        project,
-        searchCriteria,
-      );
-      const cleanRef = (ref: string) => ref.replace(/^refs\/heads\//, '');
-      return prs.map((pr) => {
-        const prId = pr.pullRequestId?.toString() || '';
-        const repoName = pr.repository?.name || '';
-        const baseUrl = orgUrl.endsWith('/') ? orgUrl.slice(0, -1) : orgUrl;
-        const webUrl = prId
-          ? `${baseUrl}/${project}/_git/${repoName}/pullrequest/${prId}`
-          : undefined;
-        return {
-          id: prId,
-          title: pr.title || '',
-          description: pr.description || '',
-          sourceBranch: cleanRef(pr.sourceRefName || ''),
-          targetBranch: cleanRef(pr.targetRefName || ''),
-          author: pr.createdBy?.displayName || '',
-          repositoryName: repoName,
-          hostType: 'azure',
-          url: webUrl,
-        };
-      });
-    } catch (error: unknown) {
-      const errMsg = error instanceof Error ? error.message : String(error);
-      throw new Error(`Failed to query PRs from Azure DevOps: ${errMsg}`, {
-        cause: error,
-      });
-    }
+    return provider.getProjectPRs(searchType);
   }
 
   getEffectiveRepoPath(repoPath: string): string {
@@ -769,7 +518,10 @@ export class PRReviewerService {
     if (expectedRepoName) {
       const remoteUrl = await this.gitService.getRemoteUrl(repoPath);
       if (remoteUrl) {
-        const parsedRemote = this.parseRemoteUrl(remoteUrl);
+        const provider = await this.getCodeReviewProvider();
+        const parsedRemote = provider
+          ? provider.parseRemoteUrl(remoteUrl)
+          : null;
         if (
           parsedRemote &&
           parsedRemote.repoName.toLowerCase() !== expectedRepoName.toLowerCase()
@@ -912,32 +664,13 @@ export class PRReviewerService {
         (phase) => phase.attach && phase.attach.toLowerCase().includes('story'),
       );
 
-      if (
-        anyPhaseNeedsStory &&
-        prDetails &&
-        prDetails.repositoryId &&
-        options.prId
-      ) {
+      if (anyPhaseNeedsStory && prDetails && options.prId) {
         try {
-          const prNumber = parseInt(prDetails.id);
-          const azureConn = settings.connectors?.azureDevOps;
-          let org = azureConn?.org || '';
-          let project = azureConn?.project || '';
-          const parsedUrl = this.parsePRUrl(options.prId);
-          if (parsedUrl) {
-            org = parsedUrl.org;
-            project = parsedUrl.project;
-          }
-          const pat = azureConn?.pat;
-          if (pat && org && project) {
-            const orgUrl = this.getOrgUrl(org);
-            const authHandler = azdev.getPersonalAccessTokenHandler(pat);
-            const connection = new azdev.WebApi(orgUrl, authHandler);
-            const gitApi: IGitApi = await connection.getGitApi();
-
-            const workItemRefs = await gitApi.getPullRequestWorkItemRefs(
+          const provider = await this.getCodeReviewProvider();
+          if (provider) {
+            const workItemRefs = await provider.getLinkedTickets(
+              prDetails.id,
               prDetails.repositoryId,
-              prNumber,
             );
 
             if (workItemRefs && workItemRefs.length > 0) {
@@ -945,16 +678,16 @@ export class PRReviewerService {
               const docProvider = await this.getDocProvider();
               const storiesList: string[] = [];
 
-              for (const ref of workItemRefs) {
-                if (ref.id) {
+              for (const refId of workItemRefs) {
+                if (refId) {
                   try {
                     let ticketData: TicketData;
                     if (issueTracker) {
-                      ticketData = await issueTracker.fetchTicket(ref.id);
+                      ticketData = await issueTracker.fetchTicket(refId);
                     } else {
                       ticketData = {
-                        id: ref.id,
-                        title: `Work Item ${ref.id}`,
+                        id: refId,
+                        title: `Work Item ${refId}`,
                         description: '',
                       };
                     }
@@ -1000,7 +733,7 @@ export class PRReviewerService {
                     }
                   } catch (err) {
                     console.error(
-                      `Failed to fetch details for work item ${ref.id}:`,
+                      `Failed to fetch details for work item ${refId}:`,
                       err,
                     );
                   }
@@ -1311,108 +1044,13 @@ export class PRReviewerService {
       line?: number;
       comment: string;
     },
-    settings: AppSettings,
+    _settings: AppSettings,
   ): Promise<void> {
-    let prNumber = parseInt(prUrlOrId);
-    const azureConn = settings.connectors?.azureDevOps;
-    let org = azureConn?.org || '';
-    let project = azureConn?.project || '';
-
-    const parsedUrl = this.parsePRUrl(prUrlOrId);
-    if (parsedUrl) {
-      prNumber = parsedUrl.prNumber;
-      org = parsedUrl.org;
-      project = parsedUrl.project;
-    } else if (isNaN(prNumber)) {
-      throw new Error(`Invalid Pull Request URL or ID format: "${prUrlOrId}"`);
-    } else {
-      // Try to detect org and project from remote URL
-      const remoteUrl = await this.gitService.getRemoteUrl(repoPath);
-      if (remoteUrl) {
-        const parsedRemote = this.parseRemoteUrl(remoteUrl);
-        if (parsedRemote) {
-          org = org || parsedRemote.org;
-          project = project || parsedRemote.project;
-        }
-      }
+    const provider = await this.getCodeReviewProvider();
+    if (!provider) {
+      throw new Error('No code review provider configured.');
     }
-
-    if (!org) {
-      throw new Error(
-        'Azure DevOps Organization is not configured in settings and could not be detected from git remote.',
-      );
-    }
-    if (!project) {
-      throw new Error(
-        'Azure DevOps Project is not configured in settings and could not be detected from git remote.',
-      );
-    }
-
-    const pat = settings.connectors?.azureDevOps?.pat;
-    if (!pat) {
-      throw new Error(
-        'Azure DevOps PAT token is missing. Please configure it in Settings.',
-      );
-    }
-
-    const orgUrl = this.getOrgUrl(org);
-    const authHandler = azdev.getPersonalAccessTokenHandler(pat);
-    const connection = new azdev.WebApi(orgUrl, authHandler);
-    const gitApi: IGitApi = await connection.getGitApi();
-
-    // Fetch the pull request to get the repository ID
-    const prDetails = await gitApi.getPullRequestById(prNumber);
-    if (!prDetails || !prDetails.repository || !prDetails.repository.id) {
-      throw new Error(`Pull Request #${prNumber} not found.`);
-    }
-
-    const repositoryId = prDetails.repository.id;
-
-    const disclaimer = [
-      '',
-      '> Generated with Stitch and GitHub Copilot.',
-      '> Like any AI generated content, mistakes and hallucinations can occur. Please review before relying on it.',
-    ].join('\n');
-
-    const contentWithDisclaimer = comment.comment + disclaimer;
-
-    // Define the thread
-    const thread: GitPullRequestCommentThread = {
-      comments: [
-        {
-          parentCommentId: 0,
-          content: contentWithDisclaimer,
-          commentType: 1, // Text comment
-        },
-      ],
-      status: 1, // Active
-    };
-
-    if (comment.type === 'line' && comment.file && comment.line) {
-      let formattedPath = comment.file.replace(/\\/g, '/');
-      if (!formattedPath.startsWith('/')) {
-        formattedPath = '/' + formattedPath;
-      }
-      thread.threadContext = {
-        filePath: formattedPath,
-        rightFileStart: {
-          line: comment.line,
-          offset: 1,
-        },
-        rightFileEnd: {
-          line: comment.line + 1,
-          offset: 1,
-        },
-      };
-    }
-
-    try {
-      await gitApi.createThread(thread, repositoryId, prNumber, project);
-    } catch (error: unknown) {
-      const errMsg = error instanceof Error ? error.message : String(error);
-      throw new Error(`Failed to create comment thread: ${errMsg}`, {
-        cause: error,
-      });
-    }
+    const remoteUrl = await this.gitService.getRemoteUrl(repoPath);
+    await provider.postPRComment(repoPath, prUrlOrId, comment, remoteUrl);
   }
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -10,11 +10,13 @@ import {
   Notification,
 } from 'electron';
 import { AzureDevOpsService } from './infrastructure/azure/azureDevOpsService';
+import { AzureDevOpsCodeReviewService } from './infrastructure/azure/azureDevOpsCodeReviewService';
 import { CopilotService } from './infrastructure/copilot/copilotService';
 import { ConfluenceService } from './infrastructure/confluence/confluenceService';
 import { AppSettings } from '../types';
 import { IssueTrackerProvider } from './infrastructure/providers/IssueTrackerProvider';
 import { DocumentationProvider } from './infrastructure/providers/DocumentationProvider';
+import { CodeReviewProvider } from './infrastructure/providers/CodeReviewProvider';
 import { StoryWriterService } from './features/story-writer/storyWriterService';
 import { TestCaseWriterService } from './features/test-case-writer/testCaseWriterService';
 import { StoryElaboratorService } from './features/story-elaborator/storyElaboratorService';
@@ -60,6 +62,7 @@ async function initStore() {
 // Global service instances
 let azureService: IssueTrackerProvider | null = null;
 let confluenceService: DocumentationProvider | null = null;
+let codeReviewProvider: CodeReviewProvider | null = null;
 const copilotService = new CopilotService();
 const gitService = new GitService();
 const storyWriterService = new StoryWriterService(copilotService);
@@ -89,6 +92,13 @@ const prReviewerService = new PRReviewerService(
   async () => {
     try {
       return await getConfluenceService();
+    } catch {
+      return null;
+    }
+  },
+  async () => {
+    try {
+      return await getCodeReviewProvider();
     } catch {
       return null;
     }
@@ -173,9 +183,30 @@ ipcMain.handle('save-settings', async (event, settings: AppSettings) => {
   // Invalidate services so they get re-created on the next fetch with new credentials
   azureService = null;
   confluenceService = null;
+  codeReviewProvider = null;
 
   return { success: true };
 });
+
+async function getCodeReviewProvider(): Promise<CodeReviewProvider> {
+  if (!codeReviewProvider) {
+    const settings = await getDecryptedSettings();
+    const sanitized = trimProperties(settings) as AppSettings;
+    const azureConn = sanitized.connectors?.azureDevOps;
+    const org = azureConn?.org;
+    const pat = azureConn?.pat;
+    const project = azureConn?.project;
+    if (!org || !pat) {
+      throw new Error('Azure DevOps settings are missing.');
+    }
+    codeReviewProvider = new AzureDevOpsCodeReviewService(
+      org,
+      pat,
+      project || '',
+    );
+  }
+  return codeReviewProvider;
+}
 
 async function getAzureService(): Promise<IssueTrackerProvider> {
   if (!azureService) {

--- a/src/main/infrastructure/azure/__tests__/azureDevOpsCodeReviewService.test.ts
+++ b/src/main/infrastructure/azure/__tests__/azureDevOpsCodeReviewService.test.ts
@@ -1,0 +1,410 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AzureDevOpsCodeReviewService } from '../azureDevOpsCodeReviewService';
+
+const mockGetPullRequestById = vi.fn();
+const mockGetPullRequestsByProject = vi.fn();
+const mockCreateThread = vi.fn();
+const mockGetPullRequestWorkItemRefs = vi.fn();
+
+const mockGitApi = {
+  getPullRequestById: mockGetPullRequestById,
+  getPullRequestsByProject: mockGetPullRequestsByProject,
+  createThread: mockCreateThread,
+  getPullRequestWorkItemRefs: mockGetPullRequestWorkItemRefs,
+};
+
+const mockConnect = vi.fn().mockResolvedValue({
+  authorizedUser: { id: 'mock-user-id' },
+});
+
+function mockWebApiFunction() {
+  return {
+    getGitApi() {
+      return Promise.resolve(mockGitApi);
+    },
+    connect: mockConnect,
+  };
+}
+
+vi.mock('azure-devops-node-api', () => {
+  return {
+    getPersonalAccessTokenHandler: vi.fn(() => ({})),
+    WebApi: mockWebApiFunction,
+  };
+});
+
+describe('AzureDevOpsCodeReviewService', () => {
+  let service: AzureDevOpsCodeReviewService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new AzureDevOpsCodeReviewService(
+      'conf-org',
+      'conf-pat',
+      'conf-proj',
+    );
+  });
+
+  describe('parsePRUrl', () => {
+    it('should parse valid dev.azure.com pullrequest URLs', () => {
+      const result = service.parsePRUrl(
+        'https://dev.azure.com/myorg/myproject/_git/myrepo/pullrequest/12345',
+      );
+      expect(result).toEqual({
+        org: 'myorg',
+        project: 'myproject',
+        repoName: 'myrepo',
+        prNumber: 12345,
+      });
+    });
+
+    it('should parse valid visualstudio.com pullrequest URLs', () => {
+      const result = service.parsePRUrl(
+        'https://myorg.visualstudio.com/myproject/_git/myrepo/pullrequest/54321',
+      );
+      expect(result).toEqual({
+        org: 'myorg',
+        project: 'myproject',
+        repoName: 'myrepo',
+        prNumber: 54321,
+      });
+    });
+
+    it('should return null for invalid URLs', () => {
+      const result = service.parsePRUrl(
+        'https://dev.azure.com/myorg/myproject',
+      );
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('parseRemoteUrl', () => {
+    it('should parse valid HTTPS remote URLs', () => {
+      const result = service.parseRemoteUrl(
+        'https://dev.azure.com/myorg/myproject/_git/myrepo',
+      );
+      expect(result).toEqual({
+        org: 'myorg',
+        project: 'myproject',
+        repoName: 'myrepo',
+      });
+    });
+
+    it('should parse valid HTTPS remote URLs with userInfo', () => {
+      const result = service.parseRemoteUrl(
+        'https://user@dev.azure.com/myorg/myproject/_git/myrepo',
+      );
+      expect(result).toEqual({
+        org: 'myorg',
+        project: 'myproject',
+        repoName: 'myrepo',
+      });
+    });
+
+    it('should parse SSH remote URLs', () => {
+      const result = service.parseRemoteUrl(
+        'git@ssh.dev.azure.com:v3/myorg/myproject/myrepo',
+      );
+      expect(result).toEqual({
+        org: 'myorg',
+        project: 'myproject',
+        repoName: 'myrepo',
+      });
+    });
+  });
+
+  describe('getPRDetails', () => {
+    it('should fetch PR details successfully using settings when given numeric ID and remote URL', async () => {
+      mockGetPullRequestById.mockResolvedValue({
+        pullRequestId: 123,
+        title: 'Pr Title',
+        description: 'Pr Description',
+        sourceRefName: 'refs/heads/feature-x',
+        targetRefName: 'refs/heads/main',
+        createdBy: { displayName: 'John Doe' },
+        repository: { id: 'repo-123', name: 'my-repo' },
+      });
+
+      const details = await service.getPRDetails(
+        '/mock/repo',
+        '123',
+        'https://dev.azure.com/myorg/myproject/_git/myrepo',
+      );
+
+      expect(mockGetPullRequestById).toHaveBeenCalledWith(123);
+      expect(details).toEqual({
+        id: '123',
+        title: 'Pr Title',
+        description: 'Pr Description',
+        sourceBranch: 'feature-x',
+        targetBranch: 'main',
+        author: 'John Doe',
+        repositoryName: 'my-repo',
+        repositoryId: 'repo-123',
+        hostType: 'azure',
+        url: 'https://dev.azure.com/conf-org/conf-proj/_git/my-repo/pullrequest/123',
+      });
+    });
+
+    it('should fetch PR details successfully falling back to remote URL when settings are empty', async () => {
+      const emptyService = new AzureDevOpsCodeReviewService('', 'conf-pat', '');
+      mockGetPullRequestById.mockResolvedValue({
+        pullRequestId: 123,
+        title: 'Pr Title',
+        description: 'Pr Description',
+        sourceRefName: 'refs/heads/feature-x',
+        targetRefName: 'refs/heads/main',
+        createdBy: { displayName: 'John Doe' },
+        repository: { id: 'repo-123', name: 'my-repo' },
+      });
+
+      const details = await emptyService.getPRDetails(
+        '/mock/repo',
+        '123',
+        'https://dev.azure.com/myorg/myproject/_git/myrepo',
+      );
+
+      expect(details.url).toBe(
+        'https://dev.azure.com/myorg/myproject/_git/my-repo/pullrequest/123',
+      );
+    });
+
+    it('should parse URL and use its org/project when given a full URL', async () => {
+      mockGetPullRequestById.mockResolvedValue({
+        pullRequestId: 999,
+        title: 'Url PR',
+        description: 'Url Desc',
+        sourceRefName: 'refs/heads/feature-url',
+        targetRefName: 'refs/heads/master',
+        createdBy: { displayName: 'Jane Doe' },
+        repository: { name: 'myrepo' },
+      });
+
+      const details = await service.getPRDetails(
+        '/mock/repo',
+        'https://dev.azure.com/url-org/url-proj/_git/myrepo/pullrequest/999',
+      );
+      expect(details.id).toBe('999');
+      expect(details.sourceBranch).toBe('feature-url');
+      expect(details.targetBranch).toBe('master');
+    });
+
+    it('should throw if target branch ref is missing', async () => {
+      mockGetPullRequestById.mockResolvedValue({
+        pullRequestId: 123,
+        title: 'Pr Title',
+      });
+
+      await expect(service.getPRDetails('/mock/repo', '123')).rejects.toThrow(
+        'missing target branch ref',
+      );
+    });
+  });
+
+  describe('getProjectPRs', () => {
+    it('should query pull requests for project and return mapped results', async () => {
+      mockGetPullRequestsByProject.mockResolvedValue([
+        {
+          pullRequestId: 444,
+          title: 'My active PR',
+          description: 'PR Description',
+          sourceRefName: 'refs/heads/feature-x',
+          targetRefName: 'refs/heads/main',
+          createdBy: { displayName: 'John Author' },
+          repository: { name: 'my-repo-name' },
+        },
+      ]);
+
+      const result = await service.getProjectPRs('all');
+      expect(result).toEqual([
+        {
+          id: '444',
+          title: 'My active PR',
+          description: 'PR Description',
+          sourceBranch: 'feature-x',
+          targetBranch: 'main',
+          author: 'John Author',
+          repositoryName: 'my-repo-name',
+          hostType: 'azure',
+          url: 'https://dev.azure.com/conf-org/conf-proj/_git/my-repo-name/pullrequest/444',
+        },
+      ]);
+
+      expect(mockGetPullRequestsByProject).toHaveBeenCalledWith('conf-proj', {
+        status: 1,
+      });
+    });
+
+    it('should filter by reviewer if searchType is assigned', async () => {
+      mockConnect.mockResolvedValue({
+        authorizedUser: { id: 'user-guid-123' },
+      });
+      mockGetPullRequestsByProject.mockResolvedValue([]);
+
+      await service.getProjectPRs('assigned');
+
+      expect(mockConnect).toHaveBeenCalled();
+      expect(mockGetPullRequestsByProject).toHaveBeenCalledWith('conf-proj', {
+        status: 1,
+        reviewerId: 'user-guid-123',
+      });
+    });
+
+    it('should filter by creator if searchType is created', async () => {
+      mockConnect.mockResolvedValue({
+        authorizedUser: { id: 'user-guid-123' },
+      });
+      mockGetPullRequestsByProject.mockResolvedValue([]);
+
+      await service.getProjectPRs('created');
+
+      expect(mockConnect).toHaveBeenCalled();
+      expect(mockGetPullRequestsByProject).toHaveBeenCalledWith('conf-proj', {
+        status: 1,
+        creatorId: 'user-guid-123',
+      });
+    });
+  });
+
+  describe('getLinkedTickets', () => {
+    it('should fetch linked ticket IDs', async () => {
+      mockGetPullRequestWorkItemRefs.mockResolvedValue([
+        { id: '1001' },
+        { id: '1002' },
+      ]);
+
+      const result = await service.getLinkedTickets('123', 'repo-123');
+      expect(result).toEqual(['1001', '1002']);
+      expect(mockGetPullRequestWorkItemRefs).toHaveBeenCalledWith(
+        'repo-123',
+        123,
+      );
+    });
+
+    it('should throw if repositoryId is missing', async () => {
+      await expect(service.getLinkedTickets('123')).rejects.toThrow(
+        'Repository ID is required',
+      );
+    });
+  });
+
+  describe('postPRComment', () => {
+    it('should successfully post a general comment', async () => {
+      mockGetPullRequestById.mockResolvedValue({
+        repository: { id: 'mock-repo-id' },
+      });
+      mockCreateThread.mockResolvedValue({});
+
+      await service.postPRComment(
+        '/mock/repo',
+        '123',
+        {
+          type: 'general',
+          comment: 'This is a general comment',
+        },
+        'https://dev.azure.com/conf-org/conf-proj/_git/my-repo',
+      );
+
+      expect(mockGetPullRequestById).toHaveBeenCalledWith(123);
+      expect(mockCreateThread).toHaveBeenCalledWith(
+        {
+          comments: [
+            {
+              parentCommentId: 0,
+              content:
+                'This is a general comment\n' +
+                [
+                  '> Generated with Stitch and GitHub Copilot.',
+                  '> Like any AI generated content, mistakes and hallucinations can occur. Please review before relying on it.',
+                ].join('\n'),
+              commentType: 1,
+            },
+          ],
+          status: 1,
+        },
+        'mock-repo-id',
+        123,
+        'conf-proj',
+      );
+    });
+
+    it('should successfully post a line comment with threadContext', async () => {
+      mockGetPullRequestById.mockResolvedValue({
+        repository: { id: 'mock-repo-id' },
+      });
+      mockCreateThread.mockResolvedValue({});
+
+      await service.postPRComment(
+        '/mock/repo',
+        '123',
+        {
+          type: 'line',
+          file: 'src/index.ts',
+          line: 42,
+          comment: 'Fix this line',
+        },
+        'https://dev.azure.com/conf-org/conf-proj/_git/my-repo',
+      );
+
+      expect(mockGetPullRequestById).toHaveBeenCalledWith(123);
+      expect(mockCreateThread).toHaveBeenCalledWith(
+        {
+          comments: [
+            {
+              parentCommentId: 0,
+              content:
+                'Fix this line\n' +
+                [
+                  '> Generated with Stitch and GitHub Copilot.',
+                  '> Like any AI generated content, mistakes and hallucinations can occur. Please review before relying on it.',
+                ].join('\n'),
+              commentType: 1,
+            },
+          ],
+          status: 1,
+          threadContext: {
+            filePath: '/src/index.ts',
+            rightFileStart: { line: 42, offset: 1 },
+            rightFileEnd: { line: 43, offset: 1 },
+          },
+        },
+        'mock-repo-id',
+        123,
+        'conf-proj',
+      );
+    });
+
+    it('should format Windows file paths with backslashes and ensure starting forward slash when posting a line comment', async () => {
+      mockGetPullRequestById.mockResolvedValue({
+        repository: { id: 'mock-repo-id' },
+      });
+      mockCreateThread.mockResolvedValue({});
+
+      await service.postPRComment(
+        '/mock/repo',
+        '123',
+        {
+          type: 'line',
+          file: 'PartySystemApi\\src\\PartySystem.Domain\\Migrations\\20260624014055_Update-Table-OrganisationType-RemoveIdentity.cs',
+          line: 10,
+          comment: 'Fix this migration',
+        },
+        'https://dev.azure.com/conf-org/conf-proj/_git/my-repo',
+      );
+
+      expect(mockCreateThread).toHaveBeenCalledWith(
+        expect.objectContaining({
+          threadContext: {
+            filePath:
+              '/PartySystemApi/src/PartySystem.Domain/Migrations/20260624014055_Update-Table-OrganisationType-RemoveIdentity.cs',
+            rightFileStart: { line: 10, offset: 1 },
+            rightFileEnd: { line: 11, offset: 1 },
+          },
+        }),
+        'mock-repo-id',
+        123,
+        'conf-proj',
+      );
+    });
+  });
+});

--- a/src/main/infrastructure/azure/azureDevOpsCodeReviewService.ts
+++ b/src/main/infrastructure/azure/azureDevOpsCodeReviewService.ts
@@ -1,0 +1,409 @@
+import * as azdev from 'azure-devops-node-api';
+import { IGitApi } from 'azure-devops-node-api/GitApi';
+import {
+  GitPullRequestSearchCriteria,
+  GitPullRequestCommentThread,
+} from 'azure-devops-node-api/interfaces/GitInterfaces';
+import { CodeReviewProvider } from '../providers/CodeReviewProvider';
+import { PRMetadata } from '../../../types';
+
+export class AzureDevOpsCodeReviewService implements CodeReviewProvider {
+  private gitApi: IGitApi | null = null;
+  private connection: azdev.WebApi | null = null;
+
+  constructor(
+    private org: string,
+    private pat: string,
+    private defaultProject: string,
+  ) {}
+
+  private getOrgUrl(orgName: string): string {
+    if (orgName.startsWith('http://') || orgName.startsWith('https://')) {
+      return orgName;
+    }
+    return `https://dev.azure.com/${orgName}`;
+  }
+
+  private async getClientForOrg(orgName: string): Promise<IGitApi> {
+    if (orgName.toLowerCase() === this.org.toLowerCase() && this.gitApi) {
+      return this.gitApi;
+    }
+    const orgUrl = this.getOrgUrl(orgName);
+    const authHandler = azdev.getPersonalAccessTokenHandler(this.pat);
+    const connection = new azdev.WebApi(orgUrl, authHandler);
+    const gitApi = await connection.getGitApi();
+    if (orgName.toLowerCase() === this.org.toLowerCase()) {
+      this.connection = connection;
+      this.gitApi = gitApi;
+    }
+    return gitApi;
+  }
+
+  parsePRUrl(url: string): {
+    org: string;
+    project: string;
+    repoName: string;
+    prNumber: number;
+  } | null {
+    const trimmed = url.trim();
+
+    // Pattern 1: dev.azure.com
+    // https://dev.azure.com/org/project/_git/repo/pullrequest/123
+    const devAzureRegex =
+      /https:\/\/dev\.azure\.com\/([^/]+)\/([^/]+)\/_git\/([^/]+)\/pullrequest\/(\d+)/i;
+    let match = devAzureRegex.exec(trimmed);
+    if (match) {
+      return {
+        org: match[1],
+        project: match[2],
+        repoName: match[3],
+        prNumber: parseInt(match[4]),
+      };
+    }
+
+    // Pattern 2: visualstudio.com
+    // https://org.visualstudio.com/project/_git/repo/pullrequest/123
+    const vsRegex =
+      /https:\/\/([^/]+)\.visualstudio\.com\/([^/]+)\/_git\/([^/]+)\/pullrequest\/(\d+)/i;
+    match = vsRegex.exec(trimmed);
+    if (match) {
+      return {
+        org: match[1],
+        project: match[2],
+        repoName: match[3],
+        prNumber: parseInt(match[4]),
+      };
+    }
+
+    return null;
+  }
+
+  parseRemoteUrl(url: string): {
+    org: string;
+    project: string;
+    repoName: string;
+  } | null {
+    const trimmed = url.trim();
+
+    // Pattern 1: HTTPS dev.azure.com
+    // https://dev.azure.com/org/project/_git/repo
+    // or https://user@dev.azure.com/org/project/_git/repo
+    const httpsRegex =
+      /https:\/\/(?:[^/]+@)?dev\.azure\.com\/([^/]+)\/([^/]+)\/_git\/([^/.]+)/i;
+    let match = httpsRegex.exec(trimmed);
+    if (match) {
+      return {
+        org: match[1],
+        project: match[2],
+        repoName: match[3],
+      };
+    }
+
+    // Pattern 2: SSH dev.azure.com
+    // git@ssh.dev.azure.com:v3/org/project/repo
+    const sshRegex = /git@ssh\.dev\.azure\.com:v3\/([^/]+)\/([^/]+)\/([^/.]+)/i;
+    match = sshRegex.exec(trimmed);
+    if (match) {
+      return {
+        org: match[1],
+        project: match[2],
+        repoName: match[3],
+      };
+    }
+
+    // Pattern 3: Legacy HTTPS visualstudio.com
+    // https://org.visualstudio.com/project/_git/repo
+    const vsRegex =
+      /https:\/\/([^/]+)\.visualstudio\.com\/([^/]+)\/_git\/([^/.]+)/i;
+    match = vsRegex.exec(trimmed);
+    if (match) {
+      return {
+        org: match[1],
+        project: match[2],
+        repoName: match[3],
+      };
+    }
+
+    return null;
+  }
+
+  async getPRDetails(
+    repoPath: string,
+    prUrlOrId: string,
+    remoteUrl?: string | null,
+  ): Promise<PRMetadata> {
+    let prNumber = parseInt(prUrlOrId);
+    let org = this.org;
+    let project = this.defaultProject;
+
+    const parsedUrl = this.parsePRUrl(prUrlOrId);
+    if (parsedUrl) {
+      prNumber = parsedUrl.prNumber;
+      org = parsedUrl.org;
+      project = parsedUrl.project;
+    } else if (isNaN(prNumber)) {
+      throw new Error(`Invalid Pull Request URL or ID format: "${prUrlOrId}"`);
+    } else {
+      if (remoteUrl) {
+        const parsedRemote = this.parseRemoteUrl(remoteUrl);
+        if (parsedRemote) {
+          org = org || parsedRemote.org;
+          project = project || parsedRemote.project;
+        }
+      }
+    }
+
+    if (!org) {
+      throw new Error(
+        'Azure DevOps Organization is not configured in settings and could not be detected from git remote.',
+      );
+    }
+    if (!project) {
+      throw new Error(
+        'Azure DevOps Project is not configured in settings and could not be detected from git remote.',
+      );
+    }
+
+    const gitApi = await this.getClientForOrg(org);
+
+    try {
+      const pr = await gitApi.getPullRequestById(prNumber);
+      if (!pr) {
+        throw new Error(`Pull Request #${prNumber} not found.`);
+      }
+
+      if (!pr.targetRefName) {
+        throw new Error(
+          `Pull Request #${prNumber} is missing target branch ref.`,
+        );
+      }
+
+      const cleanRef = (ref: string) => ref.replace(/^refs\/heads\//, '');
+      const orgUrl = this.getOrgUrl(org);
+      const baseUrl = orgUrl.endsWith('/') ? orgUrl.slice(0, -1) : orgUrl;
+      const prId = pr.pullRequestId?.toString() || prNumber.toString();
+      const repoName = pr.repository?.name || '';
+      const webUrl = `${baseUrl}/${project}/_git/${repoName}/pullrequest/${prId}`;
+
+      return {
+        id: prId,
+        title: pr.title || '',
+        description: pr.description || '',
+        sourceBranch: cleanRef(pr.sourceRefName || ''),
+        targetBranch: cleanRef(pr.targetRefName || ''),
+        author: pr.createdBy?.displayName || '',
+        repositoryName: repoName,
+        repositoryId: pr.repository?.id,
+        hostType: 'azure',
+        url: webUrl,
+      };
+    } catch (error: unknown) {
+      const errMsg = error instanceof Error ? error.message : String(error);
+      throw new Error(`Failed to fetch PR from Azure DevOps API: ${errMsg}`, {
+        cause: error,
+      });
+    }
+  }
+
+  async getProjectPRs(
+    searchType: 'assigned' | 'created' | 'all',
+  ): Promise<PRMetadata[]> {
+    const gitApi = await this.getClientForOrg(this.org);
+    const orgUrl = this.getOrgUrl(this.org);
+
+    try {
+      let reviewerId: string | undefined;
+      let creatorId: string | undefined;
+
+      if (searchType === 'assigned' || searchType === 'created') {
+        const orgUrl = this.getOrgUrl(this.org);
+        const authHandler = azdev.getPersonalAccessTokenHandler(this.pat);
+        const connection =
+          this.connection || new azdev.WebApi(orgUrl, authHandler);
+        if (!this.connection) {
+          this.connection = connection;
+        }
+        const connectionData = await connection.connect();
+        const currentUserId = connectionData.authorizedUser?.id;
+        if (!currentUserId) {
+          throw new Error(
+            'Could not resolve current authenticated user identity ID.',
+          );
+        }
+        if (searchType === 'assigned') {
+          reviewerId = currentUserId;
+        } else {
+          creatorId = currentUserId;
+        }
+      }
+
+      const searchCriteria: GitPullRequestSearchCriteria = {
+        status: 1, // Active
+      };
+      if (reviewerId) searchCriteria.reviewerId = reviewerId;
+      if (creatorId) searchCriteria.creatorId = creatorId;
+
+      const prs = await gitApi.getPullRequestsByProject(
+        this.defaultProject,
+        searchCriteria,
+      );
+      const cleanRef = (ref: string) => ref.replace(/^refs\/heads\//, '');
+      return prs.map((pr) => {
+        const prId = pr.pullRequestId?.toString() || '';
+        const repoName = pr.repository?.name || '';
+        const baseUrl = orgUrl.endsWith('/') ? orgUrl.slice(0, -1) : orgUrl;
+        const webUrl = prId
+          ? `${baseUrl}/${this.defaultProject}/_git/${repoName}/pullrequest/${prId}`
+          : undefined;
+        return {
+          id: prId,
+          title: pr.title || '',
+          description: pr.description || '',
+          sourceBranch: cleanRef(pr.sourceRefName || ''),
+          targetBranch: cleanRef(pr.targetRefName || ''),
+          author: pr.createdBy?.displayName || '',
+          repositoryName: repoName,
+          hostType: 'azure',
+          url: webUrl,
+        };
+      });
+    } catch (error: unknown) {
+      const errMsg = error instanceof Error ? error.message : String(error);
+      throw new Error(`Failed to query PRs from Azure DevOps: ${errMsg}`, {
+        cause: error,
+      });
+    }
+  }
+
+  async getLinkedTickets(
+    prId: string,
+    repositoryId?: string,
+  ): Promise<string[]> {
+    if (!repositoryId) {
+      throw new Error(
+        'Repository ID is required to fetch linked tickets in Azure DevOps.',
+      );
+    }
+    const gitApi = await this.getClientForOrg(this.org);
+    const prNumber = parseInt(prId);
+
+    try {
+      const workItemRefs = await gitApi.getPullRequestWorkItemRefs(
+        repositoryId,
+        prNumber,
+      );
+      return (workItemRefs || [])
+        .map((ref) => ref.id)
+        .filter((id): id is string => typeof id === 'string' && id !== '');
+    } catch (error: unknown) {
+      const errMsg = error instanceof Error ? error.message : String(error);
+      throw new Error(
+        `Failed to fetch linked work items from Azure DevOps: ${errMsg}`,
+        {
+          cause: error,
+        },
+      );
+    }
+  }
+
+  async postPRComment(
+    repoPath: string,
+    prUrlOrId: string,
+    comment: {
+      type: 'general' | 'line';
+      file?: string;
+      line?: number;
+      comment: string;
+    },
+    remoteUrl?: string | null,
+  ): Promise<void> {
+    let prNumber = parseInt(prUrlOrId);
+    let org = this.org;
+    let project = this.defaultProject;
+
+    const parsedUrl = this.parsePRUrl(prUrlOrId);
+    if (parsedUrl) {
+      prNumber = parsedUrl.prNumber;
+      org = parsedUrl.org;
+      project = parsedUrl.project;
+    } else if (isNaN(prNumber)) {
+      throw new Error(`Invalid Pull Request URL or ID format: "${prUrlOrId}"`);
+    } else {
+      if (remoteUrl) {
+        const parsedRemote = this.parseRemoteUrl(remoteUrl);
+        if (parsedRemote) {
+          org = org || parsedRemote.org;
+          project = project || parsedRemote.project;
+        }
+      }
+    }
+
+    if (!org) {
+      throw new Error(
+        'Azure DevOps Organization is not configured in settings and could not be detected from git remote.',
+      );
+    }
+    if (!project) {
+      throw new Error(
+        'Azure DevOps Project is not configured in settings and could not be detected from git remote.',
+      );
+    }
+
+    const gitApi = await this.getClientForOrg(org);
+
+    // Fetch the pull request to get the repository ID
+    const prDetails = await gitApi.getPullRequestById(prNumber);
+    if (!prDetails || !prDetails.repository || !prDetails.repository.id) {
+      throw new Error(`Pull Request #${prNumber} not found.`);
+    }
+
+    const repositoryId = prDetails.repository.id;
+
+    const disclaimer = [
+      '',
+      '> Generated with Stitch and GitHub Copilot.',
+      '> Like any AI generated content, mistakes and hallucinations can occur. Please review before relying on it.',
+    ].join('\n');
+
+    const contentWithDisclaimer = comment.comment + disclaimer;
+
+    // Define the thread
+    const thread: GitPullRequestCommentThread = {
+      comments: [
+        {
+          parentCommentId: 0,
+          content: contentWithDisclaimer,
+          commentType: 1, // Text comment
+        },
+      ],
+      status: 1, // Active
+    };
+
+    if (comment.type === 'line' && comment.file && comment.line) {
+      let formattedPath = comment.file.replace(/\\/g, '/');
+      if (!formattedPath.startsWith('/')) {
+        formattedPath = '/' + formattedPath;
+      }
+      thread.threadContext = {
+        filePath: formattedPath,
+        rightFileStart: {
+          line: comment.line,
+          offset: 1,
+        },
+        rightFileEnd: {
+          line: comment.line + 1,
+          offset: 1,
+        },
+      };
+    }
+
+    try {
+      await gitApi.createThread(thread, repositoryId, prNumber, project);
+    } catch (error: unknown) {
+      const errMsg = error instanceof Error ? error.message : String(error);
+      throw new Error(`Failed to create comment thread: ${errMsg}`, {
+        cause: error,
+      });
+    }
+  }
+}

--- a/src/main/infrastructure/providers/CodeReviewProvider.ts
+++ b/src/main/infrastructure/providers/CodeReviewProvider.ts
@@ -1,0 +1,40 @@
+import { PRMetadata } from '../../../types';
+
+export interface CodeReviewProvider {
+  parsePRUrl(url: string): {
+    org: string;
+    project: string;
+    repoName: string;
+    prNumber: number;
+  } | null;
+
+  parseRemoteUrl(url: string): {
+    org: string;
+    project: string;
+    repoName: string;
+  } | null;
+
+  getPRDetails(
+    repoPath: string,
+    prUrlOrId: string,
+    remoteUrl?: string | null,
+  ): Promise<PRMetadata>;
+
+  getProjectPRs(
+    searchType: 'assigned' | 'created' | 'all',
+  ): Promise<PRMetadata[]>;
+
+  getLinkedTickets(prId: string, repositoryId?: string): Promise<string[]>;
+
+  postPRComment(
+    repoPath: string,
+    prUrlOrId: string,
+    comment: {
+      type: 'general' | 'line';
+      file?: string;
+      line?: number;
+      comment: string;
+    },
+    remoteUrl?: string | null,
+  ): Promise<void>;
+}


### PR DESCRIPTION
This PR decouples the `PRReviewerService` from Azure DevOps (AzDO) by introducing a generic `CodeReviewProvider` interface and encapsulating all AzDO-specific API integration inside the new `AzureDevOpsCodeReviewService`. This refactoring makes the PR reviewer service hosting-provider agnostic, paving the way for future integrations such as GitHub, GitLab, or Bitbucket.

- **Added `CodeReviewProvider` Interface**: Defined a contract for parsing PR/remote URLs, fetching PR details, querying project PRs, getting linked work items/tickets, and posting review comments.
- **Added `AzureDevOpsCodeReviewService`**: Implemented CodeReviewProvider using azure-devops-node-api. Houses all AzDO-specific details, token configuration, and API calls.
- **Refactored `PRReviewerService`**: Removed all imports of azure-devops-node-api and delegated PR operations and URL parsing to the injected CodeReviewProvider.
- **Integrated in `index.ts`**: Set up instantiation, caching, and invalidation of the code review service in response to settings changes.
- **Refactored Unit Tests**:
  - Isolated `prReviewerService.test.ts` from AzDO SDK details by mocking the `CodeReviewProvider`.
  - Added dedicated unit tests in `azureDevOpsCodeReviewService.test.ts` to cover Azure DevOps integration and URL/model mappings.
- **Updated Documentation**: Documented the new generic provider abstraction in `docs/ARCHITECTURE.md`.