### PR TITLE
feat: track copilot metrics

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -88,8 +88,8 @@ locally on the machine.
 - **Usage Metrics Tracking**:
   - For each Copilot session, `CopilotService` listens to the `assistant.usage` event emitted by the Copilot agent.
   - The service tracks token usage metrics, including input tokens (`inputTokens`), output tokens (`outputTokens`), cached tokens (`cacheReadTokens`), and model multiplier/cost (`cost`), falling back to `0` if any metric is missing.
-  - For general sessions, the accumulated usage metrics are logged to the main process console upon session completion.
-  - For parallelized tasks like the **PR Reviewer**, individual phase sessions suppress direct console logging (`session.isPrReviewer = true`) and instead propagate their stats to the reviewer service. The service then logs individual phase usage upon completion and prints an aggregated summary of all review phases at the end of the review execution.
+  - The accumulated usage metrics are returned to the renderer process upon task completion via IPC.
+  - For parallelized tasks like the **PR Reviewer**, individual phase sessions propagate their stats to the reviewer service, which aggregates the usage across all phases and returns the total usage stats to the frontend.
 - **`request_documentation` Custom Tool**:
   - Exposed to the Copilot session during both **PR Reviewer** (when attaching linked stories) and **Story Elaborator** tasks.
   - The custom tool (`createRequestDocumentationTool` from `src/main/infrastructure/copilot/tools/documentationTool.ts`) takes a `documentId` (e.g., Confluence Page ID) and queries `ConfluenceService` to retrieve the page title and storage body layout.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -85,6 +85,11 @@ locally on the machine.
   - For the **PR Reviewer**, review comments and status outputs are parsed as JSONL lines (`type: "status"`, `type: "general"`, or `type: "line"`). When a `line` comment is parsed, the backend dynamically resolves context lines using `extractFileContextSync` and enriches the JSON object before pushing it to the UI.
   - For the **Story Elaborator**, lines are emitted via `elaboration-line`. The communication uses a strict JSON Lines (JSONL) protocol, streaming objects of type `status` (thoughts and directory search updates), `question` (with suggested answers for the user), or `plan` (the finalized implementation plan).
   - Inside `sendAndCollectStream`, a newline buffer fallback processes block-delivered responses when incremental token deltas are skipped during tool executions, ensuring smooth UI status tracking.
+- **Usage Metrics Tracking**:
+  - For each Copilot session, `CopilotService` listens to the `assistant.usage` event emitted by the Copilot agent.
+  - The service tracks token usage metrics, including input tokens (`inputTokens`), output tokens (`outputTokens`), cached tokens (`cacheReadTokens`), and model multiplier/cost (`cost`), falling back to `0` if any metric is missing.
+  - For general sessions, the accumulated usage metrics are logged to the main process console upon session completion.
+  - For parallelized tasks like the **PR Reviewer**, individual phase sessions suppress direct console logging (`session.isPrReviewer = true`) and instead propagate their stats to the reviewer service. The service then logs individual phase usage upon completion and prints an aggregated summary of all review phases at the end of the review execution.
 - **`request_documentation` Custom Tool**:
   - Exposed to the Copilot session during both **PR Reviewer** (when attaching linked stories) and **Story Elaborator** tasks.
   - The custom tool (`createRequestDocumentationTool` from `src/main/infrastructure/copilot/tools/documentationTool.ts`) takes a `documentId` (e.g., Confluence Page ID) and queries `ConfluenceService` to retrieve the page title and storage body layout.

--- a/src/main/features/pr-reviewer/__tests__/prReviewerService.test.ts
+++ b/src/main/features/pr-reviewer/__tests__/prReviewerService.test.ts
@@ -1658,6 +1658,102 @@ describe('PRReviewerService', () => {
         'original-branch-ref',
       );
     });
+
+    it('should aggregate Copilot session usage across workers and log them', async () => {
+      mockGitService.checkGitRepo.mockResolvedValue(true);
+      mockGitService.hasUncommittedChanges.mockResolvedValue(false);
+      mockGitService.fetchAndCheckoutPR.mockResolvedValue('pr-sha');
+      mockGitService.getDiffFiles.mockResolvedValue([
+        { path: 'src/index.ts', status: 'modified' },
+      ]);
+
+      vi.spyOn(prReviewerService, 'loadPhasesFromDisk').mockResolvedValue([
+        {
+          id: '010-dod.md',
+          title: 'DoD Review',
+          body: 'Check requirements',
+        },
+        {
+          id: '020-security.md',
+          title: 'Security Review',
+          body: 'Check vulnerabilities',
+        },
+      ]);
+
+      const mockConsoleLog = vi
+        .spyOn(console, 'log')
+        .mockImplementation(() => {});
+
+      const mockSession1 = {
+        disconnect: vi.fn().mockResolvedValue(undefined),
+        usage: {
+          inputTokens: 100,
+          outputTokens: 50,
+          cacheReadTokens: 10,
+          cost: 0.1,
+        },
+      };
+
+      const mockSession2 = {
+        disconnect: vi.fn().mockResolvedValue(undefined),
+        usage: {
+          inputTokens: 200,
+          outputTokens: 75,
+          cacheReadTokens: 20,
+          cost: 0.25,
+        },
+      };
+
+      const mockClient = { stop: vi.fn().mockResolvedValue(undefined) };
+
+      let sessionCount = 0;
+      mockCopilotService.createClientAndSession.mockImplementation(async () => {
+        sessionCount++;
+        return {
+          client: mockClient,
+          session: sessionCount === 1 ? mockSession1 : mockSession2,
+        };
+      });
+
+      mockCopilotService.sendAndCollectStream.mockResolvedValue('done');
+
+      // Run review
+      await prReviewerService.reviewPR('/mock/repo', 'main', settings, {
+        enabledPhaseIds: ['010-dod.md', '020-security.md'],
+        maxParallelism: 2,
+      });
+
+      // Verify that individual phase usage was logged
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining('Phase Complete: "DoD Review"'),
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining('Phase Complete: "Security Review"'),
+      );
+
+      // Verify aggregated usage was logged
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining('[Copilot PR Review - Aggregated Usage]'),
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining('- Input tokens: 300'),
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining('- Output tokens: 125'),
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining('- Cached tokens: 30'),
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining('- Model multiplier (cost): 0.35'),
+      );
+
+      // Verify sessions had isPrReviewer attached
+      expect((mockSession1 as any).isPrReviewer).toBe(true);
+      expect((mockSession2 as any).isPrReviewer).toBe(true);
+
+      mockConsoleLog.mockRestore();
+    });
   });
 
   describe('checkWorktrees', () => {

--- a/src/main/features/pr-reviewer/__tests__/prReviewerService.test.ts
+++ b/src/main/features/pr-reviewer/__tests__/prReviewerService.test.ts
@@ -1687,10 +1687,6 @@ describe('PRReviewerService', () => {
         },
       ]);
 
-      const mockConsoleLog = vi
-        .spyOn(console, 'log')
-        .mockImplementation(() => {});
-
       const mockSession1 = {
         disconnect: vi.fn().mockResolvedValue(undefined),
         usage: {
@@ -1725,41 +1721,27 @@ describe('PRReviewerService', () => {
       mockCopilotService.sendAndCollectStream.mockResolvedValue('done');
 
       // Run review
-      await prReviewerService.reviewPR('/mock/repo', 'main', settings, {
-        enabledPhaseIds: ['010-dod.md', '020-security.md'],
-        maxParallelism: 2,
+      const res = await prReviewerService.reviewPR(
+        '/mock/repo',
+        'main',
+        settings,
+        {
+          enabledPhaseIds: ['010-dod.md', '020-security.md'],
+          maxParallelism: 2,
+        },
+      );
+
+      // Verify aggregated usage was returned correctly
+      expect(res.usage).toEqual({
+        inputTokens: 300,
+        outputTokens: 125,
+        cacheReadTokens: 30,
+        cost: 0.35,
       });
-
-      // Verify that individual phase usage was logged
-      expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining('Phase Complete: "DoD Review"'),
-      );
-      expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining('Phase Complete: "Security Review"'),
-      );
-
-      // Verify aggregated usage was logged
-      expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining('[Copilot PR Review - Aggregated Usage]'),
-      );
-      expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining('- Input tokens: 300'),
-      );
-      expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining('- Output tokens: 125'),
-      );
-      expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining('- Cached tokens: 30'),
-      );
-      expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining('- Model multiplier (cost): 0.35'),
-      );
 
       // Verify sessions had isPrReviewer attached
       expect((mockSession1 as any).isPrReviewer).toBe(true);
       expect((mockSession2 as any).isPrReviewer).toBe(true);
-
-      mockConsoleLog.mockRestore();
     });
   });
 

--- a/src/main/features/pr-reviewer/__tests__/prReviewerService.test.ts
+++ b/src/main/features/pr-reviewer/__tests__/prReviewerService.test.ts
@@ -318,9 +318,16 @@ describe('PRReviewerService', () => {
 
       expect(mockSession.disconnect).toHaveBeenCalled();
       expect(mockClient.stop).toHaveBeenCalled();
-      expect(result).toBe(
-        '\n--- Phase Definition of Done Result ---\n{"type":"general","comment":"LGTM"}',
-      );
+      expect(result).toEqual({
+        result:
+          '\n--- Phase Definition of Done Result ---\n{"type":"general","comment":"LGTM"}',
+        usage: {
+          inputTokens: 0,
+          outputTokens: 0,
+          cacheReadTokens: 0,
+          cost: 0,
+        },
+      });
     });
 
     it('should cleanly stop client and session even when review throws an error', async () => {

--- a/src/main/features/pr-reviewer/prReviewerService.ts
+++ b/src/main/features/pr-reviewer/prReviewerService.ts
@@ -994,12 +994,6 @@ export class PRReviewerService {
               usage,
             });
 
-            console.log(`[Copilot PR Review - Phase Complete: "${phase.title}"]
-- Input tokens: ${usage.inputTokens}
-- Output tokens: ${usage.outputTokens}
-- Cached tokens: ${usage.cacheReadTokens}
-- Model multiplier (cost): ${usage.cost}`);
-
             try {
               await session.disconnect();
             } catch (e) {
@@ -1043,23 +1037,6 @@ export class PRReviewerService {
         (sum, stat) => sum + stat.usage.cost,
         0,
       );
-
-      if (phaseStats.length > 0) {
-        console.log(
-          `\n=========================================\n[Copilot PR Review - Phase Usage Summary]\n=========================================`,
-        );
-        for (const stat of phaseStats) {
-          console.log(`Phase "${stat.phaseTitle}":
-- Input tokens: ${stat.usage.inputTokens}
-- Output tokens: ${stat.usage.outputTokens}
-- Cached tokens: ${stat.usage.cacheReadTokens}
-- Model multiplier (cost): ${stat.usage.cost}`);
-        }
-
-        console.log(
-          `\n=========================================\n[Copilot PR Review - Aggregated Usage]\n=========================================\n- Input tokens: ${totalInputTokens}\n- Output tokens: ${totalOutputTokens}\n- Cached tokens: ${totalCacheReadTokens}\n- Model multiplier (cost): ${totalCost}\n=========================================`,
-        );
-      }
 
       if (firstError) {
         throw firstError;

--- a/src/main/features/pr-reviewer/prReviewerService.ts
+++ b/src/main/features/pr-reviewer/prReviewerService.ts
@@ -12,6 +12,7 @@ import {
   ReviewPhase,
   TicketData,
   CopilotUsage,
+  CopilotResult,
 } from '../../../types';
 import { IssueTrackerProvider } from '../../infrastructure/providers/IssueTrackerProvider';
 import { DocumentationProvider } from '../../infrastructure/providers/DocumentationProvider';
@@ -606,7 +607,7 @@ export class PRReviewerService {
       onLine?: (line: string) => void;
       maxParallelism?: number;
     } = {},
-  ): Promise<string> {
+  ): Promise<CopilotResult<string>> {
     if (!options.enabledPhaseIds || options.enabledPhaseIds.length === 0) {
       throw new Error(
         'No review phases selected. Please select at least one phase to start the review.',
@@ -1026,6 +1027,23 @@ export class PRReviewerService {
       const workers = Array.from({ length: workerCount }, () => runWorker());
       await Promise.all(workers);
 
+      const totalInputTokens = phaseStats.reduce(
+        (sum, stat) => sum + stat.usage.inputTokens,
+        0,
+      );
+      const totalOutputTokens = phaseStats.reduce(
+        (sum, stat) => sum + stat.usage.outputTokens,
+        0,
+      );
+      const totalCacheReadTokens = phaseStats.reduce(
+        (sum, stat) => sum + stat.usage.cacheReadTokens,
+        0,
+      );
+      const totalCost = phaseStats.reduce(
+        (sum, stat) => sum + stat.usage.cost,
+        0,
+      );
+
       if (phaseStats.length > 0) {
         console.log(
           `\n=========================================\n[Copilot PR Review - Phase Usage Summary]\n=========================================`,
@@ -1038,23 +1056,6 @@ export class PRReviewerService {
 - Model multiplier (cost): ${stat.usage.cost}`);
         }
 
-        const totalInputTokens = phaseStats.reduce(
-          (sum, stat) => sum + stat.usage.inputTokens,
-          0,
-        );
-        const totalOutputTokens = phaseStats.reduce(
-          (sum, stat) => sum + stat.usage.outputTokens,
-          0,
-        );
-        const totalCacheReadTokens = phaseStats.reduce(
-          (sum, stat) => sum + stat.usage.cacheReadTokens,
-          0,
-        );
-        const totalCost = phaseStats.reduce(
-          (sum, stat) => sum + stat.usage.cost,
-          0,
-        );
-
         console.log(
           `\n=========================================\n[Copilot PR Review - Aggregated Usage]\n=========================================\n- Input tokens: ${totalInputTokens}\n- Output tokens: ${totalOutputTokens}\n- Cached tokens: ${totalCacheReadTokens}\n- Model multiplier (cost): ${totalCost}\n=========================================`,
         );
@@ -1066,7 +1067,15 @@ export class PRReviewerService {
 
       const accumulatedResult = results.filter((r) => r !== '').join('');
 
-      return accumulatedResult;
+      return {
+        result: accumulatedResult,
+        usage: {
+          inputTokens: totalInputTokens,
+          outputTokens: totalOutputTokens,
+          cacheReadTokens: totalCacheReadTokens,
+          cost: totalCost,
+        },
+      };
     } finally {
       if (blockerId !== null && powerSaveBlocker.isStarted(blockerId)) {
         powerSaveBlocker.stop(blockerId);

--- a/src/main/features/pr-reviewer/prReviewerService.ts
+++ b/src/main/features/pr-reviewer/prReviewerService.ts
@@ -11,6 +11,7 @@ import {
   AppSettings,
   ReviewPhase,
   TicketData,
+  CopilotUsage,
 } from '../../../types';
 import { IssueTrackerProvider } from '../../infrastructure/providers/IssueTrackerProvider';
 import { DocumentationProvider } from '../../infrastructure/providers/DocumentationProvider';
@@ -751,6 +752,7 @@ export class PRReviewerService {
       }
 
       const results: string[] = new Array(enabledPhases.length).fill('');
+      const phaseStats: { phaseTitle: string; usage: CopilotUsage }[] = [];
       let firstError: Error | null = null;
       let queueIndex = 0;
 
@@ -920,6 +922,8 @@ export class PRReviewerService {
           }
 
           const { client, session } = clientAndSession;
+          session.isPrReviewer = true;
+          session.label = `PR Reviewer Phase: ${phase.title}`;
 
           const attachDescription =
             phase.attach && phase.attach.toLowerCase().includes('description');
@@ -977,6 +981,24 @@ export class PRReviewerService {
               firstError = err as Error;
             }
           } finally {
+            const usage: CopilotUsage = session.usage ?? {
+              inputTokens: 0,
+              outputTokens: 0,
+              cacheReadTokens: 0,
+              cost: 0,
+            };
+
+            phaseStats.push({
+              phaseTitle: phase.title,
+              usage,
+            });
+
+            console.log(`[Copilot PR Review - Phase Complete: "${phase.title}"]
+- Input tokens: ${usage.inputTokens}
+- Output tokens: ${usage.outputTokens}
+- Cached tokens: ${usage.cacheReadTokens}
+- Model multiplier (cost): ${usage.cost}`);
+
             try {
               await session.disconnect();
             } catch (e) {
@@ -1003,6 +1025,40 @@ export class PRReviewerService {
 
       const workers = Array.from({ length: workerCount }, () => runWorker());
       await Promise.all(workers);
+
+      if (phaseStats.length > 0) {
+        console.log(
+          `\n=========================================\n[Copilot PR Review - Phase Usage Summary]\n=========================================`,
+        );
+        for (const stat of phaseStats) {
+          console.log(`Phase "${stat.phaseTitle}":
+- Input tokens: ${stat.usage.inputTokens}
+- Output tokens: ${stat.usage.outputTokens}
+- Cached tokens: ${stat.usage.cacheReadTokens}
+- Model multiplier (cost): ${stat.usage.cost}`);
+        }
+
+        const totalInputTokens = phaseStats.reduce(
+          (sum, stat) => sum + stat.usage.inputTokens,
+          0,
+        );
+        const totalOutputTokens = phaseStats.reduce(
+          (sum, stat) => sum + stat.usage.outputTokens,
+          0,
+        );
+        const totalCacheReadTokens = phaseStats.reduce(
+          (sum, stat) => sum + stat.usage.cacheReadTokens,
+          0,
+        );
+        const totalCost = phaseStats.reduce(
+          (sum, stat) => sum + stat.usage.cost,
+          0,
+        );
+
+        console.log(
+          `\n=========================================\n[Copilot PR Review - Aggregated Usage]\n=========================================\n- Input tokens: ${totalInputTokens}\n- Output tokens: ${totalOutputTokens}\n- Cached tokens: ${totalCacheReadTokens}\n- Model multiplier (cost): ${totalCost}\n=========================================`,
+        );
+      }
 
       if (firstError) {
         throw firstError;

--- a/src/main/features/settings/promptComplexityService.ts
+++ b/src/main/features/settings/promptComplexityService.ts
@@ -27,6 +27,7 @@ export class PromptComplexityService {
         'auto',
         { availableTools: [], streaming: false },
       );
+    session.label = 'Prompt Complexity';
 
     try {
       let promptToCheck = '';

--- a/src/main/features/story-elaborator/storyElaboratorService.ts
+++ b/src/main/features/story-elaborator/storyElaboratorService.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { TicketData, AppSettings } from '../../../types';
+import { TicketData, AppSettings, CopilotUsage } from '../../../types';
 import { CopilotService } from '../../infrastructure/copilot/copilotService';
 import { DocumentationProvider } from '../../infrastructure/providers/DocumentationProvider';
 import { buildStoryElaboratorPrompt } from './storyElaboratorPrompts';
@@ -264,12 +264,13 @@ export class StoryElaboratorService {
     return urls;
   }
 
-  async stopStoryElaboration(ticketId: string): Promise<void> {
+  async stopStoryElaboration(ticketId: string): Promise<CopilotUsage | null> {
     const data = this.activeElaborations.get(ticketId);
-    if (!data) return;
+    if (!data) return null;
 
     this.activeElaborations.delete(ticketId);
     const { client, session, worktreeInfo } = data;
+    const usage = session.usage || null;
     try {
       await session.disconnect();
     } catch (e) {
@@ -290,6 +291,7 @@ export class StoryElaboratorService {
         console.error('Error removing worktree in stopStoryElaboration:', e);
       }
     }
+    return usage;
   }
 
   async cleanup() {

--- a/src/main/features/story-elaborator/storyElaboratorService.ts
+++ b/src/main/features/story-elaborator/storyElaboratorService.ts
@@ -125,6 +125,7 @@ export class StoryElaboratorService {
                 tools: [requestDocumentationTool],
               },
         );
+      session.label = 'Story Elaborator';
 
       // Store in map so we can continue or stop later
       this.activeElaborations.set(ticketData.id || '', {

--- a/src/main/features/story-writer/__tests__/storyWriterService.test.ts
+++ b/src/main/features/story-writer/__tests__/storyWriterService.test.ts
@@ -82,7 +82,10 @@ describe('StoryWriter feature', () => {
         'gpt-4',
         defaultSettings,
       );
-      expect(result).toBe('Mocked response');
+      expect(result).toEqual({
+        result: 'Mocked response',
+        usage: undefined,
+      });
       expect(mockCopilotService.createClientAndSession).toHaveBeenCalledWith(
         undefined,
         'gpt-4',

--- a/src/main/features/story-writer/storyWriterService.ts
+++ b/src/main/features/story-writer/storyWriterService.ts
@@ -18,6 +18,7 @@ export class StoryWriterService {
         modelOverride,
         { availableTools: [] },
       );
+    session.label = 'Story Writer';
 
     try {
       const prompt = buildStoryPrompt(

--- a/src/main/features/story-writer/storyWriterService.ts
+++ b/src/main/features/story-writer/storyWriterService.ts
@@ -1,4 +1,4 @@
-import { DocPageData, AppSettings } from '../../../types';
+import { DocPageData, AppSettings, CopilotResult } from '../../../types';
 import { CopilotService } from '../../infrastructure/copilot/copilotService';
 import { buildStoryPrompt } from './storyWriterPrompts';
 
@@ -11,7 +11,7 @@ export class StoryWriterService {
     modelOverride: string,
     settings: AppSettings,
     onLine?: (line: string) => void,
-  ): Promise<string> {
+  ): Promise<CopilotResult<string>> {
     const { client, session } =
       await this.copilotService.createClientAndSession(
         settings.copilotToken,
@@ -28,11 +28,12 @@ export class StoryWriterService {
         settings,
       );
 
-      return await this.copilotService.sendAndCollectStream(
+      const res = await this.copilotService.sendAndCollectStream(
         session,
         prompt,
         onLine,
       );
+      return { result: res, usage: session.usage };
     } catch (error) {
       console.error('Error generating stories:', error);
       throw error;

--- a/src/main/features/test-case-writer/__tests__/testCaseWriterService.test.ts
+++ b/src/main/features/test-case-writer/__tests__/testCaseWriterService.test.ts
@@ -88,7 +88,10 @@ describe('TestCaseWriter feature', () => {
         'gpt-4',
         defaultSettings,
       );
-      expect(result).toBe('Mocked response');
+      expect(result).toEqual({
+        result: 'Mocked response',
+        usage: undefined,
+      });
       expect(mockCopilotService.createClientAndSession).toHaveBeenCalledWith(
         undefined,
         'gpt-4',

--- a/src/main/features/test-case-writer/testCaseWriterService.ts
+++ b/src/main/features/test-case-writer/testCaseWriterService.ts
@@ -1,4 +1,4 @@
-import { TicketData, AppSettings } from '../../../types';
+import { TicketData, AppSettings, CopilotResult } from '../../../types';
 import { CopilotService } from '../../infrastructure/copilot/copilotService';
 import { buildTestCasePrompt } from './testCaseWriterPrompts';
 
@@ -11,7 +11,7 @@ export class TestCaseWriterService {
     modelOverride: string,
     settings: AppSettings,
     onLine?: (line: string) => void,
-  ): Promise<string> {
+  ): Promise<CopilotResult<string>> {
     const { client, session } =
       await this.copilotService.createClientAndSession(
         settings.copilotToken,
@@ -30,11 +30,12 @@ export class TestCaseWriterService {
         settings,
       );
 
-      return await this.copilotService.sendAndCollectStream(
+      const res = await this.copilotService.sendAndCollectStream(
         session,
         prompt,
         onLine,
       );
+      return { result: res, usage: session.usage };
     } catch (error) {
       console.error('Error generating test cases:', error);
       throw error;

--- a/src/main/features/test-case-writer/testCaseWriterService.ts
+++ b/src/main/features/test-case-writer/testCaseWriterService.ts
@@ -18,6 +18,7 @@ export class TestCaseWriterService {
         modelOverride,
         { availableTools: [] },
       );
+    session.label = 'Test Case Writer';
 
     try {
       const prompt = buildTestCasePrompt(

--- a/src/main/infrastructure/copilot/__tests__/copilotService.test.ts
+++ b/src/main/infrastructure/copilot/__tests__/copilotService.test.ts
@@ -524,4 +524,120 @@ describe('CopilotService', () => {
       );
     });
   });
+
+  describe('usage tracking', () => {
+    it('should track and accumulate usage from assistant.usage events and default missing values to 0', async () => {
+      const mockConsoleLog = vi
+        .spyOn(console, 'log')
+        .mockImplementation(() => {});
+
+      const responsePromise = service.sendAndCollectStream(
+        mockSession as any,
+        'prompt',
+      );
+
+      await vi.advanceTimersByTimeAsync(10);
+
+      expect(sessionListener).toBeTypeOf('function');
+
+      // Emit assistant.usage event
+      sessionListener!({
+        type: 'assistant.usage',
+        data: {
+          inputTokens: 100,
+          outputTokens: 50,
+          cacheReadTokens: 10,
+          cost: 1.5,
+        },
+      });
+
+      // Emit another usage event with some missing values to test fallback
+      sessionListener!({
+        type: 'assistant.usage',
+        data: {
+          inputTokens: 200,
+          // outputTokens, cacheReadTokens, cost are missing
+        },
+      });
+
+      // Finalize the stream
+      sessionListener!({
+        type: 'session.idle',
+      });
+
+      await responsePromise;
+
+      // Verify stats attached to session
+      expect((mockSession as any).usage).toEqual({
+        inputTokens: 300,
+        outputTokens: 50,
+        cacheReadTokens: 10,
+        cost: 1.5,
+      });
+
+      // Verify that console.log was called with stats (since session.isPrReviewer is not true)
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining('Copilot Session Usage'),
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining('Input tokens: 300'),
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining('Output tokens: 50'),
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining('Cached tokens: 10'),
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining('Model multiplier (cost): 1.5'),
+      );
+
+      mockConsoleLog.mockRestore();
+    });
+
+    it('should NOT print to console if session.isPrReviewer is true', async () => {
+      const mockConsoleLog = vi
+        .spyOn(console, 'log')
+        .mockImplementation(() => {});
+
+      const customMockSession = {
+        ...mockSession,
+        isPrReviewer: true,
+      };
+
+      const responsePromise = service.sendAndCollectStream(
+        customMockSession as any,
+        'prompt',
+      );
+
+      await vi.advanceTimersByTimeAsync(10);
+
+      sessionListener!({
+        type: 'assistant.usage',
+        data: {
+          inputTokens: 10,
+          outputTokens: 20,
+          cacheReadTokens: 5,
+          cost: 0.5,
+        },
+      });
+
+      sessionListener!({
+        type: 'session.idle',
+      });
+
+      await responsePromise;
+
+      expect(customMockSession.usage).toEqual({
+        inputTokens: 10,
+        outputTokens: 20,
+        cacheReadTokens: 5,
+        cost: 0.5,
+      });
+
+      expect(mockConsoleLog).not.toHaveBeenCalled();
+
+      mockConsoleLog.mockRestore();
+    });
+  });
 });

--- a/src/main/infrastructure/copilot/__tests__/copilotService.test.ts
+++ b/src/main/infrastructure/copilot/__tests__/copilotService.test.ts
@@ -527,10 +527,6 @@ describe('CopilotService', () => {
 
   describe('usage tracking', () => {
     it('should track and accumulate usage from assistant.usage events and default missing values to 0', async () => {
-      const mockConsoleLog = vi
-        .spyOn(console, 'log')
-        .mockImplementation(() => {});
-
       const responsePromise = service.sendAndCollectStream(
         mockSession as any,
         'prompt',
@@ -574,32 +570,9 @@ describe('CopilotService', () => {
         cacheReadTokens: 10,
         cost: 1.5,
       });
-
-      // Verify that console.log was called with stats (since session.isPrReviewer is not true)
-      expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining('Copilot Session Usage'),
-      );
-      expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining('Input tokens: 300'),
-      );
-      expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining('Output tokens: 50'),
-      );
-      expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining('Cached tokens: 10'),
-      );
-      expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining('Model multiplier (cost): 1.5'),
-      );
-
-      mockConsoleLog.mockRestore();
     });
 
     it('should NOT print to console if session.isPrReviewer is true', async () => {
-      const mockConsoleLog = vi
-        .spyOn(console, 'log')
-        .mockImplementation(() => {});
-
       const customMockSession = {
         ...mockSession,
         isPrReviewer: true,
@@ -634,10 +607,6 @@ describe('CopilotService', () => {
         cacheReadTokens: 5,
         cost: 0.5,
       });
-
-      expect(mockConsoleLog).not.toHaveBeenCalled();
-
-      mockConsoleLog.mockRestore();
     });
   });
 });

--- a/src/main/infrastructure/copilot/copilotService.ts
+++ b/src/main/infrastructure/copilot/copilotService.ts
@@ -393,14 +393,6 @@ export class CopilotService {
         clearTimeout(timeoutId);
       }
       unsubscribe();
-
-      if (!session.isPrReviewer) {
-        console.log(`[Copilot Session Usage - ${session.label || 'Unknown'}]
-- Input tokens: ${sessionUsage.inputTokens}
-- Output tokens: ${sessionUsage.outputTokens}
-- Cached tokens: ${sessionUsage.cacheReadTokens}
-- Model multiplier (cost): ${sessionUsage.cost}`);
-      }
     }
   }
 }

--- a/src/main/infrastructure/copilot/copilotService.ts
+++ b/src/main/infrastructure/copilot/copilotService.ts
@@ -1,6 +1,10 @@
 import fs from 'fs';
 import path from 'path';
-import { CopilotModel, EnvironmentCheckResult } from '../../../types';
+import {
+  CopilotModel,
+  EnvironmentCheckResult,
+  CopilotUsage,
+} from '../../../types';
 import {
   checkEnvironment,
   getNodePath,
@@ -289,6 +293,14 @@ export class CopilotService {
     let resolvePromise: (value: string) => void;
     let rejectPromise: (reason: any) => void;
 
+    const sessionUsage: CopilotUsage = {
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cost: 0,
+    };
+    session.usage = sessionUsage;
+
     const completionPromise = new Promise<string>((resolve, reject) => {
       resolvePromise = resolve;
       rejectPromise = reject;
@@ -322,6 +334,11 @@ export class CopilotService {
         }
       } else if (event.type === 'assistant.message') {
         lastAssistantMessage = event;
+      } else if (event.type === 'assistant.usage') {
+        sessionUsage.inputTokens += event.data?.inputTokens ?? 0;
+        sessionUsage.outputTokens += event.data?.outputTokens ?? 0;
+        sessionUsage.cacheReadTokens += event.data?.cacheReadTokens ?? 0;
+        sessionUsage.cost += event.data?.cost ?? 0;
       } else if (event.type === 'session.idle') {
         if (onLine && buffer.trim()) {
           buffer = parseResilientJSONL(buffer, onLine);
@@ -376,6 +393,14 @@ export class CopilotService {
         clearTimeout(timeoutId);
       }
       unsubscribe();
+
+      if (!session.isPrReviewer) {
+        console.log(`[Copilot Session Usage - ${session.label || 'Unknown'}]
+- Input tokens: ${sessionUsage.inputTokens}
+- Output tokens: ${sessionUsage.outputTokens}
+- Cached tokens: ${sessionUsage.cacheReadTokens}
+- Model multiplier (cost): ${sessionUsage.cost}`);
+      }
     }
   }
 }

--- a/src/renderer/components/UsageStatsToast.tsx
+++ b/src/renderer/components/UsageStatsToast.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { CopilotUsage } from '../../types';
+
+interface UsageStatsToastProps {
+  stats: CopilotUsage;
+  onClose: () => void;
+}
+
+const UsageStatsToast: React.FC<UsageStatsToastProps> = ({
+  stats,
+  onClose,
+}) => {
+  const { inputTokens, outputTokens, cacheReadTokens } = stats;
+
+  const cachePercentage =
+    inputTokens > 0 ? Math.round((cacheReadTokens / inputTokens) * 100) : 0;
+
+  return (
+    <div className="usage-toast" role="alert" aria-live="polite">
+      <div className="usage-toast-header">
+        <div className="usage-toast-icon">
+          <i className="fas fa-chart-bar"></i>
+        </div>
+        <h6 className="usage-toast-title">Usage Stats</h6>
+        <button
+          type="button"
+          className="usage-toast-btn-x"
+          onClick={onClose}
+          aria-label="Close"
+        >
+          <i className="fas fa-times"></i>
+        </button>
+      </div>
+      <div className="usage-toast-body">
+        <ul className="usage-toast-list">
+          <li>
+            <span>Input tokens:</span>
+            <strong>{inputTokens.toLocaleString()}</strong>
+          </li>
+          <li>
+            <span>Output tokens:</span>
+            <strong>{outputTokens.toLocaleString()}</strong>
+          </li>
+          <li>
+            <span>Cached tokens:</span>
+            <strong>{cacheReadTokens.toLocaleString()}</strong>
+          </li>
+        </ul>
+        {inputTokens > 0 && (
+          <p className="usage-toast-cache-msg">
+            {cachePercentage}% of input tokens served from the cache
+          </p>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default UsageStatsToast;

--- a/src/renderer/components/__tests__/UsageStatsToast.test.tsx
+++ b/src/renderer/components/__tests__/UsageStatsToast.test.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import UsageStatsToast from '../UsageStatsToast';
+
+describe('UsageStatsToast Component', () => {
+  const mockStats = {
+    inputTokens: 42023,
+    outputTokens: 2381,
+    cacheReadTokens: 30976,
+    cost: 0.1234,
+  };
+
+  it('renders stats correctly and calculates cache percentage', () => {
+    render(<UsageStatsToast stats={mockStats} onClose={vi.fn()} />);
+
+    expect(screen.getByText('Usage Stats')).toBeInTheDocument();
+    expect(screen.getByText('42,023')).toBeInTheDocument();
+    expect(screen.getByText('2,381')).toBeInTheDocument();
+    expect(screen.getByText('30,976')).toBeInTheDocument();
+    expect(
+      screen.getByText('74% of input tokens served from the cache'),
+    ).toBeInTheDocument();
+  });
+
+  it('calls onClose when close button is clicked', () => {
+    const onCloseSpy = vi.fn();
+    render(<UsageStatsToast stats={mockStats} onClose={onCloseSpy} />);
+
+    const closeBtn = screen.getByRole('button', { name: /close/i });
+    expect(closeBtn).toBeInTheDocument();
+
+    fireEvent.click(closeBtn);
+    expect(onCloseSpy).toHaveBeenCalledOnce();
+  });
+
+  it('does not render cache message if inputTokens is 0', () => {
+    const zeroInputStats = {
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cost: 0,
+    };
+
+    render(<UsageStatsToast stats={zeroInputStats} onClose={vi.fn()} />);
+
+    expect(
+      screen.queryByText(/of input tokens served from the cache/),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/renderer/features/pr-reviewer/PRReviewer.tsx
+++ b/src/renderer/features/pr-reviewer/PRReviewer.tsx
@@ -5,7 +5,8 @@ import { useNavigate } from 'react-router-dom';
 import PageLayout from '../../components/PageLayout';
 import ModelDropdown from '../../components/ModelDropdown';
 import { useCopilotModels } from '../../hooks/useCopilotModels';
-import { PRMetadata, ReviewPhase } from '../../../types';
+import { PRMetadata, ReviewPhase, CopilotUsage } from '../../../types';
+import UsageStatsToast from '../../components/UsageStatsToast';
 
 interface ReviewComment {
   type: 'general' | 'line';
@@ -47,6 +48,7 @@ const PRReviewer: React.FC = () => {
   const [hasReviewed, setHasReviewed] = useState(false);
   const [lastStatusTime, setLastStatusTime] = useState<Date | null>(null);
   const [customInstructions, setCustomInstructions] = useState('');
+  const [usageStats, setUsageStats] = useState<CopilotUsage | null>(null);
   const { models, selectedModel, setSelectedModel, loadingModels } =
     useCopilotModels();
   const [collapsedComments, setCollapsedComments] = useState<
@@ -405,8 +407,9 @@ const PRReviewer: React.FC = () => {
     });
 
     try {
+      setUsageStats(null);
       const enabledPhaseIds = activePhases.map((p) => p.id);
-      await window.electronAPI.reviewPR(
+      const res = await window.electronAPI.reviewPR(
         repoPath,
         selectedPR.targetBranch,
         customInstructions,
@@ -416,6 +419,9 @@ const PRReviewer: React.FC = () => {
         selectedPR.id,
         maxParallelism,
       );
+      if (res && res.usage) {
+        setUsageStats(res.usage);
+      }
       setHasReviewed(true);
       triggerNotification(
         'PR Review Complete',
@@ -1643,6 +1649,12 @@ const PRReviewer: React.FC = () => {
             </div>
           </div>
         </div>
+      )}
+      {usageStats && (
+        <UsageStatsToast
+          stats={usageStats}
+          onClose={() => setUsageStats(null)}
+        />
       )}
     </PageLayout>
   );

--- a/src/renderer/features/story-elaborator/StoryElaborator.tsx
+++ b/src/renderer/features/story-elaborator/StoryElaborator.tsx
@@ -4,8 +4,9 @@ import remarkGfm from 'remark-gfm';
 import { useCopilotModels } from '../../hooks/useCopilotModels';
 import ModelDropdown from '../../components/ModelDropdown';
 import PageLayout from '../../components/PageLayout';
-import { TicketData } from '../../../types';
+import { TicketData, CopilotUsage } from '../../../types';
 import { useTimeoutModal, isTimeoutError } from '../../context/TimeoutContext';
+import UsageStatsToast from '../../components/UsageStatsToast';
 
 interface FeedItem {
   type: 'chat' | 'status';
@@ -51,6 +52,7 @@ const StoryElaborator: React.FC = () => {
   const [isGenerating, setIsGenerating] = useState(false);
   const [isWaitingForUser, setIsWaitingForUser] = useState(false);
   const [error, setError] = useState<string>('');
+  const [usageStats, setUsageStats] = useState<CopilotUsage | null>(null);
 
   // Elaboration Content
   const [feed, setFeed] = useState<FeedItem[]>([]);
@@ -165,6 +167,7 @@ const StoryElaborator: React.FC = () => {
     }
 
     setError('');
+    setUsageStats(null);
     setStage('elaborating');
     setIsGenerating(true);
     setIsWaitingForUser(false);
@@ -227,6 +230,19 @@ const StoryElaborator: React.FC = () => {
             'Elaboration Plan Completed',
             `The agent has successfully written the plan for ticket #${ticketId}.`,
           );
+          window.electronAPI
+            .stopStoryElaboration(ticketId)
+            .then((usage) => {
+              if (usage) {
+                setUsageStats(usage);
+              }
+            })
+            .catch((err) => {
+              console.error(
+                'Error stopping story elaboration on plan complete:',
+                err,
+              );
+            });
         }
       } catch (err) {
         console.warn('Failed to parse JSONL line:', trimmed, err);
@@ -888,6 +904,12 @@ const StoryElaborator: React.FC = () => {
           </div>
         </div>
       </div>
+      {usageStats && (
+        <UsageStatsToast
+          stats={usageStats}
+          onClose={() => setUsageStats(null)}
+        />
+      )}
     </PageLayout>
   );
 };

--- a/src/renderer/features/story-writer/StoryWriter.tsx
+++ b/src/renderer/features/story-writer/StoryWriter.tsx
@@ -4,8 +4,9 @@ import remarkGfm from 'remark-gfm';
 import { useCopilotModels } from '../../hooks/useCopilotModels';
 import ModelDropdown from '../../components/ModelDropdown';
 import PageLayout from '../../components/PageLayout';
-import { DocPageData, TicketData } from '../../../types';
+import { DocPageData, TicketData, CopilotUsage } from '../../../types';
 import { useTimeoutModal, isTimeoutError } from '../../context/TimeoutContext';
+import UsageStatsToast from '../../components/UsageStatsToast';
 
 interface Story {
   title: string;
@@ -19,6 +20,7 @@ const StoryWriter: React.FC = () => {
   const isMountedRef = useRef(true);
   const [featureType, setFeatureType] = useState('Feature');
   const [storyType, setStoryType] = useState('Product Backlog Item');
+  const [usageStats, setUsageStats] = useState<CopilotUsage | null>(null);
 
   useEffect(() => {
     const fetchSettings = async () => {
@@ -219,12 +221,16 @@ const StoryWriter: React.FC = () => {
       if (!isMountedRef.current) return;
       setPageData(fetchedPage);
 
+      setUsageStats(null);
       // 2. Generate Stories using Copilot SDK (this will stream lines via event listeners)
-      await window.electronAPI.generateStories(
+      const res = await window.electronAPI.generateStories(
         fetchedPage,
         context,
         selectedModel,
       );
+      if (res && res.usage) {
+        setUsageStats(res.usage);
+      }
       triggerNotification(
         'Story Generation Complete',
         `Stitch has successfully generated stories for Confluence page "${fetchedPage.title}".`,
@@ -859,6 +865,12 @@ const StoryWriter: React.FC = () => {
           </div>
         </div>
       </div>
+      {usageStats && (
+        <UsageStatsToast
+          stats={usageStats}
+          onClose={() => setUsageStats(null)}
+        />
+      )}
     </PageLayout>
   );
 };

--- a/src/renderer/features/test-case-writer/TestCaseWriter.tsx
+++ b/src/renderer/features/test-case-writer/TestCaseWriter.tsx
@@ -2,8 +2,9 @@ import React, { useState, useEffect, useRef } from 'react';
 import { useCopilotModels } from '../../hooks/useCopilotModels';
 import ModelDropdown from '../../components/ModelDropdown';
 import PageLayout from '../../components/PageLayout';
-import { TicketData } from '../../../types';
+import { TicketData, CopilotUsage } from '../../../types';
 import { useTimeoutModal, isTimeoutError } from '../../context/TimeoutContext';
+import UsageStatsToast from '../../components/UsageStatsToast';
 
 interface TestCase {
   id: string;
@@ -61,6 +62,7 @@ const TestCaseWriter: React.FC = () => {
   const isMountedRef = useRef(true);
   const [taskType, setTaskType] = useState('Task');
   const [testTaskTitle, setTestTaskTitle] = useState('Testing');
+  const [usageStats, setUsageStats] = useState<CopilotUsage | null>(null);
 
   useEffect(() => {
     const fetchSettings = async () => {
@@ -253,12 +255,16 @@ const TestCaseWriter: React.FC = () => {
       if (!isMountedRef.current) return;
       setTicketData(fetchedTicket);
 
+      setUsageStats(null);
       // 2. Generate Test Cases using Copilot SDK (this will stream lines via event listeners)
-      await window.electronAPI.generateTestCases(
+      const res = await window.electronAPI.generateTestCases(
         fetchedTicket,
         context,
         selectedModel,
       );
+      if (res && res.usage) {
+        setUsageStats(res.usage);
+      }
       triggerNotification(
         'Test Case Generation Complete',
         `Stitch has successfully generated test cases for ticket #${fetchedTicket.id} ("${fetchedTicket.title}").`,
@@ -805,6 +811,12 @@ const TestCaseWriter: React.FC = () => {
           </div>
         </div>
       </div>
+      {usageStats && (
+        <UsageStatsToast
+          stats={usageStats}
+          onClose={() => setUsageStats(null)}
+        />
+      )}
     </PageLayout>
   );
 };

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -9,6 +9,8 @@ import {
   PRMetadata,
   PRDiffFile,
   ReviewPhase,
+  CopilotResult,
+  CopilotUsage,
 } from '../types';
 
 export interface IElectronAPI {
@@ -25,7 +27,7 @@ export interface IElectronAPI {
     ticketData: TicketData,
     context: string,
     modelOverride: string,
-  ) => Promise<string>;
+  ) => Promise<CopilotResult<string>>;
   onTestCaseLine: (callback: (line: string) => void) => () => void;
   fetchConfluencePage: (pageId: string) => Promise<DocPageData>;
   searchConfluencePages: (query: string) => Promise<DocPageData[]>;
@@ -33,7 +35,7 @@ export interface IElectronAPI {
     pageData: DocPageData,
     context: string,
     modelOverride: string,
-  ) => Promise<string>;
+  ) => Promise<CopilotResult<string>>;
   onStoryLine: (callback: (line: string) => void) => () => void;
   addComment: (ticketId: string, text: string) => Promise<void>;
   createTicket: (
@@ -61,7 +63,7 @@ export interface IElectronAPI {
     branch?: string,
   ) => Promise<string>;
   sendElaborationAnswer: (ticketId: string, answer: string) => Promise<string>;
-  stopStoryElaboration: (ticketId: string) => Promise<void>;
+  stopStoryElaboration: (ticketId: string) => Promise<CopilotUsage | null>;
   onElaborationLine: (callback: (line: string) => void) => () => void;
   getPRDetails: (repoPath: string, prUrlOrId: string) => Promise<PRMetadata>;
   checkoutPR: (
@@ -108,7 +110,7 @@ export interface IElectronAPI {
     prDescription?: string,
     prId?: string,
     maxParallelism?: number,
-  ) => Promise<string>;
+  ) => Promise<CopilotResult<string>>;
   onPRReviewLine: (callback: (line: string) => void) => () => void;
   postPRComment: (
     repoPath: string,

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -691,7 +691,7 @@ tr.is-dragging {
 .usage-toast {
   position: fixed;
   bottom: 48px; /* sits nicely above the footer */
-  right: 24px;
+  left: 24px;
   z-index: 1050;
   width: 320px;
   background: rgba(255, 255, 255, 0.85);

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -686,3 +686,124 @@ tr.is-dragging {
   opacity: 0.4;
   background-color: var(--bs-secondary-bg) !important;
 }
+
+/* Premium Usage Toast Styles */
+.usage-toast {
+  position: fixed;
+  bottom: 48px; /* sits nicely above the footer */
+  right: 24px;
+  z-index: 1050;
+  width: 320px;
+  background: rgba(255, 255, 255, 0.85);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  border-radius: 14px;
+  box-shadow: 0 10px 32px rgba(19, 56, 101, 0.12);
+  padding: 16px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  animation: toast-slide-in 0.5s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+  transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+[data-bs-theme='dark'] .usage-toast {
+  background: rgba(21, 32, 43, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 10px 32px rgba(0, 0, 0, 0.35);
+}
+
+.usage-toast-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.usage-toast-icon {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #10b981, #059669);
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 13px;
+  box-shadow: 0 4px 12px rgba(16, 185, 129, 0.35);
+}
+
+.usage-toast-title {
+  font-weight: 650;
+  font-size: 14px;
+  color: var(--bs-heading-color, #133865);
+  margin: 0;
+  flex-grow: 1;
+}
+
+[data-bs-theme='dark'] .usage-toast-title {
+  color: #10b981;
+}
+
+.usage-toast-btn-x {
+  background: transparent;
+  border: none;
+  color: var(--bs-secondary-color);
+  font-size: 14px;
+  padding: 4px;
+  cursor: pointer;
+  opacity: 0.7;
+  transition: opacity 0.2s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.usage-toast-btn-x:hover {
+  opacity: 1;
+  color: var(--bs-body-color);
+}
+
+.usage-toast-body {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.usage-toast-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 13px;
+  color: var(--bs-body-color);
+}
+
+.usage-toast-list li {
+  display: flex;
+  justify-content: space-between;
+  border-bottom: 1px dashed rgba(0, 0, 0, 0.05);
+  padding-bottom: 2px;
+}
+
+[data-bs-theme='dark'] .usage-toast-list li {
+  border-bottom: 1px dashed rgba(255, 255, 255, 0.05);
+}
+
+.usage-toast-cache-msg {
+  font-size: 12px;
+  font-weight: 600;
+  color: #059669;
+  margin: 4px 0 0 0;
+  padding: 6px 8px;
+  background: rgba(16, 185, 129, 0.1);
+  border-radius: 6px;
+  text-align: center;
+}
+
+[data-bs-theme='dark'] .usage-toast-cache-msg {
+  color: #34d399;
+  background: rgba(52, 211, 153, 0.1);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -150,3 +150,10 @@ export interface ReviewPhase {
   template?: string;
   templateError?: string;
 }
+
+export interface CopilotUsage {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cost: number;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -157,3 +157,8 @@ export interface CopilotUsage {
   cacheReadTokens: number;
   cost: number;
 }
+
+export interface CopilotResult<T> {
+  result: T;
+  usage: CopilotUsage;
+}


### PR DESCRIPTION
Resolves #152 

When we initiate the agent, we attach a listener for the `assistant.usage` event and keep track of the stats.

When the task is complete, we display a toast with the usage stats;
- Input tokens
- Output tokens
- Tokens read from cache
- % of input tokens from the cache

The toast stays visible until the user closes it, to avoid the user missing this information because they're focusing on the agent's output.

Currently processes which trigger multiple agent sessions, such as the PR Reviewer, we show an aggregate of all usage for the reviewer session. We don't currently break this down by phase in the UI, however the collection and attribution to each session is implemented.

Once we see usage for the feature as-is, and determine the best way to visualise it (expandable toast, separate modal, something else) we will implement it.