### PR TITLE
feat: tighten attribution statement

### DIFF
--- a/src/main/infrastructure/azure/__tests__/azureDevOpsCodeReviewService.test.ts
+++ b/src/main/infrastructure/azure/__tests__/azureDevOpsCodeReviewService.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { AzureDevOpsCodeReviewService } from '../azureDevOpsCodeReviewService';
+import { ATTRIBUTION_STATEMENT } from '../../constants';
 
 const mockGetPullRequestById = vi.fn();
 const mockGetPullRequestsByProject = vi.fn();
@@ -313,7 +314,7 @@ describe('AzureDevOpsCodeReviewService', () => {
               parentCommentId: 0,
               content:
                 'This is a general comment\n' +
-                ['> Generated with Stitch and GitHub Copilot.'].join('\n'),
+                [ATTRIBUTION_STATEMENT].join('\n'),
               commentType: 1,
             },
           ],
@@ -349,9 +350,7 @@ describe('AzureDevOpsCodeReviewService', () => {
           comments: [
             {
               parentCommentId: 0,
-              content:
-                'Fix this line\n' +
-                ['> Generated with Stitch and GitHub Copilot.'].join('\n'),
+              content: 'Fix this line\n' + [ATTRIBUTION_STATEMENT].join('\n'),
               commentType: 1,
             },
           ],

--- a/src/main/infrastructure/azure/__tests__/azureDevOpsCodeReviewService.test.ts
+++ b/src/main/infrastructure/azure/__tests__/azureDevOpsCodeReviewService.test.ts
@@ -313,10 +313,7 @@ describe('AzureDevOpsCodeReviewService', () => {
               parentCommentId: 0,
               content:
                 'This is a general comment\n' +
-                [
-                  '> Generated with Stitch and GitHub Copilot.',
-                  '> Like any AI generated content, mistakes and hallucinations can occur. Please review before relying on it.',
-                ].join('\n'),
+                ['> Generated with Stitch and GitHub Copilot.'].join('\n'),
               commentType: 1,
             },
           ],
@@ -354,10 +351,7 @@ describe('AzureDevOpsCodeReviewService', () => {
               parentCommentId: 0,
               content:
                 'Fix this line\n' +
-                [
-                  '> Generated with Stitch and GitHub Copilot.',
-                  '> Like any AI generated content, mistakes and hallucinations can occur. Please review before relying on it.',
-                ].join('\n'),
+                ['> Generated with Stitch and GitHub Copilot.'].join('\n'),
               commentType: 1,
             },
           ],

--- a/src/main/infrastructure/azure/__tests__/azureDevOpsCodeReviewService.test.ts
+++ b/src/main/infrastructure/azure/__tests__/azureDevOpsCodeReviewService.test.ts
@@ -312,9 +312,7 @@ describe('AzureDevOpsCodeReviewService', () => {
           comments: [
             {
               parentCommentId: 0,
-              content:
-                'This is a general comment\n' +
-                [ATTRIBUTION_STATEMENT].join('\n'),
+              content: 'This is a general comment\n' + ATTRIBUTION_STATEMENT,
               commentType: 1,
             },
           ],
@@ -350,7 +348,7 @@ describe('AzureDevOpsCodeReviewService', () => {
           comments: [
             {
               parentCommentId: 0,
-              content: 'Fix this line\n' + [ATTRIBUTION_STATEMENT].join('\n'),
+              content: 'Fix this line\n' + ATTRIBUTION_STATEMENT,
               commentType: 1,
             },
           ],

--- a/src/main/infrastructure/azure/__tests__/azureDevOpsService.test.ts
+++ b/src/main/infrastructure/azure/__tests__/azureDevOpsService.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { AzureDevOpsService } from '../azureDevOpsService';
+import { ATTRIBUTION_STATEMENT } from '../../constants';
 
 const mockWitApi = {
   getWorkItem: vi.fn(),
@@ -85,7 +86,9 @@ describe('AzureDevOpsService', () => {
           {
             op: 'add',
             path: '/fields/System.History',
-            value: 'This is a test comment',
+            value: ['This is a test comment', '', ATTRIBUTION_STATEMENT].join(
+              '\n',
+            ),
           },
           {
             op: 'add',
@@ -129,7 +132,11 @@ describe('AzureDevOpsService', () => {
           {
             op: 'add',
             path: '/fields/System.Description',
-            value: 'Need to write unit tests for Stitch services',
+            value: [
+              'Need to write unit tests for Stitch services',
+              '',
+              ATTRIBUTION_STATEMENT,
+            ].join('\n'),
           },
           {
             op: 'add',

--- a/src/main/infrastructure/azure/azureDevOpsCodeReviewService.ts
+++ b/src/main/infrastructure/azure/azureDevOpsCodeReviewService.ts
@@ -6,6 +6,7 @@ import {
 } from 'azure-devops-node-api/interfaces/GitInterfaces';
 import { CodeReviewProvider } from '../providers/CodeReviewProvider';
 import { PRMetadata } from '../../../types';
+import { ATTRIBUTION_STATEMENT } from '../constants';
 
 export class AzureDevOpsCodeReviewService implements CodeReviewProvider {
   private gitApi: IGitApi | null = null;
@@ -359,9 +360,7 @@ export class AzureDevOpsCodeReviewService implements CodeReviewProvider {
 
     const repositoryId = prDetails.repository.id;
 
-    const disclaimer = ['', '> Generated with Stitch and GitHub Copilot.'].join(
-      '\n',
-    );
+    const disclaimer = ['', ATTRIBUTION_STATEMENT].join('\n');
 
     const contentWithDisclaimer = comment.comment + disclaimer;
 

--- a/src/main/infrastructure/azure/azureDevOpsCodeReviewService.ts
+++ b/src/main/infrastructure/azure/azureDevOpsCodeReviewService.ts
@@ -359,11 +359,9 @@ export class AzureDevOpsCodeReviewService implements CodeReviewProvider {
 
     const repositoryId = prDetails.repository.id;
 
-    const disclaimer = [
-      '',
-      '> Generated with Stitch and GitHub Copilot.',
-      '> Like any AI generated content, mistakes and hallucinations can occur. Please review before relying on it.',
-    ].join('\n');
+    const disclaimer = ['', '> Generated with Stitch and GitHub Copilot.'].join(
+      '\n',
+    );
 
     const contentWithDisclaimer = comment.comment + disclaimer;
 

--- a/src/main/infrastructure/azure/azureDevOpsService.ts
+++ b/src/main/infrastructure/azure/azureDevOpsService.ts
@@ -2,6 +2,7 @@ import * as azdev from 'azure-devops-node-api';
 import { IWorkItemTrackingApi } from 'azure-devops-node-api/WorkItemTrackingApi';
 import { IssueTrackerProvider } from '../providers/IssueTrackerProvider';
 import { TicketData } from '../../../types';
+import { ATTRIBUTION_STATEMENT } from '../constants';
 
 export class AzureDevOpsService implements IssueTrackerProvider {
   private witApi: IWorkItemTrackingApi | null = null;
@@ -44,11 +45,12 @@ export class AzureDevOpsService implements IssueTrackerProvider {
 
   async addComment(ticketId: string, text: string): Promise<void> {
     const witApi = await this.getApi();
+    const commentWithAttribution = [text, '', ATTRIBUTION_STATEMENT].join('\n');
     const document = [
       {
         op: 'add',
         path: '/fields/System.History',
-        value: text,
+        value: commentWithAttribution,
       },
       {
         op: 'add',
@@ -74,12 +76,16 @@ export class AzureDevOpsService implements IssueTrackerProvider {
     const project = parentWorkItem.fields['System.TeamProject'];
     const parentUrl = parentWorkItem.url;
 
+    const descriptionWithAttribution = data.description
+      ? [data.description, '', ATTRIBUTION_STATEMENT].join('\n')
+      : ATTRIBUTION_STATEMENT;
+
     const document = [
       { op: 'add', path: '/fields/System.Title', value: data.title },
       {
         op: 'add',
         path: '/fields/System.Description',
-        value: data.description,
+        value: descriptionWithAttribution,
       },
       {
         op: 'add',

--- a/src/main/infrastructure/constants.ts
+++ b/src/main/infrastructure/constants.ts
@@ -1,0 +1,2 @@
+export const ATTRIBUTION_STATEMENT =
+  '> Generated with Stitch and GitHub Copilot.';

--- a/src/main/infrastructure/constants.ts
+++ b/src/main/infrastructure/constants.ts
@@ -1,2 +1,2 @@
 export const ATTRIBUTION_STATEMENT =
-  '> Generated with Stitch<sup>[^](https://github.com/thealternator89/stitch/)</sup> and GitHub Copilot<sup>[^](https://github.com/features/copilot)</sup>.';
+  '> Generated with Stitch<sup>[^](https://github.com/thealternator89/stitch/#readme)</sup> and GitHub Copilot<sup>[^](https://github.com/features/copilot)</sup>.';

--- a/src/main/infrastructure/constants.ts
+++ b/src/main/infrastructure/constants.ts
@@ -1,2 +1,2 @@
 export const ATTRIBUTION_STATEMENT =
-  '> Generated with Stitch and GitHub Copilot.';
+  '> Generated with Stitch<sup>[^](https://github.com/thealternator89/stitch/)</sup> and GitHub Copilot<sup>[^](https://github.com/features/copilot)</sup>.';

--- a/src/renderer/features/story-elaborator/StoryElaborator.tsx
+++ b/src/renderer/features/story-elaborator/StoryElaborator.tsx
@@ -376,10 +376,9 @@ const StoryElaborator: React.FC = () => {
     if (!planMarkdown) return;
     setIsPosting(true);
     try {
-      const disclaimer = [
-        '> Generated with Stitch and GitHub Copilot.',
-        '> Like any AI generated content, mistakes and hallucinations can occur. Please review before relying on it.',
-      ].join('\n');
+      const disclaimer = ['> Generated with Stitch and GitHub Copilot.'].join(
+        '\n',
+      );
       await window.electronAPI.addComment(
         ticketId,
         planMarkdown + '\n\n' + disclaimer,

--- a/src/renderer/features/story-elaborator/StoryElaborator.tsx
+++ b/src/renderer/features/story-elaborator/StoryElaborator.tsx
@@ -376,13 +376,7 @@ const StoryElaborator: React.FC = () => {
     if (!planMarkdown) return;
     setIsPosting(true);
     try {
-      const disclaimer = ['> Generated with Stitch and GitHub Copilot.'].join(
-        '\n',
-      );
-      await window.electronAPI.addComment(
-        ticketId,
-        planMarkdown + '\n\n' + disclaimer,
-      );
+      await window.electronAPI.addComment(ticketId, planMarkdown);
       alert('Plan added to the ticket comment successfully!');
     } catch (err: unknown) {
       console.error(err);

--- a/src/renderer/features/story-writer/StoryWriter.tsx
+++ b/src/renderer/features/story-writer/StoryWriter.tsx
@@ -276,15 +276,9 @@ const StoryWriter: React.FC = () => {
 
     setCreatingStories((prev) => ({ ...prev, [index]: true }));
     try {
-      const descriptionWithDisclaimer = [
-        story.description,
-        '',
-        '> Generated with Stitch and GitHub Copilot.',
-      ].join('\n');
-
       await window.electronAPI.createTicket(storyType, featureId, {
         title: story.title,
-        description: descriptionWithDisclaimer,
+        description: story.description,
         acceptanceCriteria: story.acceptanceCriteria,
       });
 

--- a/src/renderer/features/story-writer/StoryWriter.tsx
+++ b/src/renderer/features/story-writer/StoryWriter.tsx
@@ -280,7 +280,6 @@ const StoryWriter: React.FC = () => {
         story.description,
         '',
         '> Generated with Stitch and GitHub Copilot.',
-        '> Like any AI generated content, mistakes and hallucinations can occur. Please review before relying on it.',
       ].join('\n');
 
       await window.electronAPI.createTicket(storyType, featureId, {

--- a/src/renderer/features/test-case-writer/TestCaseWriter.tsx
+++ b/src/renderer/features/test-case-writer/TestCaseWriter.tsx
@@ -17,13 +17,7 @@ interface TestCase {
 }
 
 const generateTicketOrCommentText = (testCases: string) =>
-  [
-    'Test Cases:',
-    '',
-    testCases,
-    '',
-    '> Generated with Stitch and GitHub Copilot.',
-  ].join('\n');
+  ['Test Cases:', '', testCases].join('\n');
 
 const convertToMarkdownTable = (tcList: TestCase[]): string => {
   const activeList = tcList.filter((tc) => !tc.deleted);

--- a/src/renderer/features/test-case-writer/TestCaseWriter.tsx
+++ b/src/renderer/features/test-case-writer/TestCaseWriter.tsx
@@ -23,7 +23,6 @@ const generateTicketOrCommentText = (testCases: string) =>
     testCases,
     '',
     '> Generated with Stitch and GitHub Copilot.',
-    '> Like any AI generated content, mistakes and hallucinations can occur. Please review before relying on it.',
   ].join('\n');
 
 const convertToMarkdownTable = (tcList: TestCase[]): string => {


### PR DESCRIPTION
Resolves #153 

Replaces the previous attribution statement:

> Generated with Stitch and GitHub Copilot.
> Like any AI generated content, mistakes and hallucinations can occur. Please review before relying on it.

With a shorter one removing the explicit disclaimer - leaving the attribution as the warning. We also link to the relevant tools to enable better discovery for things like being able to find privacy and code use policies.

> Generated with Stitch<sup>[^](https://github.com/thealternator89/stitch/#readme)</sup> and GitHub Copilot<sup>[^](https://github.com/features/copilot)</sup>.

As part of this we have centralised the attribution statement rather than the previous approach where it was duplicated 4 times across the main and renderer processes. This is now solely managed and attached by the main process just before the content is posted to the appropriate platform.