### PR TITLE
feat: switch attribution statement if user edited generated content

### DIFF
--- a/src/main/features/pr-reviewer/prReviewerService.ts
+++ b/src/main/features/pr-reviewer/prReviewerService.ts
@@ -1085,6 +1085,7 @@ export class PRReviewerService {
       file?: string;
       line?: number;
       comment: string;
+      edited?: boolean;
     },
     _settings: AppSettings,
   ): Promise<void> {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -544,15 +544,18 @@ ipcMain.handle(
   },
 );
 
-ipcMain.handle('add-comment', async (event, ticketId, text) => {
+ipcMain.handle('add-comment', async (event, ticketId, text, options) => {
   const service = await getAzureService();
-  return service.addComment(ticketId, text);
+  return service.addComment(ticketId, text, options);
 });
 
-ipcMain.handle('create-ticket', async (event, type, parentTicketId, data) => {
-  const service = await getAzureService();
-  return service.createTicket(type, parentTicketId, data);
-});
+ipcMain.handle(
+  'create-ticket',
+  async (event, type, parentTicketId, data, options) => {
+    const service = await getAzureService();
+    return service.createTicket(type, parentTicketId, data, options);
+  },
+);
 
 // Keep active notifications in memory to prevent garbage collection before click/close events fire
 const activeNotifications = new Set<Notification>();

--- a/src/main/infrastructure/azure/__tests__/azureDevOpsCodeReviewService.test.ts
+++ b/src/main/infrastructure/azure/__tests__/azureDevOpsCodeReviewService.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { AzureDevOpsCodeReviewService } from '../azureDevOpsCodeReviewService';
-import { ATTRIBUTION_STATEMENT } from '../../constants';
+import {
+  ATTRIBUTION_STATEMENT_GENERATED,
+  ATTRIBUTION_STATEMENT_ASSISTED,
+} from '../../constants';
 
 const mockGetPullRequestById = vi.fn();
 const mockGetPullRequestsByProject = vi.fn();
@@ -312,7 +315,44 @@ describe('AzureDevOpsCodeReviewService', () => {
           comments: [
             {
               parentCommentId: 0,
-              content: 'This is a general comment\n' + ATTRIBUTION_STATEMENT,
+              content:
+                'This is a general comment\n' + ATTRIBUTION_STATEMENT_GENERATED,
+              commentType: 1,
+            },
+          ],
+          status: 1,
+        },
+        'mock-repo-id',
+        123,
+        'conf-proj',
+      );
+    });
+
+    it('should successfully post an assisted general comment', async () => {
+      mockGetPullRequestById.mockResolvedValue({
+        repository: { id: 'mock-repo-id' },
+      });
+      mockCreateThread.mockResolvedValue({});
+
+      await service.postPRComment(
+        '/mock/repo',
+        '123',
+        {
+          type: 'general',
+          comment: 'This is a general comment',
+          edited: true,
+        },
+        'https://dev.azure.com/conf-org/conf-proj/_git/my-repo',
+      );
+
+      expect(mockGetPullRequestById).toHaveBeenCalledWith(123);
+      expect(mockCreateThread).toHaveBeenCalledWith(
+        {
+          comments: [
+            {
+              parentCommentId: 0,
+              content:
+                'This is a general comment\n' + ATTRIBUTION_STATEMENT_ASSISTED,
               commentType: 1,
             },
           ],
@@ -348,7 +388,7 @@ describe('AzureDevOpsCodeReviewService', () => {
           comments: [
             {
               parentCommentId: 0,
-              content: 'Fix this line\n' + ATTRIBUTION_STATEMENT,
+              content: 'Fix this line\n' + ATTRIBUTION_STATEMENT_GENERATED,
               commentType: 1,
             },
           ],

--- a/src/main/infrastructure/azure/__tests__/azureDevOpsService.test.ts
+++ b/src/main/infrastructure/azure/__tests__/azureDevOpsService.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { AzureDevOpsService } from '../azureDevOpsService';
-import { ATTRIBUTION_STATEMENT } from '../../constants';
+import {
+  ATTRIBUTION_STATEMENT_GENERATED,
+  ATTRIBUTION_STATEMENT_ASSISTED,
+} from '../../constants';
 
 const mockWitApi = {
   getWorkItem: vi.fn(),
@@ -75,7 +78,7 @@ describe('AzureDevOpsService', () => {
   });
 
   describe('addComment', () => {
-    it('should update work item with history/comment comment patches', async () => {
+    it('should update work item with history/comment comment patches (generated)', async () => {
       mockWitApi.updateWorkItem.mockResolvedValueOnce({});
 
       await service.addComment('42', 'This is a test comment');
@@ -86,9 +89,40 @@ describe('AzureDevOpsService', () => {
           {
             op: 'add',
             path: '/fields/System.History',
-            value: ['This is a test comment', '', ATTRIBUTION_STATEMENT].join(
-              '\n',
-            ),
+            value: [
+              'This is a test comment',
+              '',
+              ATTRIBUTION_STATEMENT_GENERATED,
+            ].join('\n'),
+          },
+          {
+            op: 'add',
+            path: '/multilineFieldsFormat/System.History',
+            value: 'Markdown',
+          },
+        ],
+        42,
+      );
+    });
+
+    it('should update work item with history/comment comment patches (assisted)', async () => {
+      mockWitApi.updateWorkItem.mockResolvedValueOnce({});
+
+      await service.addComment('42', 'This is a test comment', {
+        edited: true,
+      });
+
+      expect(mockWitApi.updateWorkItem).toHaveBeenCalledWith(
+        undefined,
+        [
+          {
+            op: 'add',
+            path: '/fields/System.History',
+            value: [
+              'This is a test comment',
+              '',
+              ATTRIBUTION_STATEMENT_ASSISTED,
+            ].join('\n'),
           },
           {
             op: 'add',
@@ -102,7 +136,7 @@ describe('AzureDevOpsService', () => {
   });
 
   describe('createTicket', () => {
-    it('should fetch parent details and create a child ticket with reverse hierarchy link', async () => {
+    it('should fetch parent details and create a child ticket with reverse hierarchy link (generated)', async () => {
       mockWitApi.getWorkItem.mockResolvedValueOnce({
         id: 10,
         url: 'https://dev.azure.com/myorg/_apis/wit/workItems/10',
@@ -135,7 +169,78 @@ describe('AzureDevOpsService', () => {
             value: [
               'Need to write unit tests for Stitch services',
               '',
-              ATTRIBUTION_STATEMENT,
+              ATTRIBUTION_STATEMENT_GENERATED,
+            ].join('\n'),
+          },
+          {
+            op: 'add',
+            path: '/multilineFieldsFormat/System.Description',
+            value: 'Markdown',
+          },
+          {
+            op: 'add',
+            path: '/relations/-',
+            value: {
+              rel: 'System.LinkTypes.Hierarchy-Reverse',
+              url: 'https://dev.azure.com/myorg/_apis/wit/workItems/10',
+              attributes: { comment: 'Created via Stitch' },
+            },
+          },
+          {
+            op: 'add',
+            path: '/fields/Microsoft.VSTS.Common.AcceptanceCriteria',
+            value: 'Coverage should be high',
+          },
+          {
+            op: 'add',
+            path: '/multilineFieldsFormat/Microsoft.VSTS.Common.AcceptanceCriteria',
+            value: 'Markdown',
+          },
+        ],
+        'MyStitchProject',
+        'Task',
+      );
+    });
+
+    it('should fetch parent details and create a child ticket with reverse hierarchy link (assisted)', async () => {
+      mockWitApi.getWorkItem.mockResolvedValueOnce({
+        id: 10,
+        url: 'https://dev.azure.com/myorg/_apis/wit/workItems/10',
+        fields: {
+          'System.TeamProject': 'MyStitchProject',
+        },
+      });
+
+      mockWitApi.createWorkItem.mockResolvedValueOnce({});
+
+      await service.createTicket(
+        'Task',
+        '10',
+        {
+          id: '',
+          title: 'Write unit tests',
+          description: 'Need to write unit tests for Stitch services',
+          acceptanceCriteria: 'Coverage should be high',
+        },
+        { edited: true },
+      );
+
+      expect(mockWitApi.getWorkItem).toHaveBeenCalledWith(10);
+      expect(mockWitApi.createWorkItem).toHaveBeenCalledWith(
+        undefined,
+        [
+          {
+            op: 'add',
+            path: '/fields/System.Title',
+            value: 'Write unit tests',
+          },
+          {
+            op: 'add',
+            path: '/fields/System.Description',
+            value: [
+              'Need to write unit tests for Stitch services',
+              '',
+              ATTRIBUTION_STATEMENT_ASSISTED,
             ].join('\n'),
           },
           {

--- a/src/main/infrastructure/azure/azureDevOpsCodeReviewService.ts
+++ b/src/main/infrastructure/azure/azureDevOpsCodeReviewService.ts
@@ -6,7 +6,7 @@ import {
 } from 'azure-devops-node-api/interfaces/GitInterfaces';
 import { CodeReviewProvider } from '../providers/CodeReviewProvider';
 import { PRMetadata } from '../../../types';
-import { ATTRIBUTION_STATEMENT } from '../constants';
+import { getAttributionStatement } from '../constants';
 
 export class AzureDevOpsCodeReviewService implements CodeReviewProvider {
   private gitApi: IGitApi | null = null;
@@ -315,6 +315,7 @@ export class AzureDevOpsCodeReviewService implements CodeReviewProvider {
       file?: string;
       line?: number;
       comment: string;
+      edited?: boolean;
     },
     remoteUrl?: string | null,
   ): Promise<void> {
@@ -360,7 +361,7 @@ export class AzureDevOpsCodeReviewService implements CodeReviewProvider {
 
     const repositoryId = prDetails.repository.id;
 
-    const disclaimer = ['', ATTRIBUTION_STATEMENT].join('\n');
+    const disclaimer = ['', getAttributionStatement(comment.edited)].join('\n');
 
     const contentWithDisclaimer = comment.comment + disclaimer;
 

--- a/src/main/infrastructure/azure/azureDevOpsService.ts
+++ b/src/main/infrastructure/azure/azureDevOpsService.ts
@@ -2,7 +2,7 @@ import * as azdev from 'azure-devops-node-api';
 import { IWorkItemTrackingApi } from 'azure-devops-node-api/WorkItemTrackingApi';
 import { IssueTrackerProvider } from '../providers/IssueTrackerProvider';
 import { TicketData } from '../../../types';
-import { ATTRIBUTION_STATEMENT } from '../constants';
+import { getAttributionStatement } from '../constants';
 
 export class AzureDevOpsService implements IssueTrackerProvider {
   private witApi: IWorkItemTrackingApi | null = null;
@@ -43,9 +43,17 @@ export class AzureDevOpsService implements IssueTrackerProvider {
     }
   }
 
-  async addComment(ticketId: string, text: string): Promise<void> {
+  async addComment(
+    ticketId: string,
+    text: string,
+    options?: { edited?: boolean },
+  ): Promise<void> {
     const witApi = await this.getApi();
-    const commentWithAttribution = [text, '', ATTRIBUTION_STATEMENT].join('\n');
+    const commentWithAttribution = [
+      text,
+      '',
+      getAttributionStatement(options?.edited),
+    ].join('\n');
     const document = [
       {
         op: 'add',
@@ -65,6 +73,7 @@ export class AzureDevOpsService implements IssueTrackerProvider {
     type: string,
     parentTicketId: string,
     data: TicketData,
+    options?: { edited?: boolean },
   ): Promise<void> {
     const witApi = await this.getApi();
 
@@ -76,9 +85,10 @@ export class AzureDevOpsService implements IssueTrackerProvider {
     const project = parentWorkItem.fields['System.TeamProject'];
     const parentUrl = parentWorkItem.url;
 
+    const attribution = getAttributionStatement(options?.edited);
     const descriptionWithAttribution = data.description
-      ? [data.description, '', ATTRIBUTION_STATEMENT].join('\n')
-      : ATTRIBUTION_STATEMENT;
+      ? [data.description, '', attribution].join('\n')
+      : attribution;
 
     const document = [
       { op: 'add', path: '/fields/System.Title', value: data.title },

--- a/src/main/infrastructure/constants.ts
+++ b/src/main/infrastructure/constants.ts
@@ -1,7 +1,7 @@
-export const STITCH_ATTRIBUTION =
+const STITCH_ATTRIBUTION =
   'Stitch<sup>[^](https://github.com/thealternator89/stitch/#readme)</sup>';
 
-export const COPILOT_ATTRIBUTION =
+const COPILOT_ATTRIBUTION =
   'GitHub Copilot<sup>[^](https://github.com/features/copilot)</sup>';
 
 export const ATTRIBUTION_STATEMENT_GENERATED = `> Generated with ${STITCH_ATTRIBUTION} and ${COPILOT_ATTRIBUTION}.`;

--- a/src/main/infrastructure/constants.ts
+++ b/src/main/infrastructure/constants.ts
@@ -1,8 +1,12 @@
-export const ATTRIBUTION_STATEMENT_GENERATED =
-  '> Generated with Stitch<sup>[^](https://github.com/thealternator89/stitch/#readme)</sup> and GitHub Copilot<sup>[^](https://github.com/features/copilot)</sup>.';
+export const STITCH_ATTRIBUTION =
+  'Stitch<sup>[^](https://github.com/thealternator89/stitch/#readme)</sup>';
 
-export const ATTRIBUTION_STATEMENT_ASSISTED =
-  '> Assisted by Stitch<sup>[^](https://github.com/thealternator89/stitch/#readme)</sup> and GitHub Copilot<sup>[^](https://github.com/features/copilot)</sup>.';
+export const COPILOT_ATTRIBUTION =
+  'GitHub Copilot<sup>[^](https://github.com/features/copilot)</sup>';
+
+export const ATTRIBUTION_STATEMENT_GENERATED = `> Generated with ${STITCH_ATTRIBUTION} and ${COPILOT_ATTRIBUTION}.`;
+
+export const ATTRIBUTION_STATEMENT_ASSISTED = `> Assisted by ${STITCH_ATTRIBUTION} and ${COPILOT_ATTRIBUTION}.`;
 
 export const getAttributionStatement = (edited?: boolean): string => {
   return edited

--- a/src/main/infrastructure/constants.ts
+++ b/src/main/infrastructure/constants.ts
@@ -1,2 +1,11 @@
-export const ATTRIBUTION_STATEMENT =
+export const ATTRIBUTION_STATEMENT_GENERATED =
   '> Generated with Stitch<sup>[^](https://github.com/thealternator89/stitch/#readme)</sup> and GitHub Copilot<sup>[^](https://github.com/features/copilot)</sup>.';
+
+export const ATTRIBUTION_STATEMENT_ASSISTED =
+  '> Assisted by Stitch<sup>[^](https://github.com/thealternator89/stitch/#readme)</sup> and GitHub Copilot<sup>[^](https://github.com/features/copilot)</sup>.';
+
+export const getAttributionStatement = (edited?: boolean): string => {
+  return edited
+    ? ATTRIBUTION_STATEMENT_ASSISTED
+    : ATTRIBUTION_STATEMENT_GENERATED;
+};

--- a/src/main/infrastructure/providers/CodeReviewProvider.ts
+++ b/src/main/infrastructure/providers/CodeReviewProvider.ts
@@ -34,6 +34,7 @@ export interface CodeReviewProvider {
       file?: string;
       line?: number;
       comment: string;
+      edited?: boolean;
     },
     remoteUrl?: string | null,
   ): Promise<void>;

--- a/src/main/infrastructure/providers/IssueTrackerProvider.ts
+++ b/src/main/infrastructure/providers/IssueTrackerProvider.ts
@@ -2,11 +2,16 @@ import { TicketData } from '../../../types';
 
 export interface IssueTrackerProvider {
   fetchTicket(ticketId: string): Promise<TicketData>;
-  addComment(ticketId: string, text: string): Promise<void>;
+  addComment(
+    ticketId: string,
+    text: string,
+    options?: { edited?: boolean },
+  ): Promise<void>;
   createTicket(
     type: string,
     parentTicketId: string,
     data: TicketData,
+    options?: { edited?: boolean },
   ): Promise<void>;
   searchTickets(query: string, type?: string): Promise<TicketData[]>;
   getWorkItemTypes?(project: string): Promise<string[]>;

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -51,10 +51,17 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.removeListener('story-line', listener);
     };
   },
-  addComment: (ticketId: string, text: string) =>
-    ipcRenderer.invoke('add-comment', ticketId, text),
-  createTicket: (type: string, parentTicketId: string, data: TicketData) =>
-    ipcRenderer.invoke('create-ticket', type, parentTicketId, data),
+  addComment: (
+    ticketId: string,
+    text: string,
+    options?: { edited?: boolean },
+  ) => ipcRenderer.invoke('add-comment', ticketId, text, options),
+  createTicket: (
+    type: string,
+    parentTicketId: string,
+    data: TicketData,
+    options?: { edited?: boolean },
+  ) => ipcRenderer.invoke('create-ticket', type, parentTicketId, data, options),
   checkCopilotAuth: () => ipcRenderer.invoke('check-copilot-auth'),
   checkEnvironment: () => ipcRenderer.invoke('check-environment'),
   installCopilotCli: () => ipcRenderer.invoke('install-copilot-cli'),
@@ -187,6 +194,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
       file?: string;
       line?: number;
       comment: string;
+      edited?: boolean;
     },
   ): Promise<void> =>
     ipcRenderer.invoke(

--- a/src/renderer/features/pr-reviewer/PRReviewer.tsx
+++ b/src/renderer/features/pr-reviewer/PRReviewer.tsx
@@ -466,11 +466,15 @@ const PRReviewer: React.FC = () => {
       const commentText =
         updatedText !== undefined ? updatedText : comment.comment;
 
+      const isEdited =
+        updatedText !== undefined && updatedText !== comment.comment;
+
       await window.electronAPI.postPRComment(repoPath, prIdentifier, {
         type: comment.type,
         file: comment.file,
         line: comment.line,
         comment: commentText,
+        edited: isEdited,
       });
 
       // Mark as posted

--- a/src/renderer/features/test-case-writer/TestCaseWriter.tsx
+++ b/src/renderer/features/test-case-writer/TestCaseWriter.tsx
@@ -88,6 +88,7 @@ const TestCaseWriter: React.FC = () => {
   const [testCasesList, setTestCasesList] = useState<TestCase[]>([]);
   const [error, setError] = useState<string>('');
   const [isPosting, setIsPosting] = useState(false);
+  const [testCasesModified, setTestCasesModified] = useState(false);
 
   // Reordering states
   const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
@@ -97,12 +98,14 @@ const TestCaseWriter: React.FC = () => {
     setTestCasesList((prev) =>
       prev.map((tc, idx) => (idx === index ? { ...tc, deleted: true } : tc)),
     );
+    setTestCasesModified(true);
   };
 
   const handleRestore = (index: number) => {
     setTestCasesList((prev) =>
       prev.map((tc, idx) => (idx === index ? { ...tc, deleted: false } : tc)),
     );
+    setTestCasesModified(true);
   };
 
   const searchContainerRef = useRef<HTMLDivElement>(null);
@@ -164,7 +167,9 @@ const TestCaseWriter: React.FC = () => {
     try {
       const mdTable = convertToMarkdownTable(testCasesList);
       const text = generateTicketOrCommentText(mdTable);
-      await window.electronAPI.addComment(ticketId, text);
+      await window.electronAPI.addComment(ticketId, text, {
+        edited: testCasesModified,
+      });
       alert('Comment added successfully!');
     } catch (err: unknown) {
       console.error(err);
@@ -182,10 +187,17 @@ const TestCaseWriter: React.FC = () => {
     try {
       const mdTable = convertToMarkdownTable(testCasesList);
       const text = generateTicketOrCommentText(mdTable);
-      await window.electronAPI.createTicket(taskType, ticketId, {
-        title: testTaskTitle,
-        description: text,
-      });
+      await window.electronAPI.createTicket(
+        taskType,
+        ticketId,
+        {
+          title: testTaskTitle,
+          description: text,
+        },
+        {
+          edited: testCasesModified,
+        },
+      );
       alert('Task created successfully!');
     } catch (err: unknown) {
       console.error(err);
@@ -216,6 +228,7 @@ const TestCaseWriter: React.FC = () => {
     setGenerationStarted(true);
     setTestCasesList([]);
     setTicketData(null);
+    setTestCasesModified(false);
 
     // Set up real-time listener for incoming lines
     const unsubscribe = window.electronAPI.onTestCaseLine((line: string) => {
@@ -644,6 +657,7 @@ const TestCaseWriter: React.FC = () => {
                                 );
 
                                 setTestCasesList(reorderedList);
+                                setTestCasesModified(true);
                                 setDraggedIndex(null);
                                 setDragOverIndex(null);
                               }}

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -37,11 +37,16 @@ export interface IElectronAPI {
     modelOverride: string,
   ) => Promise<CopilotResult<string>>;
   onStoryLine: (callback: (line: string) => void) => () => void;
-  addComment: (ticketId: string, text: string) => Promise<void>;
+  addComment: (
+    ticketId: string,
+    text: string,
+    options?: { edited?: boolean },
+  ) => Promise<void>;
   createTicket: (
     type: string,
     parentTicketId: string,
     data: TicketData,
+    options?: { edited?: boolean },
   ) => Promise<void>;
 
   checkCopilotAuth: () => Promise<CopilotAuth>;
@@ -120,6 +125,7 @@ export interface IElectronAPI {
       file?: string;
       line?: number;
       comment: string;
+      edited?: boolean;
     },
   ) => Promise<void>;
   showNotification: (title: string, body: string) => Promise<void>;


### PR DESCRIPTION
Currently everything posted from Stitch has a fixed attribution statement attached at the bottom;

> Generated with Stitch and GitHub Copilot.

However with #120 and #132 we have allowed users to modify the AI's output before posting. So this attribution is possibly misleading - it devalues the user's input and doesn't allow readers to know that a human has performed some validation on the content.

This PR automatically switches to a slightly different wording to more accurately represent where the content has come from:

> Assisted by Stitch and GitHub Copilot.

We considered just removing the attribution statement in this case, however we decided that if we do that, it's relatively trivial (even if we built a complex detector) to modify the content in a way which is considered edited, which could be used by people to hide their AI usage from colleagues. This ensures AI provenance is still recorded while recognising the human's input too.