### PR TITLE
feat: custom review phase models

### DIFF
--- a/docs/pr-reviewer/phases.md
+++ b/docs/pr-reviewer/phases.md
@@ -45,6 +45,7 @@ Stitch:
 | `group`    | `string`   | Categorizes the phase under a group in the UI.                                                            | `"Ungrouped"`                                |
 | `include`  | `string`   | Glob pattern (parsed by `picomatch`) specifying which files must be in the PR diff for this phase to run. | None (runs on all files)                     |
 | `exclude`  | `string`   | Glob pattern specifying files that should be ignored during this phase.                                   | None                                         |
+| `model`    | `string`   | Model key override (e.g., `gpt-4o`, `gemini-1.5-flash`) to execute this specific phase with.              | None (uses review-level default model)       |
 | `attach`   | `string[]` | List of data sources to attach to the prompt context. Supported: `["description"]` or `["story"]`.        | None                                         |
 | `template` | `string`   | The filename of a template inside `~/.stitch/pr-reviewer/templates/` to wrap this phase's guidelines.     | None                                         |
 
@@ -63,6 +64,15 @@ migration rules on frontend React code).
 
 If no files in the PR match the `include` glob (or if all matching files are
 filtered out by the `exclude` glob), the phase will be skipped entirely.
+
+---
+
+## Phase Model Overrides (`model`)
+
+By default, all phases are executed using the default model configured for the review. If a specific phase requires a different model (for instance, a more capable model for complex logical validation, or a faster/cheaper model for simple style checks), you can override it using the `model` frontmatter property.
+
+- **Available Models**: The model key specified must be currently available. You can view all available model keys at the bottom of the **GitHub Copilot** settings page.
+- **Handling Unavailable Models**: If a model is not found in the list of available models, Stitch will display a danger badge indicating `"Model not available"` on that phase in the UI. The checkbox for that phase will be unchecked and disabled, and the phase will be excluded from the review run.
 
 ---
 

--- a/src/main/features/pr-reviewer/__tests__/prReviewerService.test.ts
+++ b/src/main/features/pr-reviewer/__tests__/prReviewerService.test.ts
@@ -756,6 +756,45 @@ describe('PRReviewerService', () => {
       );
       expect(mockCopilotService.createClientAndSession).not.toHaveBeenCalled();
     });
+
+    it('should use model override configured on phase rather than review-wide modelOverride', async () => {
+      vi.spyOn(prReviewerService, 'loadPhasesFromDisk').mockResolvedValue([
+        {
+          id: '020-phase-with-model.md',
+          title: 'Custom Model Phase',
+          body: 'Custom model guidelines',
+          model: 'gemini-2.0-flash',
+        },
+      ]);
+
+      const mockFiles = [{ path: 'src/index.ts', status: 'modified' }];
+      mockGitService.getDiffFiles.mockResolvedValue(mockFiles);
+
+      const mockSession = {
+        disconnect: vi.fn().mockResolvedValue(undefined),
+      };
+      const mockClient = {
+        stop: vi.fn().mockResolvedValue(undefined),
+      };
+      mockCopilotService.createClientAndSession.mockResolvedValue({
+        client: mockClient,
+        session: mockSession,
+      });
+      mockCopilotService.sendAndCollectStream.mockResolvedValue(
+        '{"type":"general","comment":"LGTM"}',
+      );
+
+      await prReviewerService.reviewPR('/mock/repo', 'main', settings, {
+        modelOverride: 'gpt-4',
+        enabledPhaseIds: ['020-phase-with-model.md'],
+      });
+
+      expect(mockCopilotService.createClientAndSession).toHaveBeenCalledWith(
+        'mock-token',
+        'gemini-2.0-flash',
+        { workingDirectory: '/mock/repo' },
+      );
+    });
   });
 
   describe('extractFileContextSync', () => {
@@ -1259,6 +1298,25 @@ describe('PRReviewerService', () => {
       expect(result[3].id).toBe('030-python.md');
 
       expect(consoleErrorSpy).toHaveBeenCalled();
+    });
+
+    it('should load phase and extract Model frontmatter if specified', async () => {
+      vi.spyOn(fs, 'existsSync').mockImplementation((filePath: any) => {
+        return !filePath.toString().endsWith('config.json');
+      });
+      vi.spyOn(fs, 'readdirSync').mockReturnValue([
+        '010-model-override.md',
+      ] as any);
+
+      vi.spyOn(fs, 'readFileSync').mockImplementation(() => {
+        return '---\ntitle: Model Override Phase\nmodel: gpt-4o\n---\nSome body';
+      });
+
+      const result = await prReviewerService.loadPhasesFromDisk();
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('010-model-override.md');
+      expect(result[0].model).toBe('gpt-4o');
     });
   });
 

--- a/src/main/features/pr-reviewer/prReviewerService.ts
+++ b/src/main/features/pr-reviewer/prReviewerService.ts
@@ -291,6 +291,9 @@ export class PRReviewerService {
           const attach = Array.isArray(parsed.frontmatter.attach)
             ? parsed.frontmatter.attach[0]
             : parsed.frontmatter.attach;
+          const model = Array.isArray(parsed.frontmatter.model)
+            ? parsed.frontmatter.model[0]
+            : parsed.frontmatter.model;
 
           phases.push({
             id: file,
@@ -302,6 +305,7 @@ export class PRReviewerService {
             body,
             template: templateName,
             templateError,
+            model: model ? String(model) : undefined,
           });
         } catch (err) {
           console.error(`Failed to read/parse phase file ${file}:`, err);
@@ -908,7 +912,7 @@ export class PRReviewerService {
           try {
             clientAndSession = await this.copilotService.createClientAndSession(
               settings.copilotToken,
-              options.modelOverride,
+              phase.model || options.modelOverride,
               sessionOpts,
             );
           } catch (err) {

--- a/src/renderer/features/pr-reviewer/PRReviewer.tsx
+++ b/src/renderer/features/pr-reviewer/PRReviewer.tsx
@@ -75,6 +75,14 @@ const PRReviewer: React.FC = () => {
   const [phases, setPhases] = useState<LocalReviewPhase[]>([]);
   const [isLoadingPhases, setIsLoadingPhases] = useState(false);
 
+  const checkIsModelMissing = (phase: ReviewPhase) => {
+    if (!phase.model) return false;
+    return (
+      !loadingModels &&
+      !models.some((m) => m.id.toLowerCase() === phase.model!.toLowerCase())
+    );
+  };
+
   const groupedPhases = useMemo(() => {
     const groups: {
       name: string;
@@ -96,7 +104,11 @@ const PRReviewer: React.FC = () => {
     setPhases((prev) =>
       prev.map((p) => {
         if ((p.group || 'Ungrouped') === groupName) {
-          return { ...p, enabled: checked };
+          const modelMissing =
+            p.model &&
+            !loadingModels &&
+            !models.some((m) => m.id.toLowerCase() === p.model!.toLowerCase());
+          return { ...p, enabled: modelMissing ? false : checked };
         }
         return p;
       }),
@@ -106,9 +118,14 @@ const PRReviewer: React.FC = () => {
   const togglePhase = (originalIndex: number, checked: boolean) => {
     setPhases((prev) => {
       const copy = [...prev];
+      const p = copy[originalIndex];
+      const modelMissing =
+        p.model &&
+        !loadingModels &&
+        !models.some((m) => m.id.toLowerCase() === p.model!.toLowerCase());
       copy[originalIndex] = {
-        ...copy[originalIndex],
-        enabled: checked,
+        ...p,
+        enabled: modelMissing ? false : checked,
       };
       return copy;
     });
@@ -157,6 +174,33 @@ const PRReviewer: React.FC = () => {
     loadPhases();
     loadParallelismSettings();
   }, []);
+
+  useEffect(() => {
+    if (loadingModels || models.length === 0 || phases.length === 0) return;
+    const hasAnyMissing = phases.some((p) => {
+      if (!p.model) return false;
+      const hasModel = models.some(
+        (m) => m.id.toLowerCase() === p.model!.toLowerCase(),
+      );
+      return !hasModel && p.enabled;
+    });
+
+    if (hasAnyMissing) {
+      setPhases((prev) =>
+        prev.map((p) => {
+          if (p.model) {
+            const hasModel = models.some(
+              (m) => m.id.toLowerCase() === p.model!.toLowerCase(),
+            );
+            if (!hasModel && p.enabled) {
+              return { ...p, enabled: false };
+            }
+          }
+          return p;
+        }),
+      );
+    }
+  }, [models, loadingModels, phases]);
 
   const loadParallelismSettings = async () => {
     try {
@@ -813,11 +857,14 @@ const PRReviewer: React.FC = () => {
                           style={{ maxHeight: '250px', overflowY: 'auto' }}
                         >
                           {groupedPhases.map((group) => {
-                            const allChecked = group.phases.every(
-                              (p) => p.phase.enabled,
+                            const selectablePhases = group.phases.filter(
+                              (p) => !checkIsModelMissing(p.phase),
                             );
+                            const allChecked =
+                              selectablePhases.length > 0 &&
+                              selectablePhases.every((p) => p.phase.enabled);
                             const someChecked =
-                              group.phases.some((p) => p.phase.enabled) &&
+                              selectablePhases.some((p) => p.phase.enabled) &&
                               !allChecked;
 
                             return (
@@ -828,6 +875,7 @@ const PRReviewer: React.FC = () => {
                                     type="checkbox"
                                     id={`group-check-${group.name}`}
                                     checked={allChecked}
+                                    disabled={selectablePhases.length === 0}
                                     ref={(el) => {
                                       if (el) {
                                         el.indeterminate = someChecked;
@@ -846,43 +894,78 @@ const PRReviewer: React.FC = () => {
                                 </div>
                                 <div className="ms-4 border-start ps-3 py-1">
                                   {group.phases.map(
-                                    ({ phase, originalIndex }) => (
-                                      <div
-                                        key={phase.id}
-                                        className="form-check mb-1"
-                                      >
-                                        <input
-                                          className="form-check-input"
-                                          type="checkbox"
-                                          id={`phase-check-${phase.id}`}
-                                          checked={phase.enabled}
-                                          onChange={(e) =>
-                                            togglePhase(
-                                              originalIndex,
-                                              e.target.checked,
-                                            )
-                                          }
-                                        />
-                                        <label
-                                          className="form-check-label small text-body-secondary"
-                                          htmlFor={`phase-check-${phase.id}`}
+                                    ({ phase, originalIndex }) => {
+                                      const modelMissing =
+                                        checkIsModelMissing(phase);
+                                      const phaseModel = phase.model;
+                                      const matchedModel = phaseModel
+                                        ? models.find(
+                                            (m) =>
+                                              m.id.toLowerCase() ===
+                                              phaseModel.toLowerCase(),
+                                          )
+                                        : null;
+
+                                      return (
+                                        <div
+                                          key={phase.id}
+                                          className="form-check mb-1"
                                         >
-                                          {phase.title}{' '}
-                                          <span className="text-muted font-monospace tiny-text ms-1">
-                                            ({phase.id})
-                                          </span>
-                                          {phase.templateError && (
-                                            <span
-                                              className="text-danger ms-2"
-                                              title={phase.templateError}
-                                              style={{ cursor: 'help' }}
-                                            >
-                                              <i className="fas fa-exclamation-circle"></i>
+                                          <input
+                                            className="form-check-input"
+                                            type="checkbox"
+                                            id={`phase-check-${phase.id}`}
+                                            checked={
+                                              !modelMissing && phase.enabled
+                                            }
+                                            disabled={modelMissing}
+                                            onChange={(e) =>
+                                              togglePhase(
+                                                originalIndex,
+                                                e.target.checked,
+                                              )
+                                            }
+                                          />
+                                          <label
+                                            className={`form-check-label small text-body-secondary ${
+                                              modelMissing
+                                                ? 'text-muted opacity-50'
+                                                : ''
+                                            }`}
+                                            htmlFor={`phase-check-${phase.id}`}
+                                          >
+                                            {phase.title}{' '}
+                                            <span className="text-muted font-monospace tiny-text ms-1">
+                                              ({phase.id})
                                             </span>
-                                          )}
-                                        </label>
-                                      </div>
-                                    ),
+                                            {phase.templateError && (
+                                              <span
+                                                className="text-danger ms-2"
+                                                title={phase.templateError}
+                                                style={{ cursor: 'help' }}
+                                              >
+                                                <i className="fas fa-exclamation-circle"></i>
+                                              </span>
+                                            )}
+                                            {phaseModel && matchedModel && (
+                                              <span className="badge bg-secondary-subtle text-secondary-emphasis ms-2 font-monospace small">
+                                                {matchedModel.name}
+                                              </span>
+                                            )}
+                                            {phaseModel && modelMissing && (
+                                              <span
+                                                className="badge bg-danger-subtle text-danger border border-danger-subtle ms-2 font-monospace small"
+                                                title="Model not available"
+                                                style={{ cursor: 'help' }}
+                                              >
+                                                <i className="fas fa-times me-1"></i>
+                                                {phaseModel}
+                                              </span>
+                                            )}
+                                          </label>
+                                        </div>
+                                      );
+                                    },
                                   )}
                                 </div>
                               </div>

--- a/src/renderer/features/settings/components/CopilotSettings.tsx
+++ b/src/renderer/features/settings/components/CopilotSettings.tsx
@@ -137,7 +137,7 @@ const CopilotSettings: React.FC<CopilotSettingsProps> = ({
                   <tr>
                     <th>Model Name</th>
                     <th>Key</th>
-                    <th style={{ width: '130px' }}>Action</th>
+                    <th style={{ width: '130px' }}></th>
                   </tr>
                 </thead>
                 <tbody>

--- a/src/renderer/features/settings/components/CopilotSettings.tsx
+++ b/src/renderer/features/settings/components/CopilotSettings.tsx
@@ -143,7 +143,14 @@ const CopilotSettings: React.FC<CopilotSettingsProps> = ({
                 <tbody>
                   {models.map((model) => (
                     <tr key={model.id}>
-                      <td className="fw-semibold text-body">{model.name}</td>
+                      <td className="fw-semibold text-body">
+                        {model.name}
+                        {selectedModel === model.id && (
+                          <span className="badge bg-success-subtle text-success border border-success-subtle ms-2 py-1 px-2 fw-semibold">
+                            <i className="fas fa-check-circle me-1"></i>Default
+                          </span>
+                        )}
+                      </td>
                       <td>
                         <code className="text-muted font-monospace">
                           {model.id}
@@ -168,12 +175,7 @@ const CopilotSettings: React.FC<CopilotSettingsProps> = ({
                               </>
                             )}
                           </button>
-                          {selectedModel === model.id ? (
-                            <span className="badge bg-success-subtle text-success border border-success-subtle py-1.5 px-2 d-flex align-items-center gap-1 fw-semibold">
-                              <i className="fas fa-check-circle"></i>
-                              <span>Default</span>
-                            </span>
-                          ) : (
+                          {selectedModel !== model.id && (
                             <button
                               type="button"
                               className="btn btn-sm btn-outline-primary py-1 px-2 d-flex align-items-center gap-1"

--- a/src/renderer/features/settings/components/CopilotSettings.tsx
+++ b/src/renderer/features/settings/components/CopilotSettings.tsx
@@ -137,7 +137,7 @@ const CopilotSettings: React.FC<CopilotSettingsProps> = ({
                   <tr>
                     <th>Model Name</th>
                     <th>Key</th>
-                    <th style={{ width: '240px' }}>Actions</th>
+                    <th style={{ width: '130px' }}>Action</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -152,40 +152,40 @@ const CopilotSettings: React.FC<CopilotSettingsProps> = ({
                         )}
                       </td>
                       <td>
-                        <code className="text-muted font-monospace">
-                          {model.id}
-                        </code>
-                      </td>
-                      <td>
                         <div className="d-flex align-items-center gap-2">
+                          <code className="text-muted font-monospace">
+                            {model.id}
+                          </code>
                           <button
                             type="button"
-                            className="btn btn-sm btn-outline-secondary py-1 px-2 d-flex align-items-center gap-1"
+                            className="btn btn-link btn-sm p-0 text-secondary d-flex align-items-center"
                             onClick={() => handleCopy(model.id)}
+                            title={
+                              copiedModelId === model.id
+                                ? 'Copied!'
+                                : 'Copy model key'
+                            }
+                            style={{ textDecoration: 'none' }}
                           >
                             {copiedModelId === model.id ? (
-                              <>
-                                <i className="fas fa-check text-success"></i>
-                                <span>Copied</span>
-                              </>
+                              <i className="fas fa-check text-success"></i>
                             ) : (
-                              <>
-                                <i className="fas fa-copy"></i>
-                                <span>Copy</span>
-                              </>
+                              <i className="fas fa-copy"></i>
                             )}
                           </button>
-                          {selectedModel !== model.id && (
-                            <button
-                              type="button"
-                              className="btn btn-sm btn-outline-primary py-1 px-2 d-flex align-items-center gap-1"
-                              onClick={() => setSelectedModel(model.id)}
-                            >
-                              <i className="fas fa-star"></i>
-                              <span>Set Default</span>
-                            </button>
-                          )}
                         </div>
+                      </td>
+                      <td>
+                        {selectedModel !== model.id && (
+                          <button
+                            type="button"
+                            className="btn btn-sm btn-outline-primary py-1 px-2 d-flex align-items-center gap-1"
+                            onClick={() => setSelectedModel(model.id)}
+                          >
+                            <i className="fas fa-star"></i>
+                            <span>Set Default</span>
+                          </button>
+                        )}
                       </td>
                     </tr>
                   ))}

--- a/src/renderer/features/settings/components/CopilotSettings.tsx
+++ b/src/renderer/features/settings/components/CopilotSettings.tsx
@@ -25,6 +25,16 @@ const CopilotSettings: React.FC<CopilotSettingsProps> = ({
   checkingAuth,
   handleCheckAuth,
 }) => {
+  const [copiedModelId, setCopiedModelId] = React.useState<string | null>(null);
+
+  const handleCopy = (id: string) => {
+    navigator.clipboard.writeText(id);
+    setCopiedModelId(id);
+    setTimeout(() => {
+      setCopiedModelId(null);
+    }, 1500);
+  };
+
   return (
     <div className="card shadow-sm border-0 bg-body-tertiary">
       <div className="card-body p-4">
@@ -138,6 +148,62 @@ const CopilotSettings: React.FC<CopilotSettingsProps> = ({
             </div>
           )}
         </div>
+
+        {models.length > 0 && (
+          <div className="mt-4 border-top pt-4">
+            <h6 className="mb-3 fw-semibold">
+              <i className="fas fa-list me-2 text-primary"></i>Available Model
+              Keys
+            </h6>
+            <div className="table-responsive border rounded bg-body">
+              <table className="table table-hover align-middle mb-0 small">
+                <thead className="table-light">
+                  <tr>
+                    <th>Model Name</th>
+                    <th>Key</th>
+                    <th style={{ width: '120px' }}>Action</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {models.map((model) => (
+                    <tr key={model.id}>
+                      <td className="fw-semibold text-body">{model.name}</td>
+                      <td>
+                        <code className="text-muted font-monospace">
+                          {model.id}
+                        </code>
+                      </td>
+                      <td>
+                        <button
+                          type="button"
+                          className="btn btn-sm btn-outline-secondary py-1 px-2 d-flex align-items-center gap-1"
+                          onClick={() => handleCopy(model.id)}
+                        >
+                          {copiedModelId === model.id ? (
+                            <>
+                              <i className="fas fa-check text-success"></i>
+                              <span>Copied</span>
+                            </>
+                          ) : (
+                            <>
+                              <i className="fas fa-copy"></i>
+                              <span>Copy</span>
+                            </>
+                          )}
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <div className="form-text mt-2">
+              Use these keys in your phase markdown files under the{' '}
+              <code>model</code> frontmatter property to override the model for
+              specific review phases.
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/renderer/features/settings/components/CopilotSettings.tsx
+++ b/src/renderer/features/settings/components/CopilotSettings.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import ModelDropdown from '../../../components/ModelDropdown';
 import { CopilotAuth, CopilotModel } from '../../../../types';
 
 interface CopilotSettingsProps {
@@ -8,7 +7,6 @@ interface CopilotSettingsProps {
   models: CopilotModel[];
   selectedModel: string;
   setSelectedModel: (val: string) => void;
-  loadingModels: boolean;
   authStatus: CopilotAuth | null;
   checkingAuth: boolean;
   handleCheckAuth: () => void;
@@ -20,7 +18,6 @@ const CopilotSettings: React.FC<CopilotSettingsProps> = ({
   models,
   selectedModel,
   setSelectedModel,
-  loadingModels,
   authStatus,
   checkingAuth,
   handleCheckAuth,
@@ -54,21 +51,6 @@ const CopilotSettings: React.FC<CopilotSettingsProps> = ({
           />
           <div className="form-text">
             Your Copilot session or API token for authentication.
-          </div>
-        </div>
-
-        <div className="mb-4">
-          <label className="form-label fw-semibold">Default Model</label>
-          <ModelDropdown
-            models={models}
-            selectedModel={selectedModel}
-            onSelect={setSelectedModel}
-            loading={loadingModels}
-            className="w-50"
-            buttonVariant="outline-secondary"
-          />
-          <div className="form-text mt-1">
-            Choose the language model used by Copilot for text generation tasks.
           </div>
         </div>
 
@@ -147,8 +129,7 @@ const CopilotSettings: React.FC<CopilotSettingsProps> = ({
         {models.length > 0 && (
           <div className="mt-4 border-top pt-4">
             <h6 className="mb-3 fw-semibold">
-              <i className="fas fa-list me-2 text-primary"></i>Available Model
-              Keys
+              <i className="fas fa-list me-2 text-primary"></i>Available Models
             </h6>
             <div className="table-responsive border rounded bg-body">
               <table className="table table-hover align-middle mb-0 small">
@@ -156,7 +137,7 @@ const CopilotSettings: React.FC<CopilotSettingsProps> = ({
                   <tr>
                     <th>Model Name</th>
                     <th>Key</th>
-                    <th style={{ width: '120px' }}>Action</th>
+                    <th style={{ width: '240px' }}>Actions</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -169,23 +150,40 @@ const CopilotSettings: React.FC<CopilotSettingsProps> = ({
                         </code>
                       </td>
                       <td>
-                        <button
-                          type="button"
-                          className="btn btn-sm btn-outline-secondary py-1 px-2 d-flex align-items-center gap-1"
-                          onClick={() => handleCopy(model.id)}
-                        >
-                          {copiedModelId === model.id ? (
-                            <>
-                              <i className="fas fa-check text-success"></i>
-                              <span>Copied</span>
-                            </>
+                        <div className="d-flex align-items-center gap-2">
+                          <button
+                            type="button"
+                            className="btn btn-sm btn-outline-secondary py-1 px-2 d-flex align-items-center gap-1"
+                            onClick={() => handleCopy(model.id)}
+                          >
+                            {copiedModelId === model.id ? (
+                              <>
+                                <i className="fas fa-check text-success"></i>
+                                <span>Copied</span>
+                              </>
+                            ) : (
+                              <>
+                                <i className="fas fa-copy"></i>
+                                <span>Copy</span>
+                              </>
+                            )}
+                          </button>
+                          {selectedModel === model.id ? (
+                            <span className="badge bg-success-subtle text-success border border-success-subtle py-1.5 px-2 d-flex align-items-center gap-1 fw-semibold">
+                              <i className="fas fa-check-circle"></i>
+                              <span>Default</span>
+                            </span>
                           ) : (
-                            <>
-                              <i className="fas fa-copy"></i>
-                              <span>Copy</span>
-                            </>
+                            <button
+                              type="button"
+                              className="btn btn-sm btn-outline-primary py-1 px-2 d-flex align-items-center gap-1"
+                              onClick={() => setSelectedModel(model.id)}
+                            >
+                              <i className="fas fa-star"></i>
+                              <span>Set Default</span>
+                            </button>
                           )}
-                        </button>
+                        </div>
                       </td>
                     </tr>
                   ))}

--- a/src/renderer/features/settings/components/CopilotSettings.tsx
+++ b/src/renderer/features/settings/components/CopilotSettings.tsx
@@ -143,14 +143,7 @@ const CopilotSettings: React.FC<CopilotSettingsProps> = ({
                 <tbody>
                   {models.map((model) => (
                     <tr key={model.id}>
-                      <td className="fw-semibold text-body">
-                        {model.name}
-                        {selectedModel === model.id && (
-                          <span className="badge bg-success-subtle text-success border border-success-subtle ms-2 py-1 px-2 fw-semibold">
-                            <i className="fas fa-check-circle me-1"></i>Default
-                          </span>
-                        )}
-                      </td>
+                      <td className="fw-semibold text-body">{model.name}</td>
                       <td>
                         <div className="d-flex align-items-center gap-2">
                           <code className="text-muted font-monospace">
@@ -176,7 +169,11 @@ const CopilotSettings: React.FC<CopilotSettingsProps> = ({
                         </div>
                       </td>
                       <td>
-                        {selectedModel !== model.id && (
+                        {selectedModel === model.id ? (
+                          <span className="badge bg-success-subtle text-success border border-success-subtle py-1.5 px-2 fw-semibold">
+                            <i className="fas fa-check-circle me-1"></i>Default
+                          </span>
+                        ) : (
                           <button
                             type="button"
                             className="btn btn-sm btn-outline-primary py-1 px-2 d-flex align-items-center gap-1"

--- a/src/renderer/features/settings/components/CopilotSettings.tsx
+++ b/src/renderer/features/settings/components/CopilotSettings.tsx
@@ -43,11 +43,6 @@ const CopilotSettings: React.FC<CopilotSettingsProps> = ({
           Configuration
         </h5>
 
-        <p className="text-muted small mb-4">
-          Configure integration with GitHub Copilot API to enable automated test
-          case and story writing.
-        </p>
-
         <div className="mb-3">
           <label className="form-label fw-semibold">Copilot API Token</label>
           <input

--- a/src/renderer/features/settings/components/Settings.tsx
+++ b/src/renderer/features/settings/components/Settings.tsx
@@ -32,8 +32,7 @@ const Settings: React.FC = () => {
   const [statusMessage, setStatusMessage] = useState('');
   const [authStatus, setAuthStatus] = useState<CopilotAuth | null>(null);
   const [checkingAuth, setCheckingAuth] = useState(false);
-  const { models, selectedModel, setSelectedModel, loadingModels } =
-    useCopilotModels();
+  const { models, selectedModel, setSelectedModel } = useCopilotModels();
 
   const [activeTab, setActiveTab] = useState<
     'general' | 'connectors' | 'copilot' | 'prompts'
@@ -263,7 +262,6 @@ const Settings: React.FC = () => {
             models={models}
             selectedModel={selectedModel}
             setSelectedModel={setSelectedModel}
-            loadingModels={loadingModels}
             authStatus={authStatus}
             checkingAuth={checkingAuth}
             handleCheckAuth={handleCheckAuth}

--- a/src/types.ts
+++ b/src/types.ts
@@ -149,6 +149,7 @@ export interface ReviewPhase {
   body: string;
   template?: string;
   templateError?: string;
+  model?: string;
 }
 
 export interface CopilotUsage {


### PR DESCRIPTION
Resolves #155

Adds a `Model` frontmatter property. If present Stitch will use the specified model rather than the review model for this specific phase.

To make this visible, the model is displayed in a badge within the phase selection list.

If the model key isn't valid, the value is displayed in a badge with an "X" icon and the phase is disabled. There is a tooltip hint explaining that the model isn't available. This allows the user to fix the issue (or explicitly comment out the `Model` property) rather then us breaking their assumption of what model will be used for this phase.

To simplify identifying the model keys to use in the frontmatter, this change also reworks the GitHub Copilot settings section to display a table of models with their key and a 'copy' button to allow users to easily find and use the value without risking typos or finding the model key manually.

As part of this the change also reworks the Default Model selection, removing the dedicated dropdown and merging it with the model table with a "Default" badge for the default model, and "Set Default" buttons to configure the default.