### PR TITLE
style: settings reorganisation

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -98,7 +98,7 @@ locally on the machine.
   - If a repository directory path is provided to the Story Elaborator, the Copilot session is created with `workingDirectory` set to that directory, giving the model first-party tool capability (e.g., browsing files, reading code, searching with grep). The model is instructed to write the plan to a file in the workspace (e.g. `implementation_plan.md`) using its tools.
   - If no repository directory is provided, the session is created with `availableTools: []` (empty array) and without workspace bounds, confining the model's operation to the ticket's text context only.
   - **PR Reviewer Parallelism & Worker Pool**:
-    - Review phases run in parallel using an asynchronous worker pool. The `maxWorkers` count is configured by a slider in the General Settings (bounded by the CPU count) or defaults to `Math.max(1, Math.floor(numCPUs / 2))`.
+    - Review phases run in parallel using an asynchronous worker pool. The `maxWorkers` count is configured by a slider in the PR Reviewer Settings (bounded by the CPU count) or defaults to `Math.max(1, Math.floor(numCPUs / 2))`.
     - **Crucial Dependency**: Parallel review execution requires Git Worktree Support to be enabled. Without worktree isolation, concurrent checkouts and file operations in a single repository would create race conditions and git conflicts. Parallelism is automatically locked to 1 if Git Worktree is disabled.
   - **Git Worktree Isolation**:
     - When Git Worktree Support is enabled, Stitch creates separate, temporary git worktree checkouts under a user-configured base directory (`gitWorktreeBaseDir`).

--- a/src/renderer/features/settings/components/GeneralSettings.tsx
+++ b/src/renderer/features/settings/components/GeneralSettings.tsx
@@ -233,41 +233,6 @@ const GeneralSettings: React.FC<GeneralSettingsProps> = ({
               )}
             </div>
           )}
-
-          <h5 className="mb-4 mt-4 border-bottom pb-2">
-            <i className="fas fa-bell me-2 text-primary"></i>Notification
-            Settings
-          </h5>
-
-          <div className="mb-2">
-            <p className="text-muted small mb-3">
-              Test native OS notifications to verify they are enabled and
-              working correctly.
-            </p>
-            <button
-              type="button"
-              className="btn btn-outline-primary d-flex align-items-center gap-2"
-              onClick={() => {
-                setTimeout(() => {
-                  window.electronAPI
-                    .showNotification(
-                      'Stitch Test Notification',
-                      'This is a test notification from Stitch! Click here to focus.',
-                    )
-                    .catch((err) => {
-                      console.error('Failed to send test notification:', err);
-                    });
-                }, 3000);
-              }}
-            >
-              <i className="fas fa-paper-plane"></i>
-              Send Test Notification (3s delay)
-            </button>
-            <p className="text-muted small mt-2 mb-0">
-              Click the button, then minimize or focus away from Stitch within 3
-              seconds to test.
-            </p>
-          </div>
         </div>
       </div>
 

--- a/src/renderer/features/settings/components/GeneralSettings.tsx
+++ b/src/renderer/features/settings/components/GeneralSettings.tsx
@@ -8,9 +8,6 @@ interface GeneralSettingsProps {
   setGitWorktreeEnabled: (enabled: boolean) => void;
   gitWorktreeBaseDir: string;
   setGitWorktreeBaseDir: (dir: string) => void;
-  maxParallelism: number;
-  setMaxParallelism: (limit: number) => void;
-  cpuCount: number;
 }
 
 const GeneralSettings: React.FC<GeneralSettingsProps> = ({
@@ -20,9 +17,6 @@ const GeneralSettings: React.FC<GeneralSettingsProps> = ({
   setGitWorktreeEnabled,
   gitWorktreeBaseDir,
   setGitWorktreeBaseDir,
-  maxParallelism,
-  setMaxParallelism,
-  cpuCount,
 }) => {
   const [hasWorktrees, setHasWorktrees] = useState(false);
   const [worktreeCount, setWorktreeCount] = useState(0);
@@ -239,54 +233,6 @@ const GeneralSettings: React.FC<GeneralSettingsProps> = ({
               )}
             </div>
           )}
-
-          <h5 className="mb-4 mt-4 border-bottom pb-2">
-            <i className="fas fa-microchip me-2 text-primary"></i>PR Reviewer
-            Concurrency Settings
-          </h5>
-
-          <div className="mb-2">
-            <label className="form-label d-block fw-semibold text-muted small uppercase tracking-wider mb-2">
-              Default Review Agent Parallelism
-            </label>
-            <p className="text-muted small mb-3">
-              Configure how many parallel GitHub Copilot agents can run reviews
-              concurrently.
-            </p>
-            {cpuCount < 4 ? (
-              <div className="alert alert-info py-2 px-3 shadow-sm border-0 bg-info-subtle text-info-emphasis small d-flex align-items-center gap-2">
-                <i className="fas fa-circle-info"></i>
-                <span>
-                  Parallelism is locked to <strong>1</strong> because your
-                  system has <strong>{cpuCount} CPU cores</strong> (fewer than 4
-                  required for parallel agents).
-                </span>
-              </div>
-            ) : (
-              <div>
-                <div className="d-flex align-items-center gap-3">
-                  <input
-                    type="range"
-                    className="form-range flex-grow-0"
-                    min="1"
-                    max={cpuCount - 2}
-                    value={maxParallelism}
-                    onChange={(e) =>
-                      setMaxParallelism(parseInt(e.target.value))
-                    }
-                    style={{ maxWidth: '300px' }}
-                  />
-                  <span className="badge bg-primary fs-6 px-3 py-2">
-                    {maxParallelism} Worker{maxParallelism > 1 ? 's' : ''}
-                  </span>
-                </div>
-                <p className="text-muted small mt-2 mb-0">
-                  Allowing between 1 and {cpuCount - 2} parallel agents (Total
-                  CPU cores: {cpuCount}).
-                </p>
-              </div>
-            )}
-          </div>
 
           <h5 className="mb-4 mt-4 border-bottom pb-2">
             <i className="fas fa-bell me-2 text-primary"></i>Notification

--- a/src/renderer/features/settings/components/PRReviewerSettings.tsx
+++ b/src/renderer/features/settings/components/PRReviewerSettings.tsx
@@ -51,8 +51,7 @@ const PRReviewerSettings: React.FC<PRReviewerSettingsProps> = ({
       <div className="card-body p-4">
         <div className="d-flex justify-content-between align-items-center mb-4 border-bottom pb-2">
           <h5 className="mb-0">
-            <i className="fas fa-user-tag me-2 text-primary"></i>PR Reviewer
-            Personas
+            <i className="fas fa-user-tag me-2 text-primary"></i>Personas
           </h5>
           <span className="badge bg-secondary-subtle text-secondary-emphasis border border-secondary-subtle">
             {personas.length} / 5 Personas
@@ -198,8 +197,8 @@ const PRReviewerSettings: React.FC<PRReviewerSettingsProps> = ({
         <hr className="my-4" />
 
         <h5 className="mb-4">
-          <i className="fas fa-microchip me-2 text-primary"></i>PR Reviewer
-          Concurrency Settings
+          <i className="fas fa-microchip me-2 text-primary"></i>Concurrency
+          Settings
         </h5>
 
         <div className="mb-2">

--- a/src/renderer/features/settings/components/PRReviewerSettings.tsx
+++ b/src/renderer/features/settings/components/PRReviewerSettings.tsx
@@ -4,11 +4,17 @@ import { Persona } from '../../../../types';
 interface PRReviewerSettingsProps {
   personas: Persona[];
   setPersonas: (personas: Persona[]) => void;
+  maxParallelism: number;
+  setMaxParallelism: (limit: number) => void;
+  cpuCount: number;
 }
 
 const PRReviewerSettings: React.FC<PRReviewerSettingsProps> = ({
   personas,
   setPersonas,
+  maxParallelism,
+  setMaxParallelism,
+  cpuCount,
 }) => {
   const handleAdd = () => {
     if (personas.length >= 5) return;
@@ -188,6 +194,54 @@ const PRReviewerSettings: React.FC<PRReviewerSettingsProps> = ({
             Maximum limit of 5 personas reached.
           </div>
         )}
+
+        <hr className="my-4" />
+
+        <h5 className="mb-4">
+          <i className="fas fa-microchip me-2 text-primary"></i>PR Reviewer
+          Concurrency Settings
+        </h5>
+
+        <div className="mb-2">
+          <label className="form-label d-block fw-semibold text-muted small uppercase tracking-wider mb-2">
+            Default Review Agent Parallelism
+          </label>
+          <p className="text-muted small mb-3">
+            Configure how many parallel GitHub Copilot agents can run reviews
+            concurrently.
+          </p>
+          {cpuCount < 4 ? (
+            <div className="alert alert-info py-2 px-3 shadow-sm border-0 bg-info-subtle text-info-emphasis small d-flex align-items-center gap-2">
+              <i className="fas fa-circle-info"></i>
+              <span>
+                Parallelism is locked to <strong>1</strong> because your system
+                has <strong>{cpuCount} CPU cores</strong> (fewer than 4 required
+                for parallel agents).
+              </span>
+            </div>
+          ) : (
+            <div>
+              <div className="d-flex align-items-center gap-3">
+                <input
+                  type="range"
+                  className="form-range flex-grow-0"
+                  min="1"
+                  max={cpuCount - 2}
+                  value={maxParallelism}
+                  onChange={(e) => setMaxParallelism(parseInt(e.target.value))}
+                  style={{ maxWidth: '300px' }}
+                />
+                <span className="badge bg-primary fs-6 px-3 py-2">
+                  {maxParallelism} Worker{maxParallelism > 1 ? 's' : ''}
+                </span>
+              </div>
+              <p className="text-muted small mt-2 mb-0">
+                Allowing between 1 and {cpuCount - 2} parallel agents (Total CPU
+                cores: {cpuCount}).
+              </p>
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/renderer/features/settings/components/Settings.tsx
+++ b/src/renderer/features/settings/components/Settings.tsx
@@ -383,7 +383,7 @@ const Settings: React.FC = () => {
               className={`settings-nav-item ${activeTab === 'general' ? 'active' : ''}`}
               onClick={() => setActiveTab('general')}
             >
-              <i className="fas fa-palette"></i>
+              <i className="fas fa-sliders"></i>
               General
             </button>
             <button

--- a/src/renderer/features/settings/components/Settings.tsx
+++ b/src/renderer/features/settings/components/Settings.tsx
@@ -277,9 +277,6 @@ const Settings: React.FC = () => {
             setGitWorktreeEnabled={setGitWorktreeEnabled}
             gitWorktreeBaseDir={gitWorktreeBaseDir}
             setGitWorktreeBaseDir={setGitWorktreeBaseDir}
-            maxParallelism={maxParallelism}
-            setMaxParallelism={setMaxParallelism}
-            cpuCount={cpuCount}
           />
         );
       case 'connectors':
@@ -355,7 +352,13 @@ const Settings: React.FC = () => {
         );
       case 'pr-reviewer':
         return (
-          <PRReviewerSettings personas={personas} setPersonas={setPersonas} />
+          <PRReviewerSettings
+            personas={personas}
+            setPersonas={setPersonas}
+            maxParallelism={maxParallelism}
+            setMaxParallelism={setMaxParallelism}
+            cpuCount={cpuCount}
+          />
         );
       default:
         return null;

--- a/src/renderer/features/settings/components/Settings.tsx
+++ b/src/renderer/features/settings/components/Settings.tsx
@@ -415,7 +415,7 @@ const Settings: React.FC = () => {
               className={`settings-nav-item ${activeTab === 'pr-reviewer' ? 'active' : ''}`}
               onClick={() => setActiveTab('pr-reviewer')}
             >
-              <i className="fas fa-user-tag"></i>
+              <i className="fas fa-code-pull-request"></i>
               PR Reviewer
             </button>
           </div>

--- a/src/renderer/features/settings/components/__tests__/PRReviewerSettings.test.tsx
+++ b/src/renderer/features/settings/components/__tests__/PRReviewerSettings.test.tsx
@@ -8,7 +8,15 @@ import { Persona } from '../../../../../types';
 
 describe('PRReviewerSettings Component', () => {
   it('renders empty state correctly', () => {
-    render(<PRReviewerSettings personas={[]} setPersonas={vi.fn()} />);
+    render(
+      <PRReviewerSettings
+        personas={[]}
+        setPersonas={vi.fn()}
+        maxParallelism={2}
+        setMaxParallelism={vi.fn()}
+        cpuCount={4}
+      />,
+    );
 
     expect(screen.getByText(/No Personas Configured/i)).toBeInTheDocument();
     expect(
@@ -18,7 +26,15 @@ describe('PRReviewerSettings Component', () => {
 
   it('triggers setPersonas when Add Persona button is clicked', () => {
     const setPersonasMock = vi.fn();
-    render(<PRReviewerSettings personas={[]} setPersonas={setPersonasMock} />);
+    render(
+      <PRReviewerSettings
+        personas={[]}
+        setPersonas={setPersonasMock}
+        maxParallelism={2}
+        setMaxParallelism={vi.fn()}
+        cpuCount={4}
+      />,
+    );
 
     const addButton = screen.getByRole('button', { name: /Add Persona/i });
     fireEvent.click(addButton);
@@ -36,7 +52,13 @@ describe('PRReviewerSettings Component', () => {
     ];
 
     render(
-      <PRReviewerSettings personas={mockPersonas} setPersonas={vi.fn()} />,
+      <PRReviewerSettings
+        personas={mockPersonas}
+        setPersonas={vi.fn()}
+        maxParallelism={2}
+        setMaxParallelism={vi.fn()}
+        cpuCount={4}
+      />,
     );
 
     expect(screen.getByDisplayValue('Security Auditor')).toBeInTheDocument();
@@ -62,6 +84,9 @@ describe('PRReviewerSettings Component', () => {
       <PRReviewerSettings
         personas={mockPersonas}
         setPersonas={setPersonasMock}
+        maxParallelism={2}
+        setMaxParallelism={vi.fn()}
+        cpuCount={4}
       />,
     );
 
@@ -91,6 +116,9 @@ describe('PRReviewerSettings Component', () => {
       <PRReviewerSettings
         personas={mockPersonas}
         setPersonas={setPersonasMock}
+        maxParallelism={2}
+        setMaxParallelism={vi.fn()}
+        cpuCount={4}
       />,
     );
 
@@ -114,6 +142,9 @@ describe('PRReviewerSettings Component', () => {
       <PRReviewerSettings
         personas={mockPersonas}
         setPersonas={setPersonasMock}
+        maxParallelism={2}
+        setMaxParallelism={vi.fn()}
+        cpuCount={4}
       />,
     );
 
@@ -132,7 +163,13 @@ describe('PRReviewerSettings Component', () => {
     ];
 
     render(
-      <PRReviewerSettings personas={mockPersonas} setPersonas={vi.fn()} />,
+      <PRReviewerSettings
+        personas={mockPersonas}
+        setPersonas={vi.fn()}
+        maxParallelism={2}
+        setMaxParallelism={vi.fn()}
+        cpuCount={4}
+      />,
     );
 
     // First persona has empty content
@@ -148,7 +185,13 @@ describe('PRReviewerSettings Component', () => {
       { name: 'none', content: 'Other guidelines' },
     ];
     render(
-      <PRReviewerSettings personas={mockPersonas} setPersonas={vi.fn()} />,
+      <PRReviewerSettings
+        personas={mockPersonas}
+        setPersonas={vi.fn()}
+        maxParallelism={2}
+        setMaxParallelism={vi.fn()}
+        cpuCount={4}
+      />,
     );
 
     const noneErrors = screen.getAllByText('"None" is a reserved name.');
@@ -160,7 +203,13 @@ describe('PRReviewerSettings Component', () => {
       { name: 'Reviewer A', content: 'Original content' },
     ];
     render(
-      <PRReviewerSettings personas={mockPersonas} setPersonas={vi.fn()} />,
+      <PRReviewerSettings
+        personas={mockPersonas}
+        setPersonas={vi.fn()}
+        maxParallelism={2}
+        setMaxParallelism={vi.fn()}
+        cpuCount={4}
+      />,
     );
 
     const contentInput = screen.getByDisplayValue('Original content');
@@ -179,5 +228,56 @@ describe('PRReviewerSettings Component', () => {
     contentInput.dispatchEvent(event);
 
     expect(preventDefaultSpy).toHaveBeenCalled();
+  });
+
+  it('renders concurrency settings correctly when cpuCount < 4', () => {
+    render(
+      <PRReviewerSettings
+        personas={[]}
+        setPersonas={vi.fn()}
+        maxParallelism={1}
+        setMaxParallelism={vi.fn()}
+        cpuCount={2}
+      />,
+    );
+
+    expect(
+      screen.getByText(
+        (_, element) =>
+          element?.tagName === 'SPAN' &&
+          (element?.textContent?.includes('Parallelism is locked to 1') ??
+            false),
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('renders concurrency settings correctly when cpuCount >= 4', () => {
+    const setMaxParallelismMock = vi.fn();
+    render(
+      <PRReviewerSettings
+        personas={[]}
+        setPersonas={vi.fn()}
+        maxParallelism={2}
+        setMaxParallelism={setMaxParallelismMock}
+        cpuCount={8}
+      />,
+    );
+
+    expect(
+      screen.queryByText(/Parallelism is locked to 1/i),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText('2 Workers')).toBeInTheDocument();
+    expect(
+      screen.getByText(/Allowing between 1 and 6 parallel agents/i),
+    ).toBeInTheDocument();
+
+    const slider = screen.getByRole('slider');
+    expect(slider).toBeInTheDocument();
+    expect(slider).toHaveAttribute('min', '1');
+    expect(slider).toHaveAttribute('max', '6');
+    expect(slider).toHaveValue('2');
+
+    fireEvent.change(slider, { target: { value: '4' } });
+    expect(setMaxParallelismMock).toHaveBeenCalledWith(4);
   });
 });


### PR DESCRIPTION
This PR reorganises and tidies up the app's settings to be easier to use.

- Moved the PR Reviewer Parallelism settings from the "General" pane to the new "PR Reviewer" pane which was created under #163 
- Updated icons to more accurately represent each settings section
- Removed the "Notification Test" section and button from general Settings