### PR TITLE
feat(pr-reviewer): display model usage breakdown

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -99,9 +99,9 @@ locally on the machine.
   - Inside `sendAndCollectStream`, a newline buffer fallback processes block-delivered responses when incremental token deltas are skipped during tool executions, ensuring smooth UI status tracking.
 - **Usage Metrics Tracking**:
   - For each Copilot session, `CopilotService` listens to the `assistant.usage` event emitted by the Copilot agent.
-  - The service tracks token usage metrics, including input tokens (`inputTokens`), output tokens (`outputTokens`), cached tokens (`cacheReadTokens`), and model multiplier/cost (`cost`), falling back to `0` if any metric is missing.
+  - The service tracks token usage metrics, including input tokens (`inputTokens`), output tokens (`outputTokens`), cached tokens (`cacheReadTokens`), model name (`model`), and model multiplier/cost (`cost`), falling back to default values if any metric is missing.
   - The accumulated usage metrics are returned to the renderer process upon task completion via IPC.
-  - For parallelized tasks like the **PR Reviewer**, individual phase sessions propagate their stats to the reviewer service, which aggregates the usage across all phases and returns the total usage stats to the frontend.
+  - For parallelized tasks like the **PR Reviewer**, individual phase sessions propagate their stats to the reviewer service, which aggregates the total usage stats and attaches per-phase usage details (`phases`) returned to the frontend for detailed inspection via the model usage toast modal.
 - **`request_documentation` Custom Tool**:
   - Exposed to the Copilot session during both **PR Reviewer** (when attaching linked stories) and **Story Elaborator** tasks.
   - The custom tool (`createRequestDocumentationTool` from `src/main/infrastructure/copilot/tools/documentationTool.ts`) takes a `documentId` (e.g., Confluence Page ID) and queries `ConfluenceService` to retrieve the page title and storage body layout.

--- a/src/main/features/pr-reviewer/__tests__/prReviewerService.test.ts
+++ b/src/main/features/pr-reviewer/__tests__/prReviewerService.test.ts
@@ -56,6 +56,7 @@ describe('PRReviewerService', () => {
       createClientAndSession: vi.fn(),
       sendAndCollectStream: vi.fn(),
       listModels: vi.fn().mockResolvedValue([]),
+      getCachedModels: vi.fn().mockReturnValue([]),
     };
     prReviewerService = new PRReviewerService(
       mockGitService,
@@ -1845,7 +1846,7 @@ describe('PRReviewerService', () => {
           body: 'Review guidelines',
         },
       ]);
-      mockCopilotService.listModels.mockResolvedValue([
+      mockCopilotService.getCachedModels.mockReturnValue([
         {
           id: 'claude-3.5-sonnet',
           name: 'Claude 3.5 Sonnet',

--- a/src/main/features/pr-reviewer/__tests__/prReviewerService.test.ts
+++ b/src/main/features/pr-reviewer/__tests__/prReviewerService.test.ts
@@ -55,6 +55,7 @@ describe('PRReviewerService', () => {
     mockCopilotService = {
       createClientAndSession: vi.fn(),
       sendAndCollectStream: vi.fn(),
+      listModels: vi.fn().mockResolvedValue([]),
     };
     prReviewerService = new PRReviewerService(
       mockGitService,
@@ -1831,6 +1832,56 @@ describe('PRReviewerService', () => {
       // Verify sessions had isPrReviewer attached
       expect((mockSession1 as any).isPrReviewer).toBe(true);
       expect((mockSession2 as any).isPrReviewer).toBe(true);
+    });
+
+    it('should map model IDs to display names if available and fall back to raw ID', async () => {
+      mockGitService.getDiffFiles.mockResolvedValue([
+        { path: 'file.ts', status: 'modified' },
+      ]);
+      vi.spyOn(prReviewerService, 'loadPhasesFromDisk').mockResolvedValue([
+        {
+          id: '010-definition-of-done.md',
+          title: 'Definition of Done',
+          body: 'Review guidelines',
+        },
+      ]);
+      mockCopilotService.listModels.mockResolvedValue([
+        {
+          id: 'claude-3.5-sonnet',
+          name: 'Claude 3.5 Sonnet',
+          billing: { multiplier: 1.5 },
+        },
+      ]);
+
+      const mockSession = {
+        disconnect: vi.fn().mockResolvedValue(undefined),
+        usage: {
+          inputTokens: 100,
+          outputTokens: 50,
+          cacheReadTokens: 10,
+          cost: 1.5,
+          model: 'claude-3.5-sonnet',
+        },
+      };
+
+      const mockClient = { stop: vi.fn().mockResolvedValue(undefined) };
+      mockCopilotService.createClientAndSession.mockResolvedValue({
+        client: mockClient,
+        session: mockSession,
+      });
+
+      mockCopilotService.sendAndCollectStream.mockResolvedValue('done');
+
+      const res = await prReviewerService.reviewPR(
+        '/mock/repo',
+        'main',
+        settings,
+        {
+          enabledPhaseIds: ['010-definition-of-done.md'],
+        },
+      );
+
+      expect(res.usage.phases?.[0].model).toBe('Claude 3.5 Sonnet');
     });
   });
 

--- a/src/main/features/pr-reviewer/__tests__/prReviewerService.test.ts
+++ b/src/main/features/pr-reviewer/__tests__/prReviewerService.test.ts
@@ -326,6 +326,17 @@ describe('PRReviewerService', () => {
           outputTokens: 0,
           cacheReadTokens: 0,
           cost: 0,
+          phases: [
+            {
+              phaseTitle: 'Definition of Done',
+              model: 'gpt-4',
+              inputTokens: 0,
+              outputTokens: 0,
+              cacheReadTokens: 0,
+              cost: 0,
+              multiplier: 0,
+            },
+          ],
         },
       });
     });
@@ -1795,6 +1806,26 @@ describe('PRReviewerService', () => {
         outputTokens: 125,
         cacheReadTokens: 30,
         cost: 0.35,
+        phases: [
+          {
+            phaseTitle: 'DoD Review',
+            model: 'Unknown',
+            inputTokens: 100,
+            outputTokens: 50,
+            cacheReadTokens: 10,
+            cost: 0.1,
+            multiplier: 0.1,
+          },
+          {
+            phaseTitle: 'Security Review',
+            model: 'Unknown',
+            inputTokens: 200,
+            outputTokens: 75,
+            cacheReadTokens: 20,
+            cost: 0.25,
+            multiplier: 0.25,
+          },
+        ],
       });
 
       // Verify sessions had isPrReviewer attached

--- a/src/main/features/pr-reviewer/prReviewerService.ts
+++ b/src/main/features/pr-reviewer/prReviewerService.ts
@@ -14,7 +14,6 @@ import {
   CopilotUsage,
   PhaseUsage,
   CopilotResult,
-  CopilotModel,
 } from '../../../types';
 import { IssueTrackerProvider } from '../../infrastructure/providers/IssueTrackerProvider';
 import { DocumentationProvider } from '../../infrastructure/providers/DocumentationProvider';
@@ -1085,14 +1084,7 @@ export class PRReviewerService {
 
       const accumulatedResult = results.filter((r) => r !== '').join('');
 
-      let availableModels: CopilotModel[] = [];
-      try {
-        availableModels = await this.copilotService.listModels(
-          settings.copilotToken,
-        );
-      } catch (err) {
-        console.error('Failed to fetch Copilot models for model mapping:', err);
-      }
+      const availableModels = this.copilotService.getCachedModels();
 
       const getModelDisplayName = (rawModel: string): string => {
         if (!rawModel) {

--- a/src/main/features/pr-reviewer/prReviewerService.ts
+++ b/src/main/features/pr-reviewer/prReviewerService.ts
@@ -14,6 +14,7 @@ import {
   CopilotUsage,
   PhaseUsage,
   CopilotResult,
+  CopilotModel,
 } from '../../../types';
 import { IssueTrackerProvider } from '../../infrastructure/providers/IssueTrackerProvider';
 import { DocumentationProvider } from '../../infrastructure/providers/DocumentationProvider';
@@ -1084,9 +1085,30 @@ export class PRReviewerService {
 
       const accumulatedResult = results.filter((r) => r !== '').join('');
 
+      let availableModels: CopilotModel[] = [];
+      try {
+        availableModels = await this.copilotService.listModels(
+          settings.copilotToken,
+        );
+      } catch (err) {
+        console.error('Failed to fetch Copilot models for model mapping:', err);
+      }
+
+      const getModelDisplayName = (rawModel: string): string => {
+        if (!rawModel) {
+          return 'Unknown';
+        }
+        const matched = availableModels.find(
+          (m) =>
+            m.id.toLowerCase() === rawModel.toLowerCase() ||
+            m.name.toLowerCase() === rawModel.toLowerCase(),
+        );
+        return matched ? matched.name : rawModel;
+      };
+
       const phaseUsageList: PhaseUsage[] = phaseStats.map((stat) => ({
         phaseTitle: stat.phaseTitle,
-        model: stat.model,
+        model: getModelDisplayName(stat.model),
         inputTokens: stat.usage.inputTokens,
         outputTokens: stat.usage.outputTokens,
         cacheReadTokens: stat.usage.cacheReadTokens,

--- a/src/main/features/pr-reviewer/prReviewerService.ts
+++ b/src/main/features/pr-reviewer/prReviewerService.ts
@@ -12,6 +12,7 @@ import {
   ReviewPhase,
   TicketData,
   CopilotUsage,
+  PhaseUsage,
   CopilotResult,
 } from '../../../types';
 import { IssueTrackerProvider } from '../../infrastructure/providers/IssueTrackerProvider';
@@ -779,7 +780,12 @@ export class PRReviewerService {
       }
 
       const results: string[] = new Array(enabledPhases.length).fill('');
-      const phaseStats: { phaseTitle: string; usage: CopilotUsage }[] = [];
+      const phaseStats: {
+        phaseTitle: string;
+        usage: CopilotUsage;
+        model: string;
+        multiplier: number;
+      }[] = [];
       let firstError: Error | null = null;
       let queueIndex = 0;
 
@@ -1016,9 +1022,16 @@ export class PRReviewerService {
               cost: 0,
             };
 
+            const fallbackModel =
+              phase.model || options.modelOverride || 'Unknown';
+            const model = usage.model || fallbackModel;
+            const multiplier = usage.cost;
+
             phaseStats.push({
               phaseTitle: phase.title,
               usage,
+              model,
+              multiplier,
             });
 
             try {
@@ -1071,6 +1084,16 @@ export class PRReviewerService {
 
       const accumulatedResult = results.filter((r) => r !== '').join('');
 
+      const phaseUsageList: PhaseUsage[] = phaseStats.map((stat) => ({
+        phaseTitle: stat.phaseTitle,
+        model: stat.model,
+        inputTokens: stat.usage.inputTokens,
+        outputTokens: stat.usage.outputTokens,
+        cacheReadTokens: stat.usage.cacheReadTokens,
+        cost: stat.usage.cost,
+        multiplier: stat.multiplier,
+      }));
+
       return {
         result: accumulatedResult,
         usage: {
@@ -1078,6 +1101,7 @@ export class PRReviewerService {
           outputTokens: totalOutputTokens,
           cacheReadTokens: totalCacheReadTokens,
           cost: totalCost,
+          phases: phaseUsageList,
         },
       };
     } finally {

--- a/src/main/infrastructure/copilot/__tests__/copilotService.test.ts
+++ b/src/main/infrastructure/copilot/__tests__/copilotService.test.ts
@@ -268,6 +268,16 @@ describe('CopilotService', () => {
     await checkExpectation;
   });
 
+  describe('getCachedModels', () => {
+    it('should return cached models synchronously', () => {
+      const mockModels = [
+        { id: 'gpt-4o', name: 'GPT-4o', billing: { multiplier: 1 } },
+      ];
+      (service as any).cachedModels = mockModels;
+      expect(service.getCachedModels()).toEqual(mockModels);
+    });
+  });
+
   it('should resiliently parse stream with leading noise and markdown wrappers', async () => {
     const lines: string[] = [];
     const responsePromise = service.sendAndCollectStream(

--- a/src/main/infrastructure/copilot/__tests__/copilotService.test.ts
+++ b/src/main/infrastructure/copilot/__tests__/copilotService.test.ts
@@ -544,6 +544,7 @@ describe('CopilotService', () => {
           outputTokens: 50,
           cacheReadTokens: 10,
           cost: 1.5,
+          model: 'claude-3.5-sonnet',
         },
       });
 
@@ -552,7 +553,7 @@ describe('CopilotService', () => {
         type: 'assistant.usage',
         data: {
           inputTokens: 200,
-          // outputTokens, cacheReadTokens, cost are missing
+          // outputTokens, cacheReadTokens are missing
         },
       });
 
@@ -569,6 +570,7 @@ describe('CopilotService', () => {
         outputTokens: 50,
         cacheReadTokens: 10,
         cost: 1.5,
+        model: 'claude-3.5-sonnet',
       });
     });
 

--- a/src/main/infrastructure/copilot/copilotService.ts
+++ b/src/main/infrastructure/copilot/copilotService.ts
@@ -338,7 +338,12 @@ export class CopilotService {
         sessionUsage.inputTokens += event.data?.inputTokens ?? 0;
         sessionUsage.outputTokens += event.data?.outputTokens ?? 0;
         sessionUsage.cacheReadTokens += event.data?.cacheReadTokens ?? 0;
-        sessionUsage.cost += event.data?.cost ?? 0;
+        if (event.data?.cost !== undefined) {
+          sessionUsage.cost = event.data.cost;
+        }
+        if (event.data?.model !== undefined) {
+          sessionUsage.model = event.data.model;
+        }
       } else if (event.type === 'session.idle') {
         if (onLine && buffer.trim()) {
           buffer = parseResilientJSONL(buffer, onLine);

--- a/src/main/infrastructure/copilot/copilotService.ts
+++ b/src/main/infrastructure/copilot/copilotService.ts
@@ -208,6 +208,10 @@ export class CopilotService {
     }
   }
 
+  getCachedModels(): CopilotModel[] {
+    return this.cachedModels;
+  }
+
   async listModels(copilotToken?: string): Promise<CopilotModel[]> {
     if (this.cachedModels.length > 0) {
       return this.cachedModels;

--- a/src/renderer/components/UsageDetailsModal.tsx
+++ b/src/renderer/components/UsageDetailsModal.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { PhaseUsage } from '../../types';
+
+interface UsageDetailsModalProps {
+  phases: PhaseUsage[];
+  onClose: () => void;
+}
+
+const UsageDetailsModal: React.FC<UsageDetailsModalProps> = ({
+  phases,
+  onClose,
+}) => {
+  return (
+    <div
+      className="env-error-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="usage-details-title"
+    >
+      <div className="near-full-modal usage-details-modal text-start p-4">
+        <div className="d-flex justify-content-between align-items-center w-100 mb-3 pb-2 border-bottom">
+          <div className="d-flex align-items-center gap-2">
+            <i className="fas fa-chart-pie text-primary fs-4"></i>
+            <h5 id="usage-details-title" className="mb-0 fw-bold">
+              Phase Usage Breakdown
+            </h5>
+          </div>
+          <button
+            type="button"
+            className="btn-close"
+            onClick={onClose}
+            aria-label="Close modal"
+          ></button>
+        </div>
+
+        <div className="w-100 overflow-x-auto mb-4">
+          <table className="table table-sm table-hover align-middle usage-details-table mb-0">
+            <thead>
+              <tr>
+                <th>Phase Name</th>
+                <th>Model Name</th>
+                <th className="text-end">Input Tokens</th>
+                <th className="text-end">Output Tokens</th>
+                <th className="text-end">Cached Tokens</th>
+                <th className="text-end">% Cached</th>
+                <th className="text-end">Multiplier</th>
+              </tr>
+            </thead>
+            <tbody>
+              {phases.map((phase, index) => {
+                const cachePercentage =
+                  phase.inputTokens > 0
+                    ? Math.round(
+                        (phase.cacheReadTokens / phase.inputTokens) * 100,
+                      )
+                    : 0;
+
+                return (
+                  <tr key={`${phase.phaseTitle}-${index}`}>
+                    <td className="fw-semibold">{phase.phaseTitle}</td>
+                    <td>
+                      <span className="badge bg-secondary-subtle text-secondary border">
+                        {phase.model}
+                      </span>
+                    </td>
+                    <td className="text-end font-monospace">
+                      {phase.inputTokens.toLocaleString()}
+                    </td>
+                    <td className="text-end font-monospace">
+                      {phase.outputTokens.toLocaleString()}
+                    </td>
+                    <td className="text-end font-monospace">
+                      {phase.cacheReadTokens.toLocaleString()}
+                    </td>
+                    <td className="text-end font-monospace">
+                      {cachePercentage}%
+                    </td>
+                    <td className="text-end font-monospace text-muted">
+                      {`×${phase.multiplier ?? 1}`}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+
+        <div className="d-flex justify-content-end w-100">
+          <button className="btn btn-indigo px-4" onClick={onClose}>
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default UsageDetailsModal;

--- a/src/renderer/components/UsageStatsToast.tsx
+++ b/src/renderer/components/UsageStatsToast.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { CopilotUsage } from '../../types';
+import UsageDetailsModal from './UsageDetailsModal';
 
 interface UsageStatsToastProps {
   stats: CopilotUsage;
@@ -10,49 +11,69 @@ const UsageStatsToast: React.FC<UsageStatsToastProps> = ({
   stats,
   onClose,
 }) => {
-  const { inputTokens, outputTokens, cacheReadTokens } = stats;
+  const [showDetailsModal, setShowDetailsModal] = useState(false);
+  const { inputTokens, outputTokens, cacheReadTokens, phases } = stats;
 
   const cachePercentage =
     inputTokens > 0 ? Math.round((cacheReadTokens / inputTokens) * 100) : 0;
 
   return (
-    <div className="usage-toast" role="alert" aria-live="polite">
-      <div className="usage-toast-header">
-        <div className="usage-toast-icon">
-          <i className="fas fa-chart-bar"></i>
+    <>
+      <div className="usage-toast" role="alert" aria-live="polite">
+        <div className="usage-toast-header">
+          <div className="usage-toast-icon">
+            <i className="fas fa-chart-bar"></i>
+          </div>
+          <h6 className="usage-toast-title">Usage Stats</h6>
+          <button
+            type="button"
+            className="usage-toast-btn-x"
+            onClick={onClose}
+            aria-label="Close"
+          >
+            <i className="fas fa-times"></i>
+          </button>
         </div>
-        <h6 className="usage-toast-title">Usage Stats</h6>
-        <button
-          type="button"
-          className="usage-toast-btn-x"
-          onClick={onClose}
-          aria-label="Close"
-        >
-          <i className="fas fa-times"></i>
-        </button>
+        <div className="usage-toast-body">
+          <ul className="usage-toast-list">
+            <li>
+              <span>Input tokens:</span>
+              <strong>{inputTokens.toLocaleString()}</strong>
+            </li>
+            <li>
+              <span>Output tokens:</span>
+              <strong>{outputTokens.toLocaleString()}</strong>
+            </li>
+            <li>
+              <span>Cached tokens:</span>
+              <strong>{cacheReadTokens.toLocaleString()}</strong>
+            </li>
+          </ul>
+          {inputTokens > 0 && (
+            <p className="usage-toast-cache-msg">
+              {cachePercentage}% of input tokens served from the cache
+            </p>
+          )}
+          {phases && phases.length > 0 && (
+            <div className="usage-toast-actions mt-2 pt-2 border-top">
+              <button
+                type="button"
+                className="btn btn-sm btn-outline-primary w-100"
+                onClick={() => setShowDetailsModal(true)}
+              >
+                More Details
+              </button>
+            </div>
+          )}
+        </div>
       </div>
-      <div className="usage-toast-body">
-        <ul className="usage-toast-list">
-          <li>
-            <span>Input tokens:</span>
-            <strong>{inputTokens.toLocaleString()}</strong>
-          </li>
-          <li>
-            <span>Output tokens:</span>
-            <strong>{outputTokens.toLocaleString()}</strong>
-          </li>
-          <li>
-            <span>Cached tokens:</span>
-            <strong>{cacheReadTokens.toLocaleString()}</strong>
-          </li>
-        </ul>
-        {inputTokens > 0 && (
-          <p className="usage-toast-cache-msg">
-            {cachePercentage}% of input tokens served from the cache
-          </p>
-        )}
-      </div>
-    </div>
+      {showDetailsModal && phases && (
+        <UsageDetailsModal
+          phases={phases}
+          onClose={() => setShowDetailsModal(false)}
+        />
+      )}
+    </>
   );
 };
 

--- a/src/renderer/components/__tests__/UsageStatsToast.test.tsx
+++ b/src/renderer/components/__tests__/UsageStatsToast.test.tsx
@@ -50,4 +50,65 @@ describe('UsageStatsToast Component', () => {
       screen.queryByText(/of input tokens served from the cache/),
     ).not.toBeInTheDocument();
   });
+
+  it('does not render More Details button when phases are not provided', () => {
+    render(<UsageStatsToast stats={mockStats} onClose={vi.fn()} />);
+
+    expect(
+      screen.queryByRole('button', { name: /more details/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders More Details button and opens modal with phase breakdown', () => {
+    const statsWithPhases = {
+      ...mockStats,
+      phases: [
+        {
+          phaseTitle: 'Phase 1: Architecture',
+          model: 'Claude 3.5 Sonnet',
+          inputTokens: 20000,
+          outputTokens: 1000,
+          cacheReadTokens: 15000,
+          cost: 1.5,
+          multiplier: 1.5,
+        },
+        {
+          phaseTitle: 'Phase 2: Security',
+          model: 'GPT-4o',
+          inputTokens: 22023,
+          outputTokens: 1381,
+          cacheReadTokens: 15976,
+          cost: 1,
+          multiplier: 1,
+        },
+      ],
+    };
+
+    render(<UsageStatsToast stats={statsWithPhases} onClose={vi.fn()} />);
+
+    const moreDetailsBtn = screen.getByRole('button', {
+      name: /more details/i,
+    });
+    expect(moreDetailsBtn).toBeInTheDocument();
+
+    // Modal initially not visible
+    expect(screen.queryByText('Phase Usage Breakdown')).not.toBeInTheDocument();
+
+    // Click More Details
+    fireEvent.click(moreDetailsBtn);
+
+    // Modal now open
+    expect(screen.getByText('Phase Usage Breakdown')).toBeInTheDocument();
+    expect(screen.getByText('Phase 1: Architecture')).toBeInTheDocument();
+    expect(screen.getByText('Claude 3.5 Sonnet')).toBeInTheDocument();
+    expect(screen.getByText('Phase 2: Security')).toBeInTheDocument();
+    expect(screen.getByText('GPT-4o')).toBeInTheDocument();
+    expect(screen.getByText('×1.5')).toBeInTheDocument();
+
+    // Close modal
+    const closeBtn = screen.getByRole('button', { name: /close modal/i });
+    fireEvent.click(closeBtn);
+
+    expect(screen.queryByText('Phase Usage Breakdown')).not.toBeInTheDocument();
+  });
 });

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -807,3 +807,17 @@ tr.is-dragging {
   color: #34d399;
   background: rgba(52, 211, 153, 0.1);
 }
+
+/* Usage Details Modal & Table */
+.usage-details-modal {
+  max-width: 900px;
+  width: 90%;
+}
+
+.usage-details-table {
+  font-size: 13px;
+}
+
+[data-bs-theme='dark'] .usage-details-table {
+  color: var(--bs-body-color);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -165,11 +165,23 @@ export interface ReviewPhase {
   model?: string;
 }
 
+export interface PhaseUsage {
+  phaseTitle: string;
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cost: number;
+  multiplier: number;
+}
+
 export interface CopilotUsage {
   inputTokens: number;
   outputTokens: number;
   cacheReadTokens: number;
   cost: number;
+  model?: string;
+  phases?: PhaseUsage[];
 }
 
 export interface CopilotResult<T> {


### PR DESCRIPTION
Currently we display a toast at the end of each AI invocation showing;
- The number of input tokens
- The number of output tokens
- The number and percentage of input tokens from the cache

For multi-agent processes, like the PR Reviewer which reviews multiple angles simultaneously, this was a single aggregated snapshot of usage.

This PR adds a "More Details" button to the model usage toast. When clicked a modal is displayed showing a table containing the:

- Phase name
- AI model
- Input Tokens
- Output Tokens
- Cached Tokens, % of input tokens
- Cost multiplier

This allows users to see exactly which phases are the most expensive.