### PR TITLE
fix(pr-reviewer): resolve comment index mismatch with unique comment IDs

### DIFF
--- a/src/renderer/features/pr-reviewer/PRReviewer.tsx
+++ b/src/renderer/features/pr-reviewer/PRReviewer.tsx
@@ -72,14 +72,14 @@ const PRReviewer: React.FC = () => {
     Record<string | number, boolean>
   >({});
   const [isPostingComment, setIsPostingComment] = useState<
-    Record<number, boolean>
+    Record<string, boolean>
   >({});
 
   // Modals
   const [showDirtyModal, setShowDirtyModal] = useState(false);
   const [showErrorModal, setShowErrorModal] = useState(false);
   const [showNoPhasesModal, setShowNoPhasesModal] = useState(false);
-  const [editingCommentIndex, setEditingCommentIndex] = useState<number | null>(
+  const [editingComment, setEditingComment] = useState<ReviewComment | null>(
     null,
   );
   const [editedCommentText, setEditedCommentText] = useState<string>('');
@@ -544,8 +544,14 @@ const PRReviewer: React.FC = () => {
           commentObj &&
           (commentObj.type === 'general' || commentObj.type === 'line')
         ) {
-          localComments.push(commentObj);
-          setComments((prev) => [...prev, commentObj]);
+          const commentWithId = {
+            ...commentObj,
+            id:
+              commentObj.id ||
+              `raw-${localComments.length}-${Date.now()}-${Math.random()}`,
+          };
+          localComments.push(commentWithId);
+          setComments((prev) => [...prev, commentWithId]);
           setLastStatusTime(new Date());
         }
       } catch (err) {
@@ -593,7 +599,13 @@ const PRReviewer: React.FC = () => {
             selectedPersona,
           );
           if (criticRes && criticRes.result) {
-            setCritiquedComments(criticRes.result);
+            const critiquedWithIds = criticRes.result.map(
+              (c: ReviewComment, idx: number) => ({
+                ...c,
+                id: c.id || `critic-${idx}-${Date.now()}-${Math.random()}`,
+              }),
+            );
+            setCritiquedComments(critiquedWithIds);
             setHasCritiqued(true);
             setCommentViewMode('critiqued');
             setPhaseProgress((prev) =>
@@ -699,18 +711,23 @@ const PRReviewer: React.FC = () => {
     setShowErrorModal(true);
   };
 
-  const handleDismissComment = (index: number) => {
-    setCollapsedComments((prev) => ({ ...prev, [index]: true }));
+  const handleDismissComment = (comment: ReviewComment) => {
+    const key = comment.id || '';
+    if (key) {
+      setCollapsedComments((prev) => ({ ...prev, [key]: true }));
+    }
   };
 
   const handlePostComment = async (
     comment: ReviewComment,
-    index: number,
     updatedText?: string,
   ) => {
     if (!selectedPR) return;
 
-    setIsPostingComment((prev) => ({ ...prev, [index]: true }));
+    const commentId = comment.id || '';
+    if (commentId) {
+      setIsPostingComment((prev) => ({ ...prev, [commentId]: true }));
+    }
     try {
       const prIdentifier =
         activeTab === 'manual' ? manualPrUrlOrId : selectedPR.id;
@@ -731,8 +748,8 @@ const PRReviewer: React.FC = () => {
 
       // Mark as posted in both lists
       const updateList = (prev: ReviewComment[]) =>
-        prev.map((c, i) =>
-          i === index ||
+        prev.map((c) =>
+          (commentId && c.id === commentId) ||
           (c.comment === comment.comment &&
             c.file === comment.file &&
             c.line === comment.line)
@@ -742,14 +759,18 @@ const PRReviewer: React.FC = () => {
       setComments(updateList);
       setCritiquedComments(updateList);
 
-      setCollapsedComments((prev) => ({ ...prev, [index]: true }));
-      setEditingCommentIndex(null);
+      if (commentId) {
+        setCollapsedComments((prev) => ({ ...prev, [commentId]: true }));
+      }
+      setEditingComment(null);
     } catch (err: unknown) {
       console.error('Failed to post comment:', err);
       const msg = err instanceof Error ? err.message : String(err);
       showError(msg);
     } finally {
-      setIsPostingComment((prev) => ({ ...prev, [index]: false }));
+      if (commentId) {
+        setIsPostingComment((prev) => ({ ...prev, [commentId]: false }));
+      }
     }
   };
 
@@ -860,9 +881,9 @@ const PRReviewer: React.FC = () => {
                   isPostingComment={isPostingComment}
                   onDismissComment={handleDismissComment}
                   onPostComment={handlePostComment}
-                  onStartEditComment={(index, commentText) => {
-                    setEditingCommentIndex(index);
-                    setEditedCommentText(commentText);
+                  onStartEditComment={(comment) => {
+                    setEditingComment(comment);
+                    setEditedCommentText(comment.comment);
                   }}
                   isHeaderCollapsed={isHeaderCollapsed}
                 />
@@ -872,14 +893,13 @@ const PRReviewer: React.FC = () => {
         )}
       </div>
 
-      {editingCommentIndex !== null && (
+      {editingComment !== null && (
         <EditCommentModal
-          editingCommentIndex={editingCommentIndex}
+          editingComment={editingComment}
           editedCommentText={editedCommentText}
           setEditedCommentText={setEditedCommentText}
-          onCancel={() => setEditingCommentIndex(null)}
+          onCancel={() => setEditingComment(null)}
           onPostComment={handlePostComment}
-          comments={comments}
           isPostingComment={isPostingComment}
         />
       )}

--- a/src/renderer/features/pr-reviewer/components/PRReviewComments.tsx
+++ b/src/renderer/features/pr-reviewer/components/PRReviewComments.tsx
@@ -17,10 +17,10 @@ interface PRReviewCommentsProps {
   rejectedCritiquedComments: ReviewComment[];
   collapsedComments: Record<string | number, boolean>;
   onToggleCollapse: (key: string | number) => void;
-  isPostingComment: Record<number, boolean>;
-  onDismissComment: (index: number) => void;
-  onPostComment: (comment: ReviewComment, index: number) => void;
-  onStartEditComment: (index: number, commentText: string) => void;
+  isPostingComment: Record<string, boolean>;
+  onDismissComment: (comment: ReviewComment) => void;
+  onPostComment: (comment: ReviewComment) => void;
+  onStartEditComment: (comment: ReviewComment) => void;
   isHeaderCollapsed: boolean;
 }
 
@@ -173,11 +173,12 @@ const PRReviewComments: React.FC<PRReviewCommentsProps> = ({
             ) : (
               <div className="comments-list">
                 {displayedComments.map((comment, index) => {
+                  const commentId = comment.id || index;
                   const isLine = comment.type === 'line';
-                  if (collapsedComments[index]) {
+                  if (collapsedComments[commentId]) {
                     return (
                       <div
-                        key={index}
+                        key={commentId}
                         className="card shadow-sm border-0 mb-2 bg-body-secondary opacity-75"
                       >
                         <div className="card-body p-2 d-flex align-items-center justify-content-between">
@@ -228,7 +229,7 @@ const PRReviewComments: React.FC<PRReviewCommentsProps> = ({
                           </div>
                           <button
                             className="btn btn-sm btn-link text-decoration-none p-0 px-2"
-                            onClick={() => onToggleCollapse(index)}
+                            onClick={() => onToggleCollapse(commentId)}
                           >
                             <i className="fas fa-chevron-down me-1"></i> Expand
                           </button>
@@ -239,7 +240,7 @@ const PRReviewComments: React.FC<PRReviewCommentsProps> = ({
 
                   return (
                     <div
-                      key={index}
+                      key={commentId}
                       className={`card shadow-sm border-0 mb-3 ${
                         isLine
                           ? 'border-start border-4 border-primary'
@@ -354,7 +355,7 @@ const PRReviewComments: React.FC<PRReviewCommentsProps> = ({
                         <div className="d-flex justify-content-end gap-2 mt-3 pt-2 border-top border-secondary-subtle">
                           <button
                             className="btn btn-sm btn-outline-secondary"
-                            onClick={() => onDismissComment(index)}
+                            onClick={() => onDismissComment(comment)}
                           >
                             <i className="fas fa-eye-slash me-1"></i>
                             Dismiss
@@ -362,10 +363,12 @@ const PRReviewComments: React.FC<PRReviewCommentsProps> = ({
                           <div className="btn-group" role="group">
                             <button
                               className="btn btn-sm btn-primary"
-                              onClick={() => onPostComment(comment, index)}
-                              disabled={isPostingComment[index]}
+                              onClick={() => onPostComment(comment)}
+                              disabled={
+                                commentId ? isPostingComment[commentId] : false
+                              }
                             >
-                              {isPostingComment[index] ? (
+                              {commentId && isPostingComment[commentId] ? (
                                 <>
                                   <span className="spinner-border spinner-border-sm me-1"></span>
                                   Posting...
@@ -379,10 +382,10 @@ const PRReviewComments: React.FC<PRReviewCommentsProps> = ({
                             </button>
                             <button
                               className="btn btn-sm btn-primary"
-                              onClick={() =>
-                                onStartEditComment(index, comment.comment)
+                              onClick={() => onStartEditComment(comment)}
+                              disabled={
+                                commentId ? isPostingComment[commentId] : false
                               }
-                              disabled={isPostingComment[index]}
                               title="Edit comment before posting"
                             >
                               <i className="fas fa-edit"></i>
@@ -403,13 +406,13 @@ const PRReviewComments: React.FC<PRReviewCommentsProps> = ({
                         Rejected Comments ({rejectedCritiquedComments.length})
                       </h6>
                       {rejectedCritiquedComments.map((comment, rIdx) => {
-                        const keyIndex = `rejected-${rIdx}`;
+                        const commentId = comment.id || `rejected-${rIdx}`;
                         const isCollapsed =
-                          collapsedComments[keyIndex] !== false;
+                          collapsedComments[commentId] !== false;
                         const isLine = comment.type === 'line';
                         return (
                           <div
-                            key={keyIndex}
+                            key={commentId}
                             className="card shadow-sm border-0 mb-2 bg-body-tertiary opacity-75"
                           >
                             <div className="card-body p-3">
@@ -436,7 +439,7 @@ const PRReviewComments: React.FC<PRReviewCommentsProps> = ({
                                 </div>
                                 <button
                                   className="btn btn-sm btn-link text-decoration-none p-0 px-2 ms-2"
-                                  onClick={() => onToggleCollapse(keyIndex)}
+                                  onClick={() => onToggleCollapse(commentId)}
                                 >
                                   <i
                                     className={`fas fa-chevron-${isCollapsed ? 'down' : 'up'} me-1`}

--- a/src/renderer/features/pr-reviewer/components/PRReviewerModals.tsx
+++ b/src/renderer/features/pr-reviewer/components/PRReviewerModals.tsx
@@ -2,28 +2,23 @@ import React from 'react';
 import { ReviewComment } from '../../../../types';
 
 interface EditCommentModalProps {
-  editingCommentIndex: number;
+  editingComment: ReviewComment;
   editedCommentText: string;
   setEditedCommentText: (text: string) => void;
   onCancel: () => void;
-  onPostComment: (
-    comment: ReviewComment,
-    index: number,
-    updatedText: string,
-  ) => void;
-  comments: ReviewComment[];
-  isPostingComment: Record<number, boolean>;
+  onPostComment: (comment: ReviewComment, updatedText: string) => void;
+  isPostingComment: Record<string, boolean>;
 }
 
 export const EditCommentModal: React.FC<EditCommentModalProps> = ({
-  editingCommentIndex,
+  editingComment,
   editedCommentText,
   setEditedCommentText,
   onCancel,
   onPostComment,
-  comments,
   isPostingComment,
 }) => {
+  const commentId = editingComment.id || '';
   return (
     <div className="env-error-overlay">
       <div
@@ -60,16 +55,10 @@ export const EditCommentModal: React.FC<EditCommentModalProps> = ({
           </button>
           <button
             className="btn btn-sm btn-primary px-4"
-            onClick={() =>
-              onPostComment(
-                comments[editingCommentIndex],
-                editingCommentIndex,
-                editedCommentText,
-              )
-            }
-            disabled={isPostingComment[editingCommentIndex]}
+            onClick={() => onPostComment(editingComment, editedCommentText)}
+            disabled={commentId ? isPostingComment[commentId] : false}
           >
-            {isPostingComment[editingCommentIndex] ? (
+            {commentId && isPostingComment[commentId] ? (
               <>
                 <span className="spinner-border spinner-border-sm me-1"></span>
                 Posting...

--- a/src/types.ts
+++ b/src/types.ts
@@ -166,6 +166,7 @@ export interface ReviewPhase {
 }
 
 export interface ReviewComment {
+  id?: string;
   type: 'general' | 'line';
   file?: string;
   line?: number;


### PR DESCRIPTION
Resolves #184 

When the PR Reviewer runs the "Critic" phase it creates a separate collection of verified comments. However, posting (including editing before posting) these comments caused them to be created using the context of the same indexed comment in the general comments list.

This caused issues such as:
- Line-based comments being posted as general comments (or vice versa)
- Line-based comments being attached to a different line and/or file as what appeared in the UI

This PR resolves this issue by avoiding using indexes, instead using a comment ID which uniquely represents a single comment, in either the raw comment list or the critiqued one.