### PR TITLE
feat: tool call improvements

### DIFF
--- a/src/main/features/pr-reviewer/__tests__/prReviewerService.test.ts
+++ b/src/main/features/pr-reviewer/__tests__/prReviewerService.test.ts
@@ -317,6 +317,7 @@ describe('PRReviewerService', () => {
         mockSession,
         expectedPrompt,
         expect.any(Function),
+        expect.any(Function),
       );
 
       expect(mockSession.disconnect).toHaveBeenCalled();
@@ -1577,6 +1578,7 @@ describe('PRReviewerService', () => {
         mockSession,
         expectedPrompt,
         expect.any(Function),
+        expect.any(Function),
       );
     });
 
@@ -1646,6 +1648,7 @@ describe('PRReviewerService', () => {
       expect(mockCopilotService.sendAndCollectStream).toHaveBeenCalledWith(
         mockSession,
         expectedPrompt,
+        expect.any(Function),
         expect.any(Function),
       );
     });

--- a/src/main/features/pr-reviewer/__tests__/prReviewerService.test.ts
+++ b/src/main/features/pr-reviewer/__tests__/prReviewerService.test.ts
@@ -304,7 +304,7 @@ describe('PRReviewerService', () => {
       expect(mockCopilotService.createClientAndSession).toHaveBeenCalledWith(
         'mock-token',
         'gpt-4',
-        { workingDirectory: '/mock/repo' },
+        expect.objectContaining({ workingDirectory: '/mock/repo' }),
       );
 
       const expectedPrompt = buildPhaseReviewPrompt(
@@ -807,7 +807,7 @@ describe('PRReviewerService', () => {
       expect(mockCopilotService.createClientAndSession).toHaveBeenCalledWith(
         'mock-token',
         'gemini-2.0-flash',
-        { workingDirectory: '/mock/repo' },
+        expect.objectContaining({ workingDirectory: '/mock/repo' }),
       );
     });
   });

--- a/src/main/features/pr-reviewer/prReviewerService.ts
+++ b/src/main/features/pr-reviewer/prReviewerService.ts
@@ -172,16 +172,12 @@ Only output a general comment if you have constructive feedback, suggestions, or
   "comment": "Your line-specific review comment in Markdown format"
 }
 
-3. For reporting status updates (e.g., when you start checking a file, analyze a function, or run check guidelines):
-{
-  "type": "status",
-  "status": "A brief message describing what you are currently doing (e.g., 'Checking authService.ts for potential logic flaws')"
-}
+For any status updates, progress updates, or internal thoughts that you want to show to the user, you MUST call the "report_intent" tool with the details of what you are doing (e.g., calling report_intent(intent: "Checking authService.ts for potential logic flaws")). You are forbidden from outputting status updates as JSON lines.
 
 Ensure the "line" number corresponds to the line in the modified version of the file (after applying the diff). The "context" field must be an integer indicating how many surrounding lines of code to display before and after this line (e.g. 0 to display only line 42, or 5 to display 5 lines before, line 42, and 5 lines after).
 You MUST only suggest line-specific comments (type: 'line') on lines that were actually changed (added or modified) as shown in the git history. Do not comment on unchanged lines.
 
-You are highly encouraged to output status updates (type: 'status') periodically as you proceed to let the user know what you are doing.
+You are highly encouraged to call the "report_intent" tool periodically as you proceed to let the user know what you are doing.
 If you have no issues or feedback to report for a phase, simply do not output any review comments (general or line-specific) at all for that phase.
 
 Begin your review now.`;
@@ -1100,6 +1096,19 @@ export class PRReviewerService {
             args?: any,
           ) => {
             if (options.onLine) {
+              if (tool === 'report_intent') {
+                if (type === 'start' && args?.intent) {
+                  options.onLine(
+                    JSON.stringify({
+                      type: 'status',
+                      status: args.intent,
+                      phaseId: phase.id,
+                      phaseTitle: phase.title,
+                    }),
+                  );
+                }
+                return;
+              }
               options.onLine(
                 JSON.stringify({
                   type: 'tool',
@@ -1116,11 +1125,16 @@ export class PRReviewerService {
           };
 
           try {
-            const res = await this.copilotService.sendAndCollectStream(
+            const streamArgs: any[] = [
               session,
               prompt,
               options.onLine ? wrappedOnLine : undefined,
-              ...(attachStory ? [onToolCallback] : []),
+            ];
+            if (options.onLine) {
+              streamArgs.push(onToolCallback);
+            }
+            const res = await this.copilotService.sendAndCollectStream(
+              ...streamArgs,
             );
             results[phaseIdx] = `\n--- Phase ${phase.title} Result ---\n${res}`;
           } catch (err) {

--- a/src/main/features/pr-reviewer/prReviewerService.ts
+++ b/src/main/features/pr-reviewer/prReviewerService.ts
@@ -1125,14 +1125,9 @@ export class PRReviewerService {
           };
 
           try {
-            const streamArgs: any[] = [
-              session,
-              prompt,
-              options.onLine ? wrappedOnLine : undefined,
-            ];
-            if (options.onLine) {
-              streamArgs.push(onToolCallback);
-            }
+            const streamArgs: [any, string, any?, any?] = options.onLine
+              ? [session, prompt, wrappedOnLine, onToolCallback]
+              : [session, prompt, undefined];
             const res = await this.copilotService.sendAndCollectStream(
               ...streamArgs,
             );

--- a/src/main/features/pr-reviewer/prReviewerService.ts
+++ b/src/main/features/pr-reviewer/prReviewerService.ts
@@ -21,6 +21,7 @@ import { IssueTrackerProvider } from '../../infrastructure/providers/IssueTracke
 import { DocumentationProvider } from '../../infrastructure/providers/DocumentationProvider';
 import { CodeReviewProvider } from '../../infrastructure/providers/CodeReviewProvider';
 import { createRequestDocumentationTool } from '../../infrastructure/copilot/tools/documentationTool';
+import { createReportIntentTool } from '../../infrastructure/copilot/tools/reportIntentTool';
 
 export function buildCriticPrompt(
   comments: ReviewComment[],
@@ -1034,16 +1035,20 @@ export class PRReviewerService {
           const attachStory =
             phase.attach && phase.attach.toLowerCase().includes('story');
 
-          const sessionOpts = attachStory
-            ? {
-                workingDirectory: effectiveRepoPath,
-                tools: [
-                  createRequestDocumentationTool(this.getDocProvider, () =>
-                    options.onLine ? wrappedOnLine : undefined,
-                  ),
-                ],
-              }
-            : { workingDirectory: effectiveRepoPath };
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const tools: any[] = [createReportIntentTool()];
+          if (attachStory) {
+            tools.push(
+              createRequestDocumentationTool(this.getDocProvider, () =>
+                options.onLine ? wrappedOnLine : undefined,
+              ),
+            );
+          }
+
+          const sessionOpts = {
+            workingDirectory: effectiveRepoPath,
+            tools,
+          };
 
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           let clientAndSession: { client: any; session: any } | null;
@@ -1125,6 +1130,7 @@ export class PRReviewerService {
           };
 
           try {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
             const streamArgs: [any, string, any?, any?] = options.onLine
               ? [session, prompt, wrappedOnLine, onToolCallback]
               : [session, prompt, undefined];

--- a/src/main/features/story-elaborator/__tests__/storyElaboratorService.test.ts
+++ b/src/main/features/story-elaborator/__tests__/storyElaboratorService.test.ts
@@ -121,10 +121,16 @@ describe('StoryElaborator feature', () => {
         undefined,
         'gpt-4',
         expect.objectContaining({
-          availableTools: ['custom:request_documentation'],
+          availableTools: [
+            'custom:request_documentation',
+            'custom:report_intent',
+          ],
           tools: expect.arrayContaining([
             expect.objectContaining({
               name: 'request_documentation',
+            }),
+            expect.objectContaining({
+              name: 'report_intent',
             }),
           ]),
         }),
@@ -262,6 +268,9 @@ describe('StoryElaborator feature', () => {
           tools: expect.arrayContaining([
             expect.objectContaining({
               name: 'request_documentation',
+            }),
+            expect.objectContaining({
+              name: 'report_intent',
             }),
           ]),
         }),

--- a/src/main/features/story-elaborator/storyElaboratorPrompts.ts
+++ b/src/main/features/story-elaborator/storyElaboratorPrompts.ts
@@ -54,15 +54,13 @@ Your communication protocol with the host application is strictly JSON Lines (JS
 Every output line MUST be a single, standalone, valid JSON object. Do NOT wrap the JSON objects in an array. Do NOT output markdown fences (like \`\`\`json) wrapping your JSONL output.
 All double quotes inside string values must be escaped as \\". All actual newlines inside string values must be escaped as \\n.
 
-You must choose one of the following JSON formats for each line you output:
-1. Status Updates (for describing your internal thoughts, what files you are reading, or progress):
-   \`{"type": "status", "text": "Analyzing codebase / reading package.json..."}\`
-   *IMPORTANT*: You must never output only status updates in a turn and then stop. If you output a status update, you must either call a tool in the same turn to continue your work (e.g. read a file, list files, search), or you must end your output with a question to the user (type: 'question') or the final plan (type: 'plan'). Ending a turn with only a status update and no tool call/question/plan is forbidden, as it will leave the session stuck.
+For any status updates, progress updates, or internal thoughts that you want to show to the user, you MUST call the "report_intent" tool with the details of what you are doing (e.g., calling report_intent(intent: "Analyzing codebase / reading package.json...")). You are forbidden from outputting status updates as JSON lines.
 
-2. Questions (if you need clarification on requirements, architectural choices, styling preferences, or codebase details from the user). Ask exactly ONE question at a time and then STOP. Do not output anything else in that turn. You can optionally provide a list of suggested answers if you are able to guess or suggest sensible options:
+You must choose one of the following JSON formats for each line you output:
+1. Questions (if you need clarification on requirements, architectural choices, styling preferences, or codebase details from the user). Ask exactly ONE question at a time and then STOP. Do not output anything else in that turn. You can optionally provide a list of suggested answers if you are able to guess or suggest sensible options:
    \`{"type": "question", "text": "Should we use React state or Redux to store this new field?", "suggestedAnswers": ["React State", "Redux", "Context API"]}\`
 
-3. The Final Plan (when all questions are answered and the plan is ready. In this case, output a single JSON object:
+2. The Final Plan (when all questions are answered and the plan is ready. In this case, output a single JSON object):
    \`{"type": "plan", "text": "# Detailed Implementation Plan\\n\\n### Proposed Changes..."}\`
 
 Follow this process:
@@ -74,7 +72,7 @@ Follow this process:
 
 You are forbidden from ending the interaction without returning the "plan" message in JSONL format.
 
-Start by analyzing the ticket details and/or repository, and ask your first question or output a status update followed by a tool call or question.
+Start by analyzing the ticket details and/or repository, and ask your first question or call the "report_intent" tool followed by a tool call or question.
 
 Your plan will be written as a comment on the ticket, so be concise and avoid repeating the ticket contents. Ideally your output is a list of things that need to be done to complete this ticket.
 `;

--- a/src/main/features/story-elaborator/storyElaboratorService.ts
+++ b/src/main/features/story-elaborator/storyElaboratorService.ts
@@ -226,6 +226,17 @@ export class StoryElaboratorService {
       args?: any,
     ) => {
       if (onLine) {
+        if (tool === 'report_intent') {
+          if (type === 'start' && args?.intent) {
+            onLine(
+              JSON.stringify({
+                type: 'status',
+                text: args.intent,
+              }),
+            );
+          }
+          return;
+        }
         onLine(
           JSON.stringify({
             type: 'tool',

--- a/src/main/features/story-elaborator/storyElaboratorService.ts
+++ b/src/main/features/story-elaborator/storyElaboratorService.ts
@@ -4,6 +4,7 @@ import { CopilotService } from '../../infrastructure/copilot/copilotService';
 import { DocumentationProvider } from '../../infrastructure/providers/DocumentationProvider';
 import { buildStoryElaboratorPrompt } from './storyElaboratorPrompts';
 import { createRequestDocumentationTool } from '../../infrastructure/copilot/tools/documentationTool';
+import { createReportIntentTool } from '../../infrastructure/copilot/tools/reportIntentTool';
 import { GitService } from '../../infrastructure/git/gitService';
 import fs from 'fs';
 import path from 'path';
@@ -111,6 +112,8 @@ export class StoryElaboratorService {
         }
       }
 
+      const reportIntentTool = createReportIntentTool();
+
       const { client, session } =
         await this.copilotService.createClientAndSession(
           settings.copilotToken,
@@ -118,11 +121,14 @@ export class StoryElaboratorService {
           effectiveRepoPath
             ? {
                 workingDirectory: effectiveRepoPath,
-                tools: [requestDocumentationTool],
+                tools: [requestDocumentationTool, reportIntentTool],
               }
             : {
-                availableTools: ['custom:request_documentation'],
-                tools: [requestDocumentationTool],
+                availableTools: [
+                  'custom:request_documentation',
+                  'custom:report_intent',
+                ],
+                tools: [requestDocumentationTool, reportIntentTool],
               },
         );
       session.label = 'Story Elaborator';

--- a/src/main/features/story-elaborator/storyElaboratorService.ts
+++ b/src/main/features/story-elaborator/storyElaboratorService.ts
@@ -5,6 +5,7 @@ import { DocumentationProvider } from '../../infrastructure/providers/Documentat
 import { buildStoryElaboratorPrompt } from './storyElaboratorPrompts';
 import { createRequestDocumentationTool } from '../../infrastructure/copilot/tools/documentationTool';
 import { createReportIntentTool } from '../../infrastructure/copilot/tools/reportIntentTool';
+import { formatToolStatus } from '../../infrastructure/copilot/tools/toolStatusFormatter';
 import { GitService } from '../../infrastructure/git/gitService';
 import fs from 'fs';
 import path from 'path';
@@ -232,27 +233,15 @@ export class StoryElaboratorService {
       args?: any,
     ) => {
       if (onLine) {
-        if (tool === 'report_intent') {
-          if (type === 'start' && args?.intent) {
-            onLine(
-              JSON.stringify({
-                type: 'status',
-                text: args.intent,
-              }),
-            );
-          }
-          return;
+        const statusText = formatToolStatus(type, tool, success, error, args);
+        if (statusText) {
+          onLine(
+            JSON.stringify({
+              type: 'status',
+              text: statusText,
+            }),
+          );
         }
-        onLine(
-          JSON.stringify({
-            type: 'tool',
-            status: type,
-            name: tool,
-            success,
-            error,
-            arguments: args,
-          }),
-        );
       }
     };
 

--- a/src/main/features/tshirt-estimator/tshirtEstimatorPrompts.ts
+++ b/src/main/features/tshirt-estimator/tshirtEstimatorPrompts.ts
@@ -26,6 +26,7 @@ Every output line MUST be a single, standalone, valid JSON object. Do NOT wrap t
 All double quotes inside string values must be escaped as \\". All actual newlines inside string values must be escaped as \\n.
 
 For any status updates, progress updates, or internal thoughts that you want to show to the user, you MUST call the "report_intent" tool with the details of what you are doing (e.g., calling report_intent(intent: "Analyzing codebase / reading package.json...")). You are forbidden from outputting status updates as JSON lines.
+You are highly encouraged to report your status frequently.
 
 You must choose one of the following JSON formats for each line you output:
 1. The Final Estimate (when your analysis is complete. In this case, output a single JSON object):

--- a/src/main/features/tshirt-estimator/tshirtEstimatorPrompts.ts
+++ b/src/main/features/tshirt-estimator/tshirtEstimatorPrompts.ts
@@ -25,12 +25,10 @@ Your communication protocol with the host application is strictly JSON Lines (JS
 Every output line MUST be a single, standalone, valid JSON object. Do NOT wrap the JSON objects in an array. Do NOT output markdown fences (like \`\`\`json) wrapping your JSONL output.
 All double quotes inside string values must be escaped as \\". All actual newlines inside string values must be escaped as \\n.
 
-You must choose one of the following JSON formats for each line you output:
-1. Status Updates (for describing your internal thoughts, what files you are reading, or progress):
-   \`{"type": "status", "text": "Analyzing codebase / reading package.json..."}\`
-   *IMPORTANT*: You must never output only status updates in a turn and then stop. If you output a status update, you must either call a tool in the same turn to continue your work (e.g. read a file, list files, search), or you must end your output with the final estimate (type: 'estimate'). Ending a turn with only a status update and no tool call or estimate is forbidden, as it will leave the session stuck.
+For any status updates, progress updates, or internal thoughts that you want to show to the user, you MUST call the "report_intent" tool with the details of what you are doing (e.g., calling report_intent(intent: "Analyzing codebase / reading package.json...")). You are forbidden from outputting status updates as JSON lines.
 
-2. The Final Estimate (when your analysis is complete. In this case, output a single JSON object):
+You must choose one of the following JSON formats for each line you output:
+1. The Final Estimate (when your analysis is complete. In this case, output a single JSON object):
    \`{"type": "estimate", "size": "XS|S|M|L|XL", "text": "Detailed reasoning explaining your estimate, what files/components will need modification, potential complexities, and verification steps in markdown format."}\`
 
 Follow this process:
@@ -40,6 +38,6 @@ Follow this process:
 
 You are forbidden from ending the interaction without returning the "estimate" message in JSONL format.
 
-Start by analyzing the proposed change details and repository, and output a status update followed by a tool call or the final estimate.
+Start by analyzing the proposed change details and repository, and call the "report_intent" tool followed by a tool call or the final estimate.
 `;
 }

--- a/src/main/features/tshirt-estimator/tshirtEstimatorService.ts
+++ b/src/main/features/tshirt-estimator/tshirtEstimatorService.ts
@@ -132,6 +132,17 @@ export class TShirtEstimatorService {
         onLine,
         (type, tool, success, error, args) => {
           if (onLine) {
+            if (tool === 'report_intent') {
+              if (type === 'start' && args?.intent) {
+                onLine(
+                  JSON.stringify({
+                    type: 'status',
+                    text: args.intent,
+                  }),
+                );
+              }
+              return;
+            }
             onLine(
               JSON.stringify({
                 type: 'tool',

--- a/src/main/features/tshirt-estimator/tshirtEstimatorService.ts
+++ b/src/main/features/tshirt-estimator/tshirtEstimatorService.ts
@@ -3,6 +3,7 @@ import { AppSettings, CopilotUsage } from '../../../types';
 import { CopilotService } from '../../infrastructure/copilot/copilotService';
 import { GitService } from '../../infrastructure/git/gitService';
 import { buildTShirtEstimatorPrompt } from './tshirtEstimatorPrompts';
+import { createReportIntentTool } from '../../infrastructure/copilot/tools/reportIntentTool';
 import fs from 'fs';
 import path from 'path';
 
@@ -112,6 +113,7 @@ export class TShirtEstimatorService {
           modelOverride,
           {
             workingDirectory: effectiveRepoPath,
+            tools: [createReportIntentTool()],
           },
         );
       session.label = 'T-Shirt Size Estimator';

--- a/src/main/features/tshirt-estimator/tshirtEstimatorService.ts
+++ b/src/main/features/tshirt-estimator/tshirtEstimatorService.ts
@@ -4,6 +4,7 @@ import { CopilotService } from '../../infrastructure/copilot/copilotService';
 import { GitService } from '../../infrastructure/git/gitService';
 import { buildTShirtEstimatorPrompt } from './tshirtEstimatorPrompts';
 import { createReportIntentTool } from '../../infrastructure/copilot/tools/reportIntentTool';
+import { formatToolStatus } from '../../infrastructure/copilot/tools/toolStatusFormatter';
 import fs from 'fs';
 import path from 'path';
 
@@ -134,27 +135,21 @@ export class TShirtEstimatorService {
         onLine,
         (type, tool, success, error, args) => {
           if (onLine) {
-            if (tool === 'report_intent') {
-              if (type === 'start' && args?.intent) {
-                onLine(
-                  JSON.stringify({
-                    type: 'status',
-                    text: args.intent,
-                  }),
-                );
-              }
-              return;
-            }
-            onLine(
-              JSON.stringify({
-                type: 'tool',
-                status: type,
-                name: tool,
-                success,
-                error,
-                arguments: args,
-              }),
+            const statusText = formatToolStatus(
+              type,
+              tool,
+              success,
+              error,
+              args,
             );
+            if (statusText) {
+              onLine(
+                JSON.stringify({
+                  type: 'status',
+                  text: statusText,
+                }),
+              );
+            }
           }
         },
       );

--- a/src/main/infrastructure/copilot/copilotService.ts
+++ b/src/main/infrastructure/copilot/copilotService.ts
@@ -363,6 +363,7 @@ export class CopilotService {
 
         resolvePromise(fullContent);
       } else if (event.type === 'tool.execution_start') {
+        console.dir(event, { depth: 4 });
         const toolName = event.data.toolName;
         activeToolCalls.set(event.data.toolCallId, toolName);
         resetTimeout();

--- a/src/main/infrastructure/copilot/tools/reportIntentTool.ts
+++ b/src/main/infrastructure/copilot/tools/reportIntentTool.ts
@@ -1,0 +1,23 @@
+export function createReportIntentTool() {
+  return {
+    name: 'report_intent',
+    description:
+      'Report the current intent, status, or progress of the agent to the user.',
+    parameters: {
+      type: 'object',
+      properties: {
+        intent: {
+          type: 'string',
+          description: 'The status or intent message to report to the user.',
+        },
+      },
+      required: ['intent'],
+    },
+    handler: async (args: { intent: string }) => {
+      // The tool handler doesn't need to do any UI updating directly because
+      // the agent's tool execution start event is already intercepted and
+      // sent to the renderer. We just return a success response so the agent knows it worked.
+      return `Status updated: "${args.intent}"`;
+    },
+  };
+}

--- a/src/main/infrastructure/copilot/tools/toolStatusFormatter.ts
+++ b/src/main/infrastructure/copilot/tools/toolStatusFormatter.ts
@@ -1,0 +1,63 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import path from 'path';
+
+function extractCommandNames(cmd: string): string {
+  if (!cmd) return 'unknown';
+  // Split by command chaining operators: &&, ||, ;, |, or newlines
+  const segments = cmd.split(/&&|\|\||;|\||\r?\n/);
+  const names: string[] = [];
+  for (const segment of segments) {
+    const trimmed = segment.trim();
+    if (!trimmed) continue;
+    // Extract the first word (the executable name)
+    const match = trimmed.match(/^([a-zA-Z0-9_-]+)/);
+    if (match) {
+      names.push(match[1]);
+    }
+  }
+  return names.length > 0 ? names.join(', ') : 'unknown';
+}
+
+export function formatToolStatus(
+  type: 'start' | 'end',
+  tool: string,
+  success?: boolean,
+  error?: string,
+  args?: any,
+): string | null {
+  if (tool === 'report_intent') {
+    if (type === 'start' && args?.intent) {
+      return args.intent;
+    }
+    return null;
+  }
+
+  let detail = '';
+  if (tool === 'grep') {
+    detail = args?.pattern ? ` (${args.pattern})` : '';
+  } else if (tool === 'view') {
+    if (args?.path) {
+      // Get last segment of path (filename)
+      const filename = path.basename(args.path);
+      detail = ` (${filename})`;
+    } else {
+      detail = ' (unknown)';
+    }
+  } else if (tool === 'bash' || tool === 'powershell') {
+    const commandNames = extractCommandNames(args?.command);
+    detail = ` (${commandNames})`;
+  } else {
+    // For other tools, we show the tool name as is (or can add more details)
+  }
+
+  if (type === 'start') {
+    return `${tool}${detail}`;
+  } else {
+    // type === 'end'
+    if (success) {
+      return null; // don't output end logs on success
+    } else {
+      return `Tool failed: ${tool}${detail}${error ? ` - ${error}` : ''}`;
+    }
+  }
+}

--- a/src/renderer/features/story-elaborator/StoryElaborator.tsx
+++ b/src/renderer/features/story-elaborator/StoryElaborator.tsx
@@ -189,22 +189,13 @@ const StoryElaborator: React.FC = () => {
         if (data.type === 'status') {
           setFeed((prev) => [...prev, { type: 'status', text: data.text }]);
         } else if (data.type === 'tool') {
-          let statusText = '';
-          if (data.name === 'report_intent') {
-            if (data.status === 'start' && data.arguments?.intent) {
-              statusText = `Intent: ${data.arguments.intent}`;
-            } else {
-              return;
-            }
-          } else {
-            if (data.status === 'end' && data.success) {
-              return; // don't clog status with "end" logs unless it fails
-            }
-            statusText =
-              data.status === 'end'
-                ? `Tool failed: ${data.name} ${data.error ? `- ${data.error}` : ''}`
-                : `Tool: ${data.name}`;
+          if (data.status === 'end' && data.success) {
+            return; // don't clog status with "end" logs unless it fails
           }
+          const statusText =
+            data.status === 'end'
+              ? `Tool failed: ${data.name} ${data.error ? `- ${data.error}` : ''}`
+              : `Tool: ${data.name}`;
           setFeed((prev) => [...prev, { type: 'status', text: statusText }]);
         } else if (data.type === 'question') {
           setIsGenerating(false);

--- a/src/renderer/features/story-elaborator/StoryElaborator.tsx
+++ b/src/renderer/features/story-elaborator/StoryElaborator.tsx
@@ -188,15 +188,6 @@ const StoryElaborator: React.FC = () => {
         const data = JSON.parse(trimmed);
         if (data.type === 'status') {
           setFeed((prev) => [...prev, { type: 'status', text: data.text }]);
-        } else if (data.type === 'tool') {
-          if (data.status === 'end' && data.success) {
-            return; // don't clog status with "end" logs unless it fails
-          }
-          const statusText =
-            data.status === 'end'
-              ? `Tool failed: ${data.name} ${data.error ? `- ${data.error}` : ''}`
-              : `Tool: ${data.name}`;
-          setFeed((prev) => [...prev, { type: 'status', text: statusText }]);
         } else if (data.type === 'question') {
           setIsGenerating(false);
           setIsWaitingForUser(true);

--- a/src/renderer/features/tshirt-estimator/TShirtEstimator.tsx
+++ b/src/renderer/features/tshirt-estimator/TShirtEstimator.tsx
@@ -179,16 +179,6 @@ const TShirtEstimator: React.FC = () => {
           const data = JSON.parse(trimmed);
           if (data.type === 'status') {
             setLogs((prev) => [...prev, { type: 'status', text: data.text }]);
-          } else if (data.type === 'tool') {
-            let statusText = '';
-            if (data.status === 'end' && data.success) {
-              return; // don't clog logs with end success messages
-            }
-            statusText =
-              data.status === 'end'
-                ? `Tool failed: ${data.name} ${data.error ? `- ${data.error}` : ''}`
-                : `Tool: ${data.name}`;
-            setLogs((prev) => [...prev, { type: 'status', text: statusText }]);
           } else if (data.type === 'estimate') {
             setSize(data.size);
             setReasoning(data.text);


### PR DESCRIPTION
This makes 2 improvements to tool calls.

1. Instead of emitting status update messages in the regular agent output, this is now done through a new `report_intent` tool call. This is mainly to improve separation of concerns, however there is a benefit that because these tool calls aren't included in the context, this enables a small token quota saving.
2. We now provide some context when displaying tool calls, e.g.
    - `grep` is now `grep (pattern)`
    - `view` is now `view (filename)` - only the final segment; `/a/b/c.txt` just shows `view (c.txt)`
    - `bash`/`powershell` is now `bash (command)` or `powershell (command)` - we only include the command (stripping arguments). If multiple commands are chained with `&&`, `||`, or `;` they are included as a list, e.g. `git add -a && git commit -m "..."` becomes `bash (git, git)`